### PR TITLE
shardsManager: fix unchanged shard assignment causes exception

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/shard/ShardManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/shard/ShardManager.java
@@ -15,7 +15,7 @@
  */
 package io.streamnative.oxia.client.shard;
 
-import static com.google.common.base.Throwables.*;
+import static com.google.common.base.Throwables.getRootCause;
 import static io.streamnative.oxia.client.shard.HashRangeShardStrategy.Xxh332HashRangeShardStrategy;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;

--- a/client/src/main/java/io/streamnative/oxia/client/shard/ShardManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/shard/ShardManager.java
@@ -215,7 +215,9 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
                                         .filter(e -> !toDelete.contains(e.getKey()))
                                         .map(Map.Entry::getValue),
                                 updates.stream())
-                        .collect(toMap(Shard::id, identity())));
+                        .collect(toMap(Shard::id, identity(),
+                                // merge function to avoid throw any exception when receive unchanged events
+                                (existing, newValue) -> newValue)));
     }
 
     @VisibleForTesting

--- a/client/src/test/java/io/streamnative/oxia/client/shard/ShardManagerTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/shard/ShardManagerTest.java
@@ -34,6 +34,7 @@ import io.streamnative.oxia.proto.ShardAssignment;
 import io.streamnative.oxia.proto.ShardAssignments;
 import io.streamnative.oxia.proto.ShardAssignmentsRequest;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -87,6 +88,34 @@ public class ShardManagerTest {
                                                 entry(6L, new Shard(6L, "leader 4", new HashRange(13, 13))));
                                 assertThat(a).isUnmodifiable();
                             });
+        }
+
+        @Test
+        void recomputeShardHashBoundariesWithSameValue() {
+            var existing =
+                    Map.of(
+                            1L, new Shard(1L, "leader 1", new HashRange(1, 3)),
+                            2L, new Shard(2L, "leader 1", new HashRange(7, 9)),
+                            3L, new Shard(3L, "leader 2", new HashRange(4, 6)),
+                            4L, new Shard(4L, "leader 2", new HashRange(10, 11)),
+                            5L, new Shard(5L, "leader 3", new HashRange(11, 12)),
+                            6L, new Shard(6L, "leader 4", new HashRange(13, 13)));
+            var assignments = ShardManager.recomputeShardHashBoundaries(existing,
+                    // same values
+                    new HashSet<>(existing.values()));
+            assertThat(assignments)
+                    .satisfies( a -> {
+                        assertThat(a)
+                                .containsOnly(
+                                        entry(1L, new Shard(1L, "leader 1", new HashRange(1, 3))),
+                                        entry(2L, new Shard(2L, "leader 1", new HashRange(7, 9))),
+                                        entry(3L, new Shard(3L, "leader 2", new HashRange(4, 6))),
+                                        entry(4L, new Shard(4L, "leader 2", new HashRange(10, 11))),
+                                        entry(5L, new Shard(5L, "leader 3", new HashRange(11, 12))),
+                                        entry(6L, new Shard(6L, "leader 4", new HashRange(13, 13)))
+                                );
+                        assertThat(a).isUnmodifiable();
+                    });
         }
     }
 

--- a/client/src/test/java/io/streamnative/oxia/client/shard/ShardManagerTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/shard/ShardManagerTest.java
@@ -100,22 +100,24 @@ public class ShardManagerTest {
                             4L, new Shard(4L, "leader 2", new HashRange(10, 11)),
                             5L, new Shard(5L, "leader 3", new HashRange(11, 12)),
                             6L, new Shard(6L, "leader 4", new HashRange(13, 13)));
-            var assignments = ShardManager.recomputeShardHashBoundaries(existing,
-                    // same values
-                    new HashSet<>(existing.values()));
+            var assignments =
+                    ShardManager.recomputeShardHashBoundaries(
+                            existing,
+                            // same values
+                            new HashSet<>(existing.values()));
             assertThat(assignments)
-                    .satisfies( a -> {
-                        assertThat(a)
-                                .containsOnly(
-                                        entry(1L, new Shard(1L, "leader 1", new HashRange(1, 3))),
-                                        entry(2L, new Shard(2L, "leader 1", new HashRange(7, 9))),
-                                        entry(3L, new Shard(3L, "leader 2", new HashRange(4, 6))),
-                                        entry(4L, new Shard(4L, "leader 2", new HashRange(10, 11))),
-                                        entry(5L, new Shard(5L, "leader 3", new HashRange(11, 12))),
-                                        entry(6L, new Shard(6L, "leader 4", new HashRange(13, 13)))
-                                );
-                        assertThat(a).isUnmodifiable();
-                    });
+                    .satisfies(
+                            a -> {
+                                assertThat(a)
+                                        .containsOnly(
+                                                entry(1L, new Shard(1L, "leader 1", new HashRange(1, 3))),
+                                                entry(2L, new Shard(2L, "leader 1", new HashRange(7, 9))),
+                                                entry(3L, new Shard(3L, "leader 2", new HashRange(4, 6))),
+                                                entry(4L, new Shard(4L, "leader 2", new HashRange(10, 11))),
+                                                entry(5L, new Shard(5L, "leader 3", new HashRange(11, 12))),
+                                                entry(6L, new Shard(6L, "leader 4", new HashRange(13, 13))));
+                                assertThat(a).isUnmodifiable();
+                            });
         }
     }
 


### PR DESCRIPTION
### Issue
https://github.com/streamnative/oxia-java/issues/170


### RCA

Oxia-java client didn't handle well with unchanged assignments. which calls the `toMap` method with the duplicated key and causes an exception throw in the GRPC stream.

The real exception capture by Arthas
```
java.lang.IllegalStateException: Duplicate key 36 (attempted merging values Shard[id=36, leader=***********, hashRange=HashRange[minInclusive=0, maxInclusive=4294967295]] and Shard[id=36, leader=***********, hashRange=HashRange[minInclusive=0, maxInclusive=4294967295]])
```

Why can the client receive notification about unchanged assignments?
1. The coordinator sends node-level assignments to the oxia server.
2. The oxia server will filter the namespace without an equals check and then send it to the client. (maybe caused by cost/data consistent consideration) 

### Modification

- Add merge function to avoid exception
- Print the root cause messages.