### PR TITLE
Disable client cache

### DIFF
--- a/pulsar-metadatastore-oxia/src/main/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStore.java
+++ b/pulsar-metadatastore-oxia/src/main/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStore.java
@@ -66,6 +66,7 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
                         .sessionTimeout(Duration.ofMillis(metadataStoreConfig.getSessionTimeoutMillis()))
                         .batchLinger(Duration.ofMillis(linger))
                         .maxRequestsPerBatch(metadataStoreConfig.getBatchingMaxOperations())
+                        .disableRecordCache()
                         .asyncClient()
                         .get();
         client.notifications(this::notificationCallback);


### PR DESCRIPTION
Pulsar has it's own cache in the megastore layer. Enabling the client cache has no benefit.