### PR TITLE
Tidy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ Common build actions:
 [release-workflow]: https://github.com/streamnative/streamnative-ci/actions/workflows/maven-tag-deploy.yml
 [dependencies-file]: https://github.com/streamnative/streamnative-ci/blob/master/images/dependencies.json
 [ci-repo]: https://github.com/streamnative/streamnative-ci
+

--- a/client/README.md
+++ b/client/README.md
@@ -117,7 +117,6 @@ client.notifications(
 | `sessionTimeout`         |           15s | Period of inactivity after which session will be closed     |
 | `clientIdentifier`       | <random UUID> | String that uniquely identifies this client instance        |
 
-
 ## Metrics
 
 The Oxia Java client collects various metrics about the operations being performed. There is an


### PR DESCRIPTION
* Move **Metrics** section to client README
* Rename min/max → start/end in documentation (missed from #72)