### PR TITLE
Support fast fail while connecting to the wrong namespace.

### DIFF
--- a/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientFailFastIT.java
+++ b/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientFailFastIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2022-2023 StreamNative Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.oxia.client.it;
+
+
+import io.streamnative.oxia.client.OxiaClientBuilder;
+import io.streamnative.oxia.client.shard.NamespaceNotFoundException;
+import io.streamnative.oxia.testcontainers.OxiaContainer;
+import java.util.concurrent.CompletionException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@Slf4j
+public class OxiaClientFailFastIT {
+
+    @Container
+    private static final OxiaContainer oxia =
+            new OxiaContainer(OxiaContainer.DEFAULT_IMAGE_NAME)
+                    .withShards(4)
+                    .withLogConsumer(new Slf4jLogConsumer(log));
+
+    @Test
+    public void testWrongNamespace() {
+        try {
+            new OxiaClientBuilder(oxia.getServiceAddress())
+                    .namespace("my-ns-does-not-exist")
+                    .asyncClient()
+                    .join();
+            Assertions.fail("Unexpected behaviour!");
+        } catch (CompletionException exception) {
+            Assertions.assertNotNull(exception.getCause());
+            Assertions.assertTrue(exception.getCause() instanceof NamespaceNotFoundException);
+        }
+    }
+}

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/CustomStatusCode.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/CustomStatusCode.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2022-2023 StreamNative Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.oxia.client.grpc;
+
+
+import java.util.Objects;
+import lombok.NonNull;
+
+/** Customised GRPC status code. */
+public enum CustomStatusCode {
+    ErrorNamespaceNotFound,
+    // fallback to Status.code
+    UNKNOWN;
+
+    public static @NonNull CustomStatusCode fromDescription(String description) {
+        Objects.requireNonNull(description);
+        return switch (description) {
+            case "oxia: namespace not found" -> ErrorNamespaceNotFound;
+            default -> UNKNOWN;
+        };
+    }
+}

--- a/client/src/main/java/io/streamnative/oxia/client/shard/NamespaceNotFoundException.java
+++ b/client/src/main/java/io/streamnative/oxia/client/shard/NamespaceNotFoundException.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 /** The namespace not found in shards assignments. */
 public class NamespaceNotFoundException extends RuntimeException {
     @Getter private final String namespace;
+    @Getter private final boolean retryable;
 
     /**
      * Creates an instance of the exception.
@@ -30,6 +31,19 @@ public class NamespaceNotFoundException extends RuntimeException {
      */
     public NamespaceNotFoundException(@NonNull String namespace) {
         super(String.format("namespace %s not found in shards assignments", namespace));
+        this.retryable = false;
+        this.namespace = namespace;
+    }
+
+    /**
+     * Creates a retryable instance of the exception.
+     *
+     * @param namespace The namespace specified in the call.
+     * @param retryable If the exception is retryable
+     */
+    public NamespaceNotFoundException(@NonNull String namespace, boolean retryable) {
+        super(String.format("namespace %s not found in shards assignments", namespace));
+        this.retryable = retryable;
         this.namespace = namespace;
     }
 }

--- a/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStoreProviderTest.java
+++ b/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStoreProviderTest.java
@@ -50,11 +50,6 @@ public class OxiaMetadataStoreProviderTest implements OxiaTestBase {
     }
 
     @Test
-    public void testCreateWithUnknownNamespace() {
-        // Todo
-    }
-
-    @Test
     public void testCreateWithIllegalURL() {
         // Test with multiple url parts
         try {


### PR DESCRIPTION
### Motivation

Support fast fail while connecting to the wrong namespace.

The GRPC-Java client can't expand the `grpc-status` since it uses the predefined status code and hard code in the logic.
https://github.com/grpc/grpc-java/blob/58e2224df9b8f55cf2ecbd298e8fdfed03590426/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java#L181-L183
I tried to parse metadata, but unfortunately, the framework removed it before giving it to the caller. Therefore, I can only use the status description to identify which error I've got.

Maybe we can put it into the new GRPC protocol metadata(header) field? I am unsure if I am missing some operations to solve this problem. Please don't hesitate to correct me. Thanks!