### PR TITLE
Refactored Put & Delete options

### DIFF
--- a/client-api/src/main/java/io/streamnative/oxia/client/api/AsyncOxiaClient.java
+++ b/client-api/src/main/java/io/streamnative/oxia/client/api/AsyncOxiaClient.java
@@ -17,6 +17,7 @@ package io.streamnative.oxia.client.api;
 
 import io.streamnative.oxia.client.api.exceptions.UnexpectedVersionIdException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import lombok.NonNull;
@@ -29,7 +30,7 @@ public interface AsyncOxiaClient extends AutoCloseable {
      * specified, at the instant when the put is applied. The put will not be applied if the server's
      * versionId of the record does not match the expectation set in the call. If you wish the put to
      * succeed only if the key does not already exist on the server, then pass the {@link
-     * Version#KeyNotExists} value.
+     * PutOption#IfRecordDoesNotExist} value.
      *
      * @param key The key with which the value should be associated.
      * @param value The value to associate with the key.
@@ -40,7 +41,20 @@ public interface AsyncOxiaClient extends AutoCloseable {
      *     the call.
      */
     @NonNull
-    CompletableFuture<PutResult> put(String key, byte[] value, PutOption... options);
+    CompletableFuture<PutResult> put(String key, byte[] value, Set<PutOption> options);
+
+    /**
+     * Conditionally associates a value with a key if the server's versionId of the record is as
+     * specified, at the instant when the put is applied. The put will not be applied if the server's
+     * versionId of the record does not match the expectation set in the call.
+     *
+     * @param key The key with which the value should be associated.
+     * @param value The value to associate with the key.
+     * @return The result of the put at the specified key. Supplied via a future that returns the
+     *     {@link PutResult}.
+     */
+    @NonNull
+    CompletableFuture<PutResult> put(String key, byte[] value);
 
     /**
      * Conditionally deletes the record associated with the key if the record exists, and the server's
@@ -56,7 +70,17 @@ public interface AsyncOxiaClient extends AutoCloseable {
      *     versionId at the server did not that match supplied in the call.
      */
     @NonNull
-    CompletableFuture<Boolean> delete(String key, DeleteOption... options);
+    CompletableFuture<Boolean> delete(String key, Set<DeleteOption> options);
+
+    /**
+     * Unconditionally deletes the record associated with the key if the record exists.
+     *
+     * @param key Deletes the record with the specified key.
+     * @return A future that completes when the delete call has returned. The future can return a flag
+     *     that will be true if the key was actually present on the server, false otherwise.
+     */
+    @NonNull
+    CompletableFuture<Boolean> delete(String key);
 
     /**
      * Deletes any records with keys within the specified range. For more information on how keys are

--- a/client-api/src/main/java/io/streamnative/oxia/client/api/DeleteOption.java
+++ b/client-api/src/main/java/io/streamnative/oxia/client/api/DeleteOption.java
@@ -15,50 +15,9 @@
  */
 package io.streamnative.oxia.client.api;
 
-import static io.streamnative.oxia.client.api.DeleteOption.VersionIdDeleteOption;
-import static io.streamnative.oxia.client.api.DeleteOption.VersionIdDeleteOption.IfVersionIdEquals;
-import static io.streamnative.oxia.client.api.DeleteOption.VersionIdDeleteOption.Unconditionally;
+public sealed interface DeleteOption permits OptionVersionId {
 
-public sealed interface DeleteOption permits VersionIdDeleteOption {
-
-    default boolean cannotCoExistWith(DeleteOption option) {
-        return false;
-    }
-
-    sealed interface VersionIdDeleteOption extends DeleteOption
-            permits IfVersionIdEquals, Unconditionally {
-
-        Long toVersionId();
-
-        default boolean cannotCoExistWith(DeleteOption option) {
-            return option instanceof VersionIdDeleteOption;
-        }
-
-        record IfVersionIdEquals(long versionId) implements VersionIdDeleteOption {
-
-            public IfVersionIdEquals {
-                if (versionId < 0) {
-                    throw new IllegalArgumentException("versionId cannot be less than 0 - was: " + versionId);
-                }
-            }
-
-            @Override
-            public Long toVersionId() {
-                return versionId();
-            }
-        }
-
-        record Unconditionally() implements VersionIdDeleteOption {
-            @Override
-            public Long toVersionId() {
-                return null;
-            }
-        }
-    }
-
-    VersionIdDeleteOption Unconditionally = new VersionIdDeleteOption.Unconditionally();
-
-    static VersionIdDeleteOption ifVersionIdEquals(long versionId) {
-        return new IfVersionIdEquals(versionId);
+    static DeleteOption IfVersionIdEquals(long versionId) {
+        return new OptionVersionId.OptionVersionIdEqual(versionId);
     }
 }

--- a/client-api/src/main/java/io/streamnative/oxia/client/api/OptionEphemeral.java
+++ b/client-api/src/main/java/io/streamnative/oxia/client/api/OptionEphemeral.java
@@ -15,12 +15,4 @@
  */
 package io.streamnative.oxia.client.api;
 
-public sealed interface PutOption permits OptionEphemeral, OptionVersionId {
-
-    PutOption IfRecordDoesNotExist = new OptionVersionId.OptionRecordDoesNotExist();
-    PutOption AsEphemeralRecord = new OptionEphemeral();
-
-    static PutOption IfVersionIdEquals(long versionId) {
-        return new OptionVersionId.OptionVersionIdEqual(versionId);
-    }
-}
+public record OptionEphemeral() implements PutOption {}

--- a/client-api/src/main/java/io/streamnative/oxia/client/api/OptionVersionId.java
+++ b/client-api/src/main/java/io/streamnative/oxia/client/api/OptionVersionId.java
@@ -15,12 +15,23 @@
  */
 package io.streamnative.oxia.client.api;
 
-public sealed interface PutOption permits OptionEphemeral, OptionVersionId {
+public sealed interface OptionVersionId extends PutOption, DeleteOption
+        permits OptionVersionId.OptionRecordDoesNotExist, OptionVersionId.OptionVersionIdEqual {
 
-    PutOption IfRecordDoesNotExist = new OptionVersionId.OptionRecordDoesNotExist();
-    PutOption AsEphemeralRecord = new OptionEphemeral();
+    long versionId();
 
-    static PutOption IfVersionIdEquals(long versionId) {
-        return new OptionVersionId.OptionVersionIdEqual(versionId);
+    record OptionVersionIdEqual(long versionId) implements OptionVersionId {
+        public OptionVersionIdEqual {
+            if (versionId < 0) {
+                throw new IllegalArgumentException("versionId cannot be less than 0 - was: " + versionId);
+            }
+        }
+    }
+
+    record OptionRecordDoesNotExist() implements OptionVersionId {
+        @Override
+        public long versionId() {
+            return Version.KeyNotExists;
+        }
     }
 }

--- a/client-api/src/main/java/io/streamnative/oxia/client/api/SyncOxiaClient.java
+++ b/client-api/src/main/java/io/streamnative/oxia/client/api/SyncOxiaClient.java
@@ -17,11 +17,22 @@ package io.streamnative.oxia.client.api;
 
 import io.streamnative.oxia.client.api.exceptions.UnexpectedVersionIdException;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import lombok.NonNull;
 
 /** Synchronous client for the Oxia service. */
 public interface SyncOxiaClient extends AutoCloseable {
+
+    /**
+     * Associates a value with a key if the server's versionId of the record is as specified, at the
+     * instant when the put is applied.
+     *
+     * @param key The key with which the value should be associated.
+     * @param value The value to associate with the key.
+     * @return The result of the put at the specified key.
+     */
+    PutResult put(@NonNull String key, byte @NonNull [] value);
 
     /**
      * Conditionally associates a value with a key if the server's versionId of the record is as
@@ -37,8 +48,16 @@ public interface SyncOxiaClient extends AutoCloseable {
      * @throws UnexpectedVersionIdException The versionId at the server did not that match supplied in
      *     the call.
      */
-    PutResult put(@NonNull String key, byte @NonNull [] value, PutOption... options)
+    PutResult put(@NonNull String key, byte @NonNull [] value, Set<PutOption> options)
             throws UnexpectedVersionIdException;
+
+    /**
+     * Unconditionally deletes the record associated with the key if the record exists.
+     *
+     * @param key Deletes the record with the specified key.
+     * @return True if the key was actually present on the server, false otherwise.
+     */
+    boolean delete(@NonNull String key);
 
     /**
      * Conditionally deletes the record associated with the key if the record exists, and the server's
@@ -52,7 +71,7 @@ public interface SyncOxiaClient extends AutoCloseable {
      * @throws UnexpectedVersionIdException The versionId at the server did not that match supplied in
      *     the call.
      */
-    boolean delete(@NonNull String key, @NonNull DeleteOption... options)
+    boolean delete(@NonNull String key, @NonNull Set<DeleteOption> options)
             throws UnexpectedVersionIdException;
 
     /**

--- a/client/src/main/java/io/streamnative/oxia/client/CachingAsyncOxiaClient.java
+++ b/client/src/main/java/io/streamnative/oxia/client/CachingAsyncOxiaClient.java
@@ -25,7 +25,9 @@ import io.streamnative.oxia.client.api.GetResult;
 import io.streamnative.oxia.client.api.Notification;
 import io.streamnative.oxia.client.api.PutOption;
 import io.streamnative.oxia.client.api.PutResult;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -49,15 +51,25 @@ class CachingAsyncOxiaClient implements AsyncOxiaClient {
     }
 
     @Override
+    public @NonNull CompletableFuture<PutResult> put(@NonNull String key, byte @NonNull [] value) {
+        return put(key, value, Collections.emptySet());
+    }
+
+    @Override
     public @NonNull CompletableFuture<PutResult> put(
-            @NonNull String key, byte @NonNull [] value, @NonNull PutOption... options) {
+            @NonNull String key, byte @NonNull [] value, @NonNull Set<PutOption> options) {
         recordCache.synchronous().invalidate(key);
         return delegate.put(key, value, options);
     }
 
     @Override
+    public @NonNull CompletableFuture<Boolean> delete(@NonNull String key) {
+        return delete(key, Collections.emptySet());
+    }
+
+    @Override
     public @NonNull CompletableFuture<Boolean> delete(
-            @NonNull String key, @NonNull DeleteOption... options) {
+            @NonNull String key, @NonNull Set<DeleteOption> options) {
         recordCache.synchronous().invalidate(key);
         return delegate.delete(key, options);
     }

--- a/client/src/main/java/io/streamnative/oxia/client/SyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/SyncOxiaClientImpl.java
@@ -23,7 +23,9 @@ import io.streamnative.oxia.client.api.PutOption;
 import io.streamnative.oxia.client.api.PutResult;
 import io.streamnative.oxia.client.api.SyncOxiaClient;
 import io.streamnative.oxia.client.api.exceptions.UnexpectedVersionIdException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import lombok.AccessLevel;
@@ -35,10 +37,15 @@ import lombok.SneakyThrows;
 class SyncOxiaClientImpl implements SyncOxiaClient {
     private final AsyncOxiaClient asyncClient;
 
+    @Override
+    public PutResult put(@NonNull String key, byte @NonNull [] value) {
+        return put(key, value, Collections.emptySet());
+    }
+
     @SneakyThrows
     @Override
     public @NonNull PutResult put(
-            @NonNull String key, byte @NonNull [] value, @NonNull PutOption... options) {
+            @NonNull String key, byte @NonNull [] value, @NonNull Set<PutOption> options) {
         try {
             return asyncClient.put(key, value, options).get();
         } catch (InterruptedException e) {
@@ -51,7 +58,13 @@ class SyncOxiaClientImpl implements SyncOxiaClient {
 
     @SneakyThrows
     @Override
-    public boolean delete(@NonNull String key, @NonNull DeleteOption... options)
+    public boolean delete(@NonNull String key) {
+        return delete(key, Collections.emptySet());
+    }
+
+    @SneakyThrows
+    @Override
+    public boolean delete(@NonNull String key, @NonNull Set<DeleteOption> options)
             throws UnexpectedVersionIdException {
         try {
             return asyncClient.delete(key, options).get();

--- a/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
@@ -15,7 +15,7 @@
  */
 package io.streamnative.oxia.client;
 
-import static io.streamnative.oxia.client.api.PutOption.ifVersionIdEquals;
+import static io.streamnative.oxia.client.api.PutOption.IfVersionIdEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,6 +47,7 @@ import io.streamnative.oxia.proto.ListResponse;
 import io.streamnative.oxia.proto.ReactorOxiaClientGrpc.ReactorOxiaClientStub;
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -146,7 +147,7 @@ class AsyncOxiaClientImplTest {
         when(shardManager.get(key)).thenReturn(shardId);
         when(writeBatchManager.getBatcher(shardId)).thenReturn(batcher);
         doNothing().when(batcher).add(opCaptor.capture());
-        var result = client.put(key, value, ifVersionIdEquals(expectedVersionId));
+        var result = client.put(key, value, Set.of(IfVersionIdEquals(expectedVersionId)));
         assertThat(result).isNotCompleted();
         assertThat(opCaptor.getValue())
                 .satisfies(
@@ -161,7 +162,7 @@ class AsyncOxiaClientImplTest {
     void putInvalidOptions() {
         var key = "key";
         var value = "hello".getBytes(UTF_8);
-        var result = client.put(key, value, ifVersionIdEquals(1L), ifVersionIdEquals(2L));
+        var result = client.put(key, value, Set.of(IfVersionIdEquals(1L), IfVersionIdEquals(2L)));
         assertThat(result).isCompletedExceptionally();
     }
 
@@ -218,7 +219,7 @@ class AsyncOxiaClientImplTest {
         when(shardManager.get(key)).thenReturn(shardId);
         when(writeBatchManager.getBatcher(shardId)).thenReturn(batcher);
         doNothing().when(batcher).add(opCaptor.capture());
-        var result = client.delete(key, DeleteOption.ifVersionIdEquals(expectedVersionId));
+        var result = client.delete(key, Set.of(DeleteOption.IfVersionIdEquals(expectedVersionId)));
         assertThat(result).isNotCompleted();
         assertThat(opCaptor.getValue())
                 .satisfies(
@@ -232,7 +233,8 @@ class AsyncOxiaClientImplTest {
     void deleteInvalidOptions() {
         var key = "key";
         var result =
-                client.delete(key, DeleteOption.ifVersionIdEquals(1L), DeleteOption.ifVersionIdEquals(2L));
+                client.delete(
+                        key, Set.of(DeleteOption.IfVersionIdEquals(1L), DeleteOption.IfVersionIdEquals(2L)));
         assertThat(result).isCompletedExceptionally();
     }
 

--- a/client/src/test/java/io/streamnative/oxia/client/CachingAsyncOxiaClientTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/CachingAsyncOxiaClientTest.java
@@ -34,6 +34,7 @@ import io.streamnative.oxia.client.api.Notification.KeyDeleted;
 import io.streamnative.oxia.client.api.Notification.KeyModified;
 import io.streamnative.oxia.client.api.PutResult;
 import io.streamnative.oxia.client.api.Version;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -72,22 +73,22 @@ class CachingAsyncOxiaClientTest {
         var value = "value".getBytes(UTF_8);
         var version = new Version(1L, 2L, 3L, 4L, Optional.empty(), Optional.empty());
         var result = CompletableFuture.completedFuture(new PutResult(version));
-        when(delegate.put("a", value)).thenReturn(result);
+        when(delegate.put("a", value, Collections.emptySet())).thenReturn(result);
         assertThat(client.put("a", value)).isSameAs(result);
         var inOrder = inOrder(delegate, syncCache);
         inOrder.verify(syncCache).invalidate("a");
-        inOrder.verify(delegate).put("a", value);
+        inOrder.verify(delegate).put("a", value, Collections.emptySet());
     }
 
     @Test
     void delete() {
         when(cache.synchronous()).thenReturn(syncCache);
         var result = CompletableFuture.completedFuture(true);
-        when(delegate.delete("a")).thenReturn(result);
+        when(delegate.delete("a", Collections.emptySet())).thenReturn(result);
         assertThat(client.delete("a")).isSameAs(result);
         var inOrder = inOrder(delegate, syncCache);
         inOrder.verify(syncCache).invalidate("a");
-        inOrder.verify(delegate).delete("a");
+        inOrder.verify(delegate).delete("a", Collections.emptySet());
     }
 
     @Test

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
@@ -60,6 +60,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -145,10 +146,10 @@ class BatchTest {
         CompletableFuture<Boolean> deleteCallable = new CompletableFuture<>();
         CompletableFuture<Void> deleteRangeCallable = new CompletableFuture<>();
 
-        PutOperation put = new PutOperation(putCallable, "", new byte[0], Optional.of(1L), false);
+        PutOperation put = new PutOperation(putCallable, "", new byte[0], OptionalLong.of(1), false);
         PutOperation putEphemeral =
-                new PutOperation(putEphemeralCallable, "", new byte[0], Optional.of(1L), true);
-        DeleteOperation delete = new DeleteOperation(deleteCallable, "", Optional.of(1L));
+                new PutOperation(putEphemeralCallable, "", new byte[0], OptionalLong.of(1), true);
+        DeleteOperation delete = new DeleteOperation(deleteCallable, "", OptionalLong.of(1));
         DeleteRangeOperation deleteRange = new DeleteRangeOperation(deleteRangeCallable, "a", "b");
 
         String clientIdentifier = "client-id";

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatcherTest.java
@@ -35,7 +35,7 @@ import io.streamnative.oxia.client.api.PutResult;
 import io.streamnative.oxia.client.batch.Operation.ReadOperation.GetOperation;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -107,7 +107,7 @@ class BatcherTest {
         var callback = new CompletableFuture<PutResult>();
         Operation<?> op =
                 new Operation.WriteOperation.PutOperation(
-                        callback, "key", "value".getBytes(StandardCharsets.UTF_8), Optional.empty(), false);
+                        callback, "key", "value".getBytes(StandardCharsets.UTF_8), OptionalLong.empty(), false);
         when(batchFactory.getBatch(shardId)).thenReturn(batch);
         when(batch.size()).thenReturn(config.maxRequestsPerBatch(), 1);
         when(batch.canAdd(any())).thenReturn(false);

--- a/client/src/test/java/io/streamnative/oxia/client/batch/OperationTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/OperationTest.java
@@ -43,6 +43,7 @@ import io.streamnative.oxia.proto.PutResponse;
 import io.streamnative.oxia.proto.Version;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.DisplayName;
@@ -145,7 +146,7 @@ class OperationTest {
     class PutOperationTests {
         CompletableFuture<PutResult> callback = new CompletableFuture<>();
         byte[] payload = "hello".getBytes(UTF_8);
-        PutOperation op = new PutOperation(callback, "key", payload, Optional.of(10L), false);
+        PutOperation op = new PutOperation(callback, "key", payload, OptionalLong.of(10), false);
         long sessionId = 0L;
         String clientId = "client-id";
         SessionInfo sessionInfo = new SessionInfo(sessionId, clientId);
@@ -154,16 +155,18 @@ class OperationTest {
         void constructInvalidExpectedVersionId() {
             assertThatNoException()
                     .isThrownBy(
-                            () -> new PutOperation(callback, "key", payload, Optional.of(KeyNotExists), false));
+                            () ->
+                                    new PutOperation(callback, "key", payload, OptionalLong.of(KeyNotExists), false));
             assertThatNoException()
-                    .isThrownBy(() -> new PutOperation(callback, "key", payload, Optional.of(0L), false));
-            assertThatThrownBy(() -> new PutOperation(callback, "key", payload, Optional.of(-2L), false))
+                    .isThrownBy(() -> new PutOperation(callback, "key", payload, OptionalLong.of(0L), false));
+            assertThatThrownBy(
+                            () -> new PutOperation(callback, "key", payload, OptionalLong.of(-2L), false))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         void toProtoNoExpectedVersion() {
-            var op = new PutOperation(callback, "key", payload, Optional.empty(), false);
+            var op = new PutOperation(callback, "key", payload, OptionalLong.empty(), false);
             var request = op.toProto(Optional.empty());
             assertThat(request)
                     .satisfies(
@@ -178,7 +181,7 @@ class OperationTest {
 
         @Test
         void toProtoExpectedVersion() {
-            var op = new PutOperation(callback, "key", payload, Optional.of(1L), false);
+            var op = new PutOperation(callback, "key", payload, OptionalLong.of(1L), false);
             var request = op.toProto(Optional.empty());
             assertThat(request)
                     .satisfies(
@@ -193,7 +196,7 @@ class OperationTest {
 
         @Test
         void toProtoNoExistingVersion() {
-            var op = new PutOperation(callback, "key", payload, Optional.of(KeyNotExists), false);
+            var op = new PutOperation(callback, "key", payload, OptionalLong.of(KeyNotExists), false);
             var request = op.toProto(Optional.empty());
             assertThat(request)
                     .satisfies(
@@ -208,7 +211,7 @@ class OperationTest {
 
         @Test
         void toProtoEphemeral() {
-            var op = new PutOperation(callback, "key", payload, Optional.empty(), true);
+            var op = new PutOperation(callback, "key", payload, OptionalLong.empty(), true);
             var request = op.toProto(Optional.of(sessionInfo));
             assertThat(request)
                     .satisfies(
@@ -238,7 +241,7 @@ class OperationTest {
 
         @Test
         void completeKeyAlreadyExists() {
-            var op = new PutOperation(callback, "key", payload, Optional.of(KeyNotExists), false);
+            var op = new PutOperation(callback, "key", payload, OptionalLong.of(KeyNotExists), false);
             var response = PutResponse.newBuilder().setStatus(UNEXPECTED_VERSION_ID).build();
             op.complete(response);
             assertThat(callback).isCompletedExceptionally();
@@ -254,7 +257,7 @@ class OperationTest {
 
         @Test
         void completeSessionDoesNotExist() {
-            var op = new PutOperation(callback, "key", payload, Optional.empty(), true);
+            var op = new PutOperation(callback, "key", payload, OptionalLong.empty(), true);
             var response = PutResponse.newBuilder().setStatus(SESSION_DOES_NOT_EXIST).build();
             op.complete(response);
             assertThat(callback).isCompletedExceptionally();
@@ -332,15 +335,15 @@ class OperationTest {
     @DisplayName("Tests of delete operation")
     class DeleteOperationTests {
         CompletableFuture<Boolean> callback = new CompletableFuture<>();
-        DeleteOperation op = new DeleteOperation(callback, "key", Optional.of(10L));
+        DeleteOperation op = new DeleteOperation(callback, "key", OptionalLong.of(10L));
 
         @Test
         void constructInvalidExpectedVersionId() {
             assertThatNoException()
-                    .isThrownBy(() -> new DeleteOperation(callback, "key", Optional.of(0L)));
-            assertThatThrownBy(() -> new DeleteOperation(callback, "key", Optional.of(KeyNotExists)))
+                    .isThrownBy(() -> new DeleteOperation(callback, "key", OptionalLong.of(0L)));
+            assertThatThrownBy(() -> new DeleteOperation(callback, "key", OptionalLong.of(KeyNotExists)))
                     .isInstanceOf(IllegalArgumentException.class);
-            assertThatThrownBy(() -> new DeleteOperation(callback, "key", Optional.of(-2L)))
+            assertThatThrownBy(() -> new DeleteOperation(callback, "key", OptionalLong.of(-2L)))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 


### PR DESCRIPTION
 * Avoid expensive allocations during validation in the hot path
 * Take `Set<PutOption>` instead of `PutOption...` because it will make it easier for complex wrappers to use