### PR TITLE
feat: improve error log when get shards assignments

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/shard/ShardManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/shard/ShardManager.java
@@ -143,7 +143,7 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
                 }
             }
         }
-        log.warn("Failed receiving shard assignments: {}", getRootCause(error).getMessage());
+        log.warn("Failed receiving shard assignments.", getRootCause(error));
         executor.schedule(
                 () -> {
                     if (!closed) {


### PR DESCRIPTION
### Motivation

In the today's testing, we got a not useful log. it's better to improve it.


<img width="1211" alt="image" src="https://github.com/user-attachments/assets/25bdfddb-f1c5-4021-a5ab-5bc6132c3593">


### Modification

- Print the exception when got an error.