### PR TITLE
Consume notifications only when needed

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -60,7 +60,8 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         Supplier<ReactorOxiaClientStub> stubFactory =
                 () -> reactorStubFactory.apply(config.serviceAddress());
         var shardManager = new ShardManager(stubFactory, config.metrics());
-        var notificationManager = new NotificationManager(reactorStubFactory, config.metrics());
+        var notificationManager =
+                new NotificationManager(reactorStubFactory, shardManager, config.metrics());
 
         Function<Long, String> leaderFn = shardManager::leader;
         var stubByShardId = leaderFn.andThen(reactorStubFactory);


### PR DESCRIPTION
Previously, the client would subscribe to notifications whether it needed to or not. However, this change only subscribes when a callback is registered.