### PR TITLE
Add support for running against a container

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -106,6 +106,11 @@
             <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -58,7 +58,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                                 config.notificationCallback());
 
         BlockingStubByShardId blockingStubByShardId =
-                new BlockingStubByShardId(shardManager, channelManager.getBlockingStubFactory());
+                new BlockingStubByShardId(shardManager, channelManager.getBlockingStubFactory(), config);
         readBatchManager = BatchManager.newReadBatchManager(config, blockingStubByShardId);
         writeBatchManager = BatchManager.newWriteBatchManager(config, blockingStubByShardId);
         shardManager.start().join();

--- a/client/src/main/java/io/streamnative/oxia/client/BlockingStubByShardId.java
+++ b/client/src/main/java/io/streamnative/oxia/client/BlockingStubByShardId.java
@@ -23,10 +23,17 @@ import lombok.NonNull;
 
 record BlockingStubByShardId(
         @NonNull ShardManager shardManager,
-        @NonNull Function<String, OxiaClientBlockingStub> blockingStubFactory)
+        @NonNull Function<String, OxiaClientBlockingStub> blockingStubFactory,
+        @NonNull ClientConfig config)
         implements Function<Long, OxiaClientBlockingStub> {
     @Override
     public @NonNull OxiaClientBlockingStub apply(@NonNull Long shardId) {
-        return blockingStubFactory.apply(shardManager.leader(shardId));
+        String leader;
+        if (config.standalone()) {
+            leader = config.serviceAddress();
+        } else {
+            leader = shardManager.leader(shardId);
+        }
+        return blockingStubFactory.apply(leader);
     }
 }

--- a/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
@@ -27,4 +27,5 @@ public record ClientConfig(
         @NonNull Duration requestTimeout,
         @NonNull Duration batchLinger,
         int maxRequestsPerBatch,
-        int operationQueueCapacity) {}
+        int operationQueueCapacity,
+        boolean standalone) {}

--- a/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilder.java
+++ b/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilder.java
@@ -40,6 +40,7 @@ public class OxiaClientBuilder implements ClientBuilder<OxiaClientBuilder> {
     @NonNull private Duration batchLinger = DefaultBatchLinger;
     private int maxRequestsPerBatch = DefaultMaxRequestsPerBatch;
     private int operationQueueCapacity = DefaultOperationQueueCapacity;
+    private boolean standalone = false;
 
     @Override
     public @NonNull OxiaClientBuilder notificationCallback(
@@ -76,6 +77,11 @@ public class OxiaClientBuilder implements ClientBuilder<OxiaClientBuilder> {
         return this;
     }
 
+    public OxiaClientBuilder standalone() {
+        standalone = true;
+        return this;
+    }
+
     public @NonNull AsyncOxiaClient asyncClient() throws ExecutionException, InterruptedException {
         var config =
                 new ClientConfig(
@@ -84,7 +90,8 @@ public class OxiaClientBuilder implements ClientBuilder<OxiaClientBuilder> {
                         requestTimeout,
                         batchLinger,
                         maxRequestsPerBatch,
-                        operationQueueCapacity);
+                        operationQueueCapacity,
+                        standalone);
         return new AsyncOxiaClientImpl(config);
     }
 

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
@@ -21,6 +21,7 @@ import static io.streamnative.oxia.proto.OxiaClientGrpc.newBlockingStub;
 import static io.streamnative.oxia.proto.Status.KEY_NOT_FOUND;
 import static io.streamnative.oxia.proto.Status.OK;
 import static io.streamnative.oxia.proto.Status.UNEXPECTED_VERSION_ID;
+import static java.time.Duration.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -55,7 +56,6 @@ import io.streamnative.oxia.proto.ReadResponse;
 import io.streamnative.oxia.proto.WriteRequest;
 import io.streamnative.oxia.proto.WriteResponse;
 import java.time.Clock;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -400,7 +400,7 @@ class BatchTest {
 
         @Mock Clock clock;
 
-        ClientConfig config = new ClientConfig("address", n -> {}, Duration.ZERO, Duration.ZERO, 1, 1);
+        ClientConfig config = new ClientConfig("address", n -> {}, ZERO, ZERO, 1, 1, false);
 
         @BeforeEach
         void mocking() {

--- a/client/src/test/java/io/streamnative/oxia/client/grpc/ReceiveWithRecoveryTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/grpc/ReceiveWithRecoveryTest.java
@@ -18,6 +18,7 @@ package io.streamnative.oxia.client.grpc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,9 +59,9 @@ class RecoveryTests {
 
     @Test
     void retry() throws Exception {
-        //noinspection unchecked
-        when(receiver.receive())
-                .thenReturn(terminalError, terminalError, terminalComplete, terminalBlocking);
+        doReturn(terminalError, terminalError, terminalComplete, terminalBlocking)
+                .when(receiver)
+                .receive();
         when(retryIntervalFn.apply(anyLong())).thenReturn(1L);
         var terminated = recovery.receive();
         await().untilAsserted(() -> assertThat(retryCounter).hasValue(4));

--- a/client/src/test/resources/simplelogger.properties
+++ b/client/src/test/resources/simplelogger.properties
@@ -1,0 +1,17 @@
+#
+# Copyright © 2022-2023 StreamNative Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.slf4j.simpleLogger.log.io.streamnative=debug

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
                 <version>${mockito.junit.jupiter.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -198,10 +204,17 @@
                 <artifactId>license-maven-plugin</artifactId>
                 <version>${license.plugin.version}</version>
                 <configuration>
-                    <header>etc/APACHE-2.txt</header>
                     <mapping>
                         <proto>DOUBLESLASH_STYLE</proto>
                     </mapping>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>etc/APACHE-2.txt</header>
+                            <excludes>
+                                <exclude>NOTICE</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -30,13 +30,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
When running against a container, specifically Testcontainers, the advertised address will be on the standard port, 6648. However the port exposed to the client on the host will be a random mapped port. In this case we can intercept the shard manager and just use the original standalone service address instead.

This also fixes a couple of minor warnings - compiler unchecked warnings and missing slf4j implementation for tests.