### PR TITLE
Switch grpc okhttp to grpc netty

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-okhttp</artifactId>
+            <artifactId>grpc-netty-shaded</artifactId>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>


### PR DESCRIPTION
### Motivation

Use `grpc-netty-shaded` instead of `grpc-okhttp`, as the GRPC-Java documentation recommends.

![image](https://user-images.githubusercontent.com/74767115/227791312-8219c59d-df0c-4292-99fe-e7704c50de9a.png)
