### PR TITLE
Use `BlockingQueue.take()` instead of `poll()`

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/batch/Batcher.java
+++ b/client/src/main/java/io/streamnative/oxia/client/batch/Batcher.java
@@ -52,6 +52,9 @@ public class Batcher implements Runnable, AutoCloseable {
 
     @SneakyThrows
     public <R> void add(@NonNull Operation<R> operation) {
+        if (closed) {
+            throw new IllegalStateException("Batcher has been closed");
+        }
         var timeout = config.requestTimeout();
         try {
             if (!operations.offer(operation, timeout.toMillis(), MILLISECONDS)) {

--- a/client/src/test/java/io/streamnative/oxia/client/notify/NotificationManagerTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/notify/NotificationManagerTest.java
@@ -19,10 +19,10 @@ import static io.streamnative.oxia.proto.NotificationType.KEY_CREATED;
 import static io.streamnative.oxia.proto.NotificationType.KEY_DELETED;
 import static io.streamnative.oxia.proto.NotificationType.KEY_MODIFIED;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import io.grpc.ManagedChannel;
 import io.grpc.Server;


### PR DESCRIPTION
When the queue is empty, we need to use `take()` to block until the next item is available. 

`poll()` just returns immediately with null and we just enter an infinite loop.