### PR TITLE
Downgrade gRPC version to 1.55

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -34,7 +34,6 @@
         <grpc-test.version>1.2.2</grpc-test.version>
         <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
         <javax.annotation.version>1.3.2</javax.annotation.version>
-        <protobuf.version>3.25.0</protobuf.version>
         <reactor.version>3.5.2</reactor.version>
         <reactor-grpc.version>1.2.4</reactor-grpc.version>
         <zah.version>0.16</zah.version>
@@ -93,6 +92,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-inprocess</artifactId>
+            <version>1.59.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -216,7 +216,7 @@
                 <configuration>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <protocPlugins>
                         <protocPlugin>
                             <id>reactor-grpc</id>
@@ -231,7 +231,7 @@
                     <dependency>
                         <groupId>com.google.protobuf</groupId>
                         <artifactId>protoc</artifactId>
-                        <version>${protoc.version}</version>
+                        <version>${protobuf.version}</version>
                         <classifier>${os.detected.classifier}</classifier>
                         <type>exe</type>
                     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,14 +83,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <grpc.version>1.59.0</grpc.version>
+        <grpc.version>1.55.3</grpc.version>
         <!-- The protoc version should match the used protobuf-java version.
              See https://protobuf.dev/support/cross-version-runtime-guarantee/.
              Find out the compatible protobuf-java version for the respective grpc-protobuf version by looking up
              the pom file in https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/ and looking for the protobuf-java
              version in that file.
              -->
-        <protoc.version>3.24.0</protoc.version>
+        <protobuf.version>3.24.0</protobuf.version>
 
         <assertj.version>3.24.1</assertj.version>
         <awaitility.version>3.0.0</awaitility.version>


### PR DESCRIPTION
Using gRPC 1.55 to match version used in Pulsar, so we don't need to pick shaded version.