### PR TITLE
fix: fix unrecovery channel exception

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStub.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStub.java
@@ -53,7 +53,6 @@ public class OxiaStub implements AutoCloseable {
                                         ? TlsChannelCredentials.newBuilder().build()
                                         : InsecureChannelCredentials.create())
                         .directExecutor()
-                        .disableRetry()
                         .build(),
                 namespace,
                 authentication);


### PR DESCRIPTION
### Motivation

I observe we have some connection issue when restart oxia server that causes the client can't work.  the client consist print error logs like:

```
Caused by: java.net.UnknownHostException: xxxxxxxxx: Name does not resolve
	at java.base/java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method)
	at java.base/java.net.Inet4AddressImpl.lookupAllHostAddr(Unknown Source)
	at java.base/java.net.InetAddress$PlatformResolver.lookupByName(Unknown Source)
	at java.base/java.net.InetAddress.getAddressesFromNameService(Unknown Source)
	at java.base/java.net.InetAddress$NameServiceAddresses.get(Unknown Source)
	at java.base/java.net.InetAddress.getAllByName0(Unknown Source)
	at java.base/java.net.InetAddress.getAllByName(Unknown Source)
	at io.grpc.internal.DnsNameResolver$JdkAddressResolver.resolveAddress(DnsNameResolver.java:632)
```

The RC is that the channel will not retry after met issues. then constantly return error when send messages by  `FailingClientStream`

the issue introduced by https://github.com/streamnative/oxia-java/pull/166