### PR TITLE
feat: improve the reconnection backoff

### DIFF
--- a/client-api/src/main/java/io/streamnative/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/streamnative/oxia/client/api/OxiaClientBuilder.java
@@ -53,6 +53,8 @@ public interface OxiaClientBuilder {
 
     OxiaClientBuilder authentication(Authentication authentication);
 
+    OxiaClientBuilder connectionBackoff(Duration minDelay, Duration maxDelay);
+
     /**
      * Configure the authentication plugin and its parameters.
      *

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -84,6 +84,17 @@
             <version>1.59.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.streamnative.oxia</groupId>
+            <artifactId>oxia-testcontainers</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -75,10 +75,12 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
     static @NonNull CompletableFuture<AsyncOxiaClient> newInstance(@NonNull ClientConfig config) {
         ScheduledExecutorService executor =
                 Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("oxia-client"));
-        final var oxiaBackoffProvider = OxiaBackoffProvider
-                .create(config.connectionBackoffMinDelay(), config.connectionBackoffMaxDelay());
+        final var oxiaBackoffProvider =
+                OxiaBackoffProvider.create(
+                        config.connectionBackoffMinDelay(), config.connectionBackoffMaxDelay());
         var stubManager =
-                new OxiaStubManager(config.namespace(), config.authentication(), config.enableTls(), oxiaBackoffProvider);
+                new OxiaStubManager(
+                        config.namespace(), config.authentication(), config.enableTls(), oxiaBackoffProvider);
 
         var instrumentProvider = new InstrumentProvider(config.openTelemetry(), config.namespace());
         var serviceAddrStub = stubManager.getStub(config.serviceAddress());

--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -35,6 +35,7 @@ import io.streamnative.oxia.client.batch.Operation.ReadOperation.GetOperation;
 import io.streamnative.oxia.client.batch.Operation.WriteOperation.DeleteOperation;
 import io.streamnative.oxia.client.batch.Operation.WriteOperation.DeleteRangeOperation;
 import io.streamnative.oxia.client.batch.Operation.WriteOperation.PutOperation;
+import io.streamnative.oxia.client.grpc.OxiaBackoffProvider;
 import io.streamnative.oxia.client.grpc.OxiaStubManager;
 import io.streamnative.oxia.client.grpc.OxiaStubProvider;
 import io.streamnative.oxia.client.metrics.Counter;
@@ -74,8 +75,10 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
     static @NonNull CompletableFuture<AsyncOxiaClient> newInstance(@NonNull ClientConfig config) {
         ScheduledExecutorService executor =
                 Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("oxia-client"));
+        final var oxiaBackoffProvider = OxiaBackoffProvider
+                .create(config.connectionBackoffMinDelay(), config.connectionBackoffMaxDelay());
         var stubManager =
-                new OxiaStubManager(config.namespace(), config.authentication(), config.enableTls());
+                new OxiaStubManager(config.namespace(), config.authentication(), config.enableTls(), oxiaBackoffProvider);
 
         var instrumentProvider = new InstrumentProvider(config.openTelemetry(), config.namespace());
         var serviceAddrStub = stubManager.getStub(config.serviceAddress());

--- a/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
@@ -19,7 +19,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.streamnative.oxia.client.api.Authentication;
 import java.time.Duration;
 import javax.annotation.Nullable;
-
 import lombok.NonNull;
 
 public record ClientConfig(
@@ -35,5 +34,4 @@ public record ClientConfig(
         @Nullable Authentication authentication,
         boolean enableTls,
         @NonNull Duration connectionBackoffMinDelay,
-        @NonNull Duration connectionBackoffMaxDelay
-) {}
+        @NonNull Duration connectionBackoffMaxDelay) {}

--- a/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
@@ -19,6 +19,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.streamnative.oxia.client.api.Authentication;
 import java.time.Duration;
 import javax.annotation.Nullable;
+
 import lombok.NonNull;
 
 public record ClientConfig(
@@ -32,4 +33,7 @@ public record ClientConfig(
         OpenTelemetry openTelemetry,
         @NonNull String namespace,
         @Nullable Authentication authentication,
-        boolean enableTls) {}
+        boolean enableTls,
+        @NonNull Duration connectionBackoffMinDelay,
+        @NonNull Duration connectionBackoffMaxDelay
+) {}

--- a/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilderImpl.java
@@ -67,6 +67,10 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     @Nullable protected Authentication authentication;
     protected boolean enableTls = DefaultEnableTls;
 
+    @NonNull protected Duration connectionBackoffMinDelay = Duration.ofMillis(100);
+    @NonNull protected Duration connectionBackoffMaxDelay = Duration.ofSeconds(30);
+
+
     @Override
     public @NonNull OxiaClientBuilder requestTimeout(@NonNull Duration requestTimeout) {
         if (requestTimeout.isNegative() || requestTimeout.equals(ZERO)) {
@@ -138,6 +142,13 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     @Override
     public OxiaClientBuilder authentication(Authentication authentication) {
         this.authentication = authentication;
+        return this;
+    }
+
+    @Override
+    public OxiaClientBuilder connectionBackoff(Duration minDelay, Duration maxDelay) {
+        this.connectionBackoffMinDelay = minDelay;
+        this.connectionBackoffMaxDelay = maxDelay;
         return this;
     }
 
@@ -227,7 +238,9 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                         openTelemetry,
                         namespace,
                         authentication,
-                        enableTls);
+                        enableTls,
+                        connectionBackoffMinDelay,
+                        connectionBackoffMaxDelay);
         return AsyncOxiaClientImpl.newInstance(config);
     }
 

--- a/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilderImpl.java
@@ -70,7 +70,6 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     @NonNull protected Duration connectionBackoffMinDelay = Duration.ofMillis(100);
     @NonNull protected Duration connectionBackoffMaxDelay = Duration.ofSeconds(30);
 
-
     @Override
     public @NonNull OxiaClientBuilder requestTimeout(@NonNull Duration requestTimeout) {
         if (requestTimeout.isNegative() || requestTimeout.equals(ZERO)) {

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaBackoffProvider.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaBackoffProvider.java
@@ -1,26 +1,41 @@
+/*
+ * Copyright © 2022-2024 StreamNative Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.oxia.client.grpc;
 
 import io.grpc.internal.BackoffPolicy;
 import io.streamnative.oxia.client.util.Backoff;
-
-import javax.annotation.concurrent.ThreadSafe;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 public final class OxiaBackoffProvider implements BackoffPolicy.Provider {
-    public static final BackoffPolicy.Provider DEFAULT = new OxiaBackoffProvider(Backoff.DEFAULT_INITIAL_DELAY_MILLIS,
-            TimeUnit.MILLISECONDS, Backoff.DEFAULT_MAX_DELAY_SECONDS,
-            TimeUnit.MILLISECONDS);
+    public static final BackoffPolicy.Provider DEFAULT =
+            new OxiaBackoffProvider(
+                    Backoff.DEFAULT_INITIAL_DELAY_MILLIS,
+                    TimeUnit.MILLISECONDS,
+                    Backoff.DEFAULT_MAX_DELAY_SECONDS,
+                    TimeUnit.MILLISECONDS);
     private final long initialDelay;
     private final TimeUnit unitInitialDelay;
     private final long maxDelay;
     private final TimeUnit unitMaxDelay;
 
-    OxiaBackoffProvider(long initialDelay,
-                        TimeUnit unitInitialDelay,
-                        long maxDelay,
-                        TimeUnit unitMaxDelay) {
+    OxiaBackoffProvider(
+            long initialDelay, TimeUnit unitInitialDelay, long maxDelay, TimeUnit unitMaxDelay) {
         this.initialDelay = initialDelay;
         this.unitInitialDelay = unitInitialDelay;
         this.maxDelay = maxDelay;
@@ -33,7 +48,7 @@ public final class OxiaBackoffProvider implements BackoffPolicy.Provider {
     }
 
     public static BackoffPolicy.Provider create(Duration minDelay, Duration maxDelay) {
-        return new OxiaBackoffProvider(minDelay.getNano(),
-                TimeUnit.NANOSECONDS, maxDelay.getNano(), TimeUnit.NANOSECONDS);
+        return new OxiaBackoffProvider(
+                minDelay.getNano(), TimeUnit.NANOSECONDS, maxDelay.getNano(), TimeUnit.NANOSECONDS);
     }
 }

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaBackoffProvider.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaBackoffProvider.java
@@ -1,0 +1,39 @@
+package io.streamnative.oxia.client.grpc;
+
+import io.grpc.internal.BackoffPolicy;
+import io.streamnative.oxia.client.util.Backoff;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@ThreadSafe
+public final class OxiaBackoffProvider implements BackoffPolicy.Provider {
+    public static final BackoffPolicy.Provider DEFAULT = new OxiaBackoffProvider(Backoff.DEFAULT_INITIAL_DELAY_MILLIS,
+            TimeUnit.MILLISECONDS, Backoff.DEFAULT_MAX_DELAY_SECONDS,
+            TimeUnit.MILLISECONDS);
+    private final long initialDelay;
+    private final TimeUnit unitInitialDelay;
+    private final long maxDelay;
+    private final TimeUnit unitMaxDelay;
+
+    OxiaBackoffProvider(long initialDelay,
+                        TimeUnit unitInitialDelay,
+                        long maxDelay,
+                        TimeUnit unitMaxDelay) {
+        this.initialDelay = initialDelay;
+        this.unitInitialDelay = unitInitialDelay;
+        this.maxDelay = maxDelay;
+        this.unitMaxDelay = unitMaxDelay;
+    }
+
+    @Override
+    public BackoffPolicy get() {
+        return new Backoff(initialDelay, unitInitialDelay, maxDelay, unitMaxDelay);
+    }
+
+    public static BackoffPolicy.Provider create(Duration minDelay, Duration maxDelay) {
+        return new OxiaBackoffProvider(minDelay.getNano(),
+                TimeUnit.NANOSECONDS, maxDelay.getNano(), TimeUnit.NANOSECONDS);
+    }
+}

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubManager.java
@@ -30,7 +30,9 @@ public class OxiaStubManager implements AutoCloseable {
     @Nullable private final BackoffPolicy.Provider backoffProvider;
 
     public OxiaStubManager(
-            String namespace, @Nullable Authentication authentication, boolean enableTls,
+            String namespace,
+            @Nullable Authentication authentication,
+            boolean enableTls,
             @Nullable BackoffPolicy.Provider backoffProvider) {
         this.namespace = namespace;
         this.authentication = authentication;

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubManager.java
@@ -15,6 +15,7 @@
  */
 package io.streamnative.oxia.client.grpc;
 
+import io.grpc.internal.BackoffPolicy;
 import io.streamnative.oxia.client.api.Authentication;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,17 +27,20 @@ public class OxiaStubManager implements AutoCloseable {
     private final String namespace;
     @Nullable private final Authentication authentication;
     private final boolean enableTls;
+    @Nullable private final BackoffPolicy.Provider backoffProvider;
 
     public OxiaStubManager(
-            String namespace, @Nullable Authentication authentication, boolean enableTls) {
+            String namespace, @Nullable Authentication authentication, boolean enableTls,
+            @Nullable BackoffPolicy.Provider backoffProvider) {
         this.namespace = namespace;
         this.authentication = authentication;
         this.enableTls = enableTls;
+        this.backoffProvider = backoffProvider;
     }
 
     public OxiaStub getStub(String address) {
         return stubs.computeIfAbsent(
-                address, addr -> new OxiaStub(addr, namespace, authentication, enableTls));
+                address, addr -> new OxiaStub(addr, namespace, authentication, enableTls, backoffProvider));
     }
 
     @Override

--- a/client/src/main/java/io/streamnative/oxia/client/util/Backoff.java
+++ b/client/src/main/java/io/streamnative/oxia/client/util/Backoff.java
@@ -16,7 +16,6 @@
 package io.streamnative.oxia.client.util;
 
 import io.grpc.internal.BackoffPolicy;
-
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -33,15 +32,11 @@ public final class Backoff implements BackoffPolicy {
                 DEFAULT_INITIAL_DELAY_MILLIS,
                 TimeUnit.MILLISECONDS,
                 DEFAULT_MAX_DELAY_SECONDS,
-                TimeUnit.SECONDS
-        );
+                TimeUnit.SECONDS);
     }
 
     public Backoff(
-            long initialDelay,
-            TimeUnit unitInitialDelay,
-            long maxDelay,
-            TimeUnit unitMaxDelay) {
+            long initialDelay, TimeUnit unitInitialDelay, long maxDelay, TimeUnit unitMaxDelay) {
         this.initialDelayMillis = unitInitialDelay.toMillis(initialDelay);
         this.maxDelayMillis = unitMaxDelay.toMillis(maxDelay);
         this.nextDelayMillis = initialDelayMillis;
@@ -61,7 +56,6 @@ public final class Backoff implements BackoffPolicy {
     public void reset() {
         this.nextDelayMillis = initialDelayMillis;
     }
-
 
     @Override
     public long nextBackoffNanos() {

--- a/client/src/main/java/io/streamnative/oxia/client/util/Backoff.java
+++ b/client/src/main/java/io/streamnative/oxia/client/util/Backoff.java
@@ -15,37 +15,35 @@
  */
 package io.streamnative.oxia.client.util;
 
-import java.time.Clock;
+import io.grpc.internal.BackoffPolicy;
+
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
-public class Backoff {
+public final class Backoff implements BackoffPolicy {
     private final long initialDelayMillis;
     private long nextDelayMillis;
     private final long maxDelayMillis;
-    private final Clock clock;
 
-    private static final long DEFAULT_INITIAL_DELAY_MILLIS = 100;
-    private static final long DEFAULT_MAX_DELAY_SECONDS = 60;
+    public static final long DEFAULT_INITIAL_DELAY_MILLIS = 100;
+    public static final long DEFAULT_MAX_DELAY_SECONDS = 60;
 
     public Backoff() {
         this(
                 DEFAULT_INITIAL_DELAY_MILLIS,
                 TimeUnit.MILLISECONDS,
                 DEFAULT_MAX_DELAY_SECONDS,
-                TimeUnit.SECONDS,
-                Clock.systemUTC());
+                TimeUnit.SECONDS
+        );
     }
 
     public Backoff(
             long initialDelay,
             TimeUnit unitInitialDelay,
             long maxDelay,
-            TimeUnit unitMaxDelay,
-            Clock clock) {
+            TimeUnit unitMaxDelay) {
         this.initialDelayMillis = unitInitialDelay.toMillis(initialDelay);
         this.maxDelayMillis = unitMaxDelay.toMillis(maxDelay);
-        this.clock = clock;
         this.nextDelayMillis = initialDelayMillis;
     }
 
@@ -62,5 +60,11 @@ public class Backoff {
 
     public void reset() {
         this.nextDelayMillis = initialDelayMillis;
+    }
+
+
+    @Override
+    public long nextBackoffNanos() {
+        return TimeUnit.MILLISECONDS.toNanos(nextDelayMillis());
     }
 }

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
@@ -45,6 +45,7 @@ import io.streamnative.oxia.client.batch.Operation.ReadOperation.GetOperation;
 import io.streamnative.oxia.client.batch.Operation.WriteOperation.DeleteOperation;
 import io.streamnative.oxia.client.batch.Operation.WriteOperation.DeleteRangeOperation;
 import io.streamnative.oxia.client.batch.Operation.WriteOperation.PutOperation;
+import io.streamnative.oxia.client.grpc.OxiaBackoffProvider;
 import io.streamnative.oxia.client.grpc.OxiaStub;
 import io.streamnative.oxia.client.grpc.OxiaStubProvider;
 import io.streamnative.oxia.client.metrics.InstrumentProvider;
@@ -101,7 +102,9 @@ class BatchTest {
                     null,
                     OxiaClientBuilderImpl.DefaultNamespace,
                     authentication,
-                    authentication != null);
+                    authentication != null,
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(30));
 
     private final OxiaClientImplBase serviceImpl =
             mock(
@@ -167,7 +170,7 @@ class BatchTest {
                 new OxiaStub(
                         InProcessChannelBuilder.forName(serverName).directExecutor().build(),
                         "default",
-                        authentication);
+                        authentication, OxiaBackoffProvider.DEFAULT);
         clientByShardId = mock(OxiaStubProvider.class);
         lenient().when(clientByShardId.getStubForShard(anyLong())).thenReturn(stub);
     }
@@ -485,7 +488,9 @@ class BatchTest {
                         null,
                         DefaultNamespace,
                         null,
-                        false);
+                        false,
+                        Duration.ofMillis(100),
+                        Duration.ofSeconds(30));
 
         @Nested
         @DisplayName("Tests of write batch factory")

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
@@ -170,7 +170,8 @@ class BatchTest {
                 new OxiaStub(
                         InProcessChannelBuilder.forName(serverName).directExecutor().build(),
                         "default",
-                        authentication, OxiaBackoffProvider.DEFAULT);
+                        authentication,
+                        OxiaBackoffProvider.DEFAULT);
         clientByShardId = mock(OxiaStubProvider.class);
         lenient().when(clientByShardId.getStubForShard(anyLong())).thenReturn(stub);
     }

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatcherTest.java
@@ -62,7 +62,9 @@ class BatcherTest {
                     null,
                     OxiaClientBuilderImpl.DefaultNamespace,
                     null,
-                    false);
+                    false,
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(30));
 
     BatchedArrayBlockingQueue<Operation<?>> queue;
     Batcher batcher;

--- a/client/src/test/java/io/streamnative/oxia/client/grpc/OxiaStubTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/grpc/OxiaStubTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022-2024 StreamNative Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.oxia.client.grpc;
 
 import io.grpc.stub.StreamObserver;
@@ -5,22 +20,14 @@ import io.streamnative.oxia.proto.GetRequest;
 import io.streamnative.oxia.proto.ReadRequest;
 import io.streamnative.oxia.proto.ReadResponse;
 import io.streamnative.oxia.testcontainers.OxiaContainer;
-import lombok.Cleanup;
-import lombok.SneakyThrows;
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
-import net.bytebuddy.implementation.bytecode.Throw;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.EnumOptions;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 
 @Testcontainers
 @Slf4j
@@ -40,11 +47,9 @@ public class OxiaStubTest {
     public void testOxiaReconnectBackoff(BackoffType type) throws Exception {
         final OxiaStubManager stubManager;
         if (type == BackoffType.Oxia) {
-            stubManager = new OxiaStubManager("default",
-                    null, false, OxiaBackoffProvider.DEFAULT);
+            stubManager = new OxiaStubManager("default", null, false, OxiaBackoffProvider.DEFAULT);
         } else {
-            stubManager = new OxiaStubManager("default",
-                    null, false, null);
+            stubManager = new OxiaStubManager("default", null, false, null);
         }
 
         final OxiaStub stub = stubManager.getStub(oxia.getServiceAddress());
@@ -69,10 +74,9 @@ public class OxiaStubTest {
 
         oxia.start();
 
-
         startTime = System.currentTimeMillis();
         elapse = 10 * 1000;
-        boolean success  = false;
+        boolean success = false;
         while (System.currentTimeMillis() - startTime <= elapse) {
             try {
                 sendMessage(stub).join();
@@ -90,29 +94,31 @@ public class OxiaStubTest {
     }
 
     private static CompletableFuture<Void> sendMessage(OxiaStub stub) {
-        final var readRequest = ReadRequest.newBuilder()
-                .setShardId(0)
-                .addGets(GetRequest.newBuilder()
-                        .setKey("test")
-                        .build())
-                .build();
+        final var readRequest =
+                ReadRequest.newBuilder()
+                        .setShardId(0)
+                        .addGets(GetRequest.newBuilder().setKey("test").build())
+                        .build();
         final CompletableFuture<Void> f = new CompletableFuture<>();
-        stub.async().read(readRequest, new StreamObserver<>() {
-            @Override
-            public void onNext(ReadResponse value) {
-                f.complete(null);
-            }
+        stub.async()
+                .read(
+                        readRequest,
+                        new StreamObserver<>() {
+                            @Override
+                            public void onNext(ReadResponse value) {
+                                f.complete(null);
+                            }
 
-            @Override
-            public void onError(Throwable t) {
-                f.completeExceptionally(t);
-            }
+                            @Override
+                            public void onError(Throwable t) {
+                                f.completeExceptionally(t);
+                            }
 
-            @Override
-            public void onCompleted() {
-                f.complete(null);
-            }
-        });
+                            @Override
+                            public void onCompleted() {
+                                f.complete(null);
+                            }
+                        });
         return f;
     }
 }

--- a/client/src/test/java/io/streamnative/oxia/client/grpc/OxiaStubTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/grpc/OxiaStubTest.java
@@ -1,0 +1,118 @@
+package io.streamnative.oxia.client.grpc;
+
+import io.grpc.stub.StreamObserver;
+import io.streamnative.oxia.proto.GetRequest;
+import io.streamnative.oxia.proto.ReadRequest;
+import io.streamnative.oxia.proto.ReadResponse;
+import io.streamnative.oxia.testcontainers.OxiaContainer;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.implementation.bytecode.Throw;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.EnumOptions;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+@Testcontainers
+@Slf4j
+public class OxiaStubTest {
+    @Container
+    private static final OxiaContainer oxia =
+            new OxiaContainer(OxiaContainer.DEFAULT_IMAGE_NAME, 4, true)
+                    .withLogConsumer(new Slf4jLogConsumer(log));
+
+    public enum BackoffType {
+        GRPC,
+        Oxia,
+    }
+
+    @ParameterizedTest
+    @EnumSource(BackoffType.class)
+    public void testOxiaReconnectBackoff(BackoffType type) throws Exception {
+        final OxiaStubManager stubManager;
+        if (type == BackoffType.Oxia) {
+            stubManager = new OxiaStubManager("default",
+                    null, false, OxiaBackoffProvider.DEFAULT);
+        } else {
+            stubManager = new OxiaStubManager("default",
+                    null, false, null);
+        }
+
+        final OxiaStub stub = stubManager.getStub(oxia.getServiceAddress());
+        sendMessage(stub).join();
+
+        oxia.stop();
+
+        // failed to send messages
+        long startTime = System.currentTimeMillis();
+        long elapse = 30 * 1000;
+        while (System.currentTimeMillis() - startTime <= elapse) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            try {
+                sendMessage(stub).join();
+            } catch (Throwable ignore) {
+            }
+        }
+
+        oxia.start();
+
+
+        startTime = System.currentTimeMillis();
+        elapse = 10 * 1000;
+        boolean success  = false;
+        while (System.currentTimeMillis() - startTime <= elapse) {
+            try {
+                sendMessage(stub).join();
+                success = true;
+            } catch (Throwable ignore) {
+
+            }
+        }
+        if (type == BackoffType.Oxia) {
+            Assertions.assertTrue(success);
+        } else {
+            Assertions.assertFalse(success);
+        }
+        stubManager.close();
+    }
+
+    private static CompletableFuture<Void> sendMessage(OxiaStub stub) {
+        final var readRequest = ReadRequest.newBuilder()
+                .setShardId(0)
+                .addGets(GetRequest.newBuilder()
+                        .setKey("test")
+                        .build())
+                .build();
+        final CompletableFuture<Void> f = new CompletableFuture<>();
+        stub.async().read(readRequest, new StreamObserver<>() {
+            @Override
+            public void onNext(ReadResponse value) {
+                f.complete(null);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                f.completeExceptionally(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                f.complete(null);
+            }
+        });
+        return f;
+    }
+}

--- a/client/src/test/java/io/streamnative/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/session/SessionTest.java
@@ -79,7 +79,9 @@ class SessionTest {
                         null,
                         DefaultNamespace,
                         null,
-                        false);
+                        false,
+                        Duration.ofMillis(100),
+                        Duration.ofSeconds(30));
 
         String serverName = InProcessServerBuilder.generateName();
         service = new TestService();


### PR DESCRIPTION
### Motivation

The GRPC default backoff is from 2s to 120s, which is very long for time sensitive usage.

### Modification

Using reflection to replace the existing backoff here due to that is not configurable.


FYI: https://github.com/grpc/grpc-java/issues/10932#issuecomment-1954913671