### PR TITLE
Manage protoc version as part of the build

### DIFF
--- a/.github/workflows/ci-maven-publish-release.yaml
+++ b/.github/workflows/ci-maven-publish-release.yaml
@@ -28,10 +28,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release Maven package
         uses: samuelmeuli/action-maven-publish@v1

--- a/.github/workflows/dispatch-build-test-image.yaml
+++ b/.github/workflows/dispatch-build-test-image.yaml
@@ -26,10 +26,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: mvn clean install -DskipTests
       - name: Extract Maven project version

--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and Verify
         run: mvn --no-transfer-progress --batch-mode verify
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements:
 
 * JDK 17
 * Maven 3.8.6+
-* [protoc](https://grpc.io/docs/protoc-installation/)
 
 Common build actions:
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -216,7 +216,7 @@
                 <configuration>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-                    <protocExecutable>protoc</protocExecutable>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                     <protocPlugins>
                         <protocPlugin>
                             <id>reactor-grpc</id>
@@ -227,6 +227,15 @@
                         </protocPlugin>
                     </protocPlugins>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protoc</artifactId>
+                        <version>${protoc.version}</version>
+                        <classifier>${os.detected.classifier}</classifier>
+                        <type>exe</type>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <goals>
@@ -241,7 +250,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.2</version>
+                <version>1.7.1</version>
             </extension>
         </extensions>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <grpc.version>1.59.0</grpc.version>
+        <!-- The protoc version should match the used protobuf-java version.
+             See https://protobuf.dev/support/cross-version-runtime-guarantee/.
+             Find out the compatible protobuf-java version for the respective grpc-protobuf version by looking up
+             the pom file in https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/ and looking for the protobuf-java
+             version in that file.
+             -->
+        <protoc.version>3.24.0</protoc.version>
 
         <assertj.version>3.24.1</assertj.version>
         <awaitility.version>3.0.0</awaitility.version>


### PR DESCRIPTION
The protoc version should match the used protobuf-java version. See https://protobuf.dev/support/cross-version-runtime-guarantee/. That's why it's better to manage the protoc version as part of the build.

There's a dependency between grpc and protobuf too. The compatible protobuf-java version for the respective grpc-protobuf version can be looked up in the the pom file in https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/ and looking for the protobuf-java version in that file. For grpc 1.59.0, the pom file is https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.59.0/grpc-protobuf-1.59.0.pom . It depends on protobuf-java 3.24.0 .
