### PR TITLE
Pin version of Guava to 32.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <mockito.junit.jupiter.version>4.11.0</mockito.junit.jupiter.version>
         <opentelemetry.version>1.23.1</opentelemetry.version>
         <testcontainers.version>1.17.6</testcontainers.version>
+        <guava.version>32.1.3-jre</guava.version>
 
         <checkstyle.plugin.version>3.3.1</checkstyle.plugin.version>
         <jacoco.plugin.version>0.8.8</jacoco.plugin.version>
@@ -99,6 +100,11 @@
                 <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION

```
├────────────────────────────────────────────────────────┼───────────────┼──────────┤        ├───────────────────┤                ├──────────────────────────────────────────────────────────────┤
│ com.google.guava:guava                                 │ CVE-2023-2976 │ MEDIUM   │        │ 31.0.1-jre        │                │ guava: insecure temporary directory creation                 │
│ (pulsar-metadatastore-oxia-0.0.11-shaded.jar)          │               │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-2976                    │
│                                                        ├───────────────┼──────────┤        │                   │                ├──────────────────────────────────────────────────────────────┤
│                                                        │ CVE-2020-8908 │ LOW      │        │                   │                │ local information disclosure via temporary directory created │
│                                                        │               │          │        │                   │                │ with unsafe permissions                                      │
│                                                        │               │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2020-8908                    │
├────────────────────────────────────────────────────────┼───────────────┼──────────┤        ├───────────────────┤                ├──────────────────────────────────────────────────────────────┤
```