### PR TITLE
feat: support thread scope distributed lock

### DIFF
--- a/client-api/src/main/java/io/streamnative/oxia/client/api/LockManager.java
+++ b/client-api/src/main/java/io/streamnative/oxia/client/api/LockManager.java
@@ -24,7 +24,9 @@ public interface LockManager extends Closeable {
      *
      * @param key the key associated with the lock
      * @return an AsyncLock instance for the specified key
+     * @deprecated use {@link LockManager#getSharedLock(String)}
      */
+    @Deprecated
     default AsyncLock getLightWeightLock(String key) {
         return getLightWeightLock(key, OptionBackoff.DEFAULT);
     }
@@ -35,6 +37,58 @@ public interface LockManager extends Closeable {
      * @param key the key associated with the lock
      * @param optionBackoff the backoff options to be used for lock acquisition retries
      * @return an AsyncLock instance for the specified key
+     * @deprecated use {@link LockManager#getSharedLock(String, OptionBackoff)}
      */
-    AsyncLock getLightWeightLock(String key, OptionBackoff optionBackoff);
+    @Deprecated
+    default AsyncLock getLightWeightLock(String key, OptionBackoff optionBackoff) {
+        return getSharedLock(key, optionBackoff);
+    }
+
+    /**
+     * Gets a shared asynchronous lock for the specified key with default backoff options. Note:
+     * "Shared" implies that a single lock key is shared among all threads. If different threads
+     * attempt to acquire a lock that has already been acquired by another thread, a
+     * IllegalLockStatusException from {@link
+     * io.streamnative.oxia.client.api.exceptions.LockException.IllegalLockStatusException} will be
+     * raised.
+     *
+     * @param key the key associated with the lock
+     * @return an AsyncLock instance for the specified key
+     */
+    default AsyncLock getSharedLock(String key) {
+        return getLightWeightLock(key, OptionBackoff.DEFAULT);
+    }
+
+    /**
+     * Gets a shared asynchronous lock for the specified key with custom backoff options. Note:
+     * "Shared" implies that a single lock key is shared among all threads. If different threads
+     * attempt to acquire a lock that has already been acquired by another thread, a
+     * IllegalLockStatusException from {@link
+     * io.streamnative.oxia.client.api.exceptions.LockException.IllegalLockStatusException} will be
+     * raised.
+     *
+     * @param key the key associated with the lock
+     * @param optionBackoff the backoff options to be used for lock acquisition retries
+     * @return an AsyncLock instance for the specified key
+     */
+    AsyncLock getSharedLock(String key, OptionBackoff optionBackoff);
+
+    /**
+     * Gets a thread simple asynchronous lock for the specified key with default backoff options.
+     *
+     * @param key the key associated with the lock
+     * @return an AsyncLock instance for the specified key
+     */
+    default AsyncLock getThreadSimpleLock(String key) {
+        return getThreadSimpleLock(key, OptionBackoff.DEFAULT);
+    }
+
+    /**
+     * Gets a thread simple asynchronous lock for the specified key with custom backoff options.
+     *
+     * @param key the key associated with the lock
+     * @param optionBackoff the backoff options to be used for lock acquisition retries
+     * @return an AsyncLock instance for the specified key
+     */
+    AsyncLock getThreadSimpleLock(String key, OptionBackoff optionBackoff);
 }

--- a/client-it/src/test/resources/simplelogger.properties
+++ b/client-it/src/test/resources/simplelogger.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-org.slf4j.simpleLogger.log.io.streamnative=info
+org.slf4j.simpleLogger.log.io.streamnative=debug

--- a/client-it/src/test/resources/simplelogger.properties
+++ b/client-it/src/test/resources/simplelogger.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-org.slf4j.simpleLogger.log.io.streamnative=debug
+org.slf4j.simpleLogger.log.io.streamnative=info

--- a/client/src/main/java/io/streamnative/oxia/client/lock/NotificationReceiver.java
+++ b/client/src/main/java/io/streamnative/oxia/client/lock/NotificationReceiver.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2022-2024 StreamNative Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.oxia.client.lock;
+
+import io.streamnative.oxia.client.api.Notification;
+
+public interface NotificationReceiver {
+
+    void notifyStateChanged(Notification notification);
+}

--- a/client/src/main/java/io/streamnative/oxia/client/lock/ThreadSimpleLock.java
+++ b/client/src/main/java/io/streamnative/oxia/client/lock/ThreadSimpleLock.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2022-2024 StreamNative Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.oxia.client.lock;
+
+import io.streamnative.oxia.client.api.AsyncLock;
+import io.streamnative.oxia.client.api.AsyncOxiaClient;
+import io.streamnative.oxia.client.api.Notification;
+import io.streamnative.oxia.client.api.OptionAutoRevalidate;
+import io.streamnative.oxia.client.api.exceptions.LockException;
+import io.streamnative.oxia.client.util.Backoff;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+
+final class ThreadSimpleLock implements AsyncLock, NotificationReceiver {
+    private final SharedSimpleLock distributedLock;
+    private final Semaphore memorySemaphore;
+
+    @SafeVarargs
+    public ThreadSimpleLock(
+            AsyncOxiaClient client,
+            String key,
+            ScheduledExecutorService executorService,
+            Backoff backoff,
+            OptionAutoRevalidate optionAutoRevalidate,
+            Class<? extends Throwable>... retryableExceptions) {
+        this.distributedLock =
+                new SharedSimpleLock(
+                        client, key, executorService, backoff, optionAutoRevalidate, retryableExceptions);
+        this.memorySemaphore = new Semaphore(1);
+    }
+
+    @Override
+    public LockStatus getStatus() {
+        return distributedLock.getStatus();
+    }
+
+    @Override
+    public CompletableFuture<Void> lock() {
+        return lock(ForkJoinPool.commonPool());
+    }
+
+    @Override
+    public CompletableFuture<Void> tryLock() {
+        return tryLock(ForkJoinPool.commonPool());
+    }
+
+    @Override
+    public CompletableFuture<Void> unlock() {
+        return unlock(ForkJoinPool.commonPool());
+    }
+
+    @Override
+    public CompletableFuture<Void> lock(ExecutorService executorService) {
+        try {
+            memorySemaphore.acquire();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return CompletableFuture.failedFuture(ex);
+        }
+        return distributedLock
+                .lock(executorService)
+                .whenComplete(
+                        (r, err) -> {
+                            if (err != null) {
+                                // lock distributed lock failed
+                                // rollback the memory lock
+                                memorySemaphore.release();
+                            }
+                        });
+    }
+
+    @Override
+    public CompletableFuture<Void> tryLock(ExecutorService executorService) {
+        if (!memorySemaphore.tryAcquire()) {
+            return CompletableFuture.failedFuture(new LockException.LockBusyException());
+        }
+        return distributedLock
+                .tryLock(executorService)
+                .whenComplete(
+                        (r, err) -> {
+                            if (err != null) {
+                                // distributed lock failed, rollback the memory lock
+                                memorySemaphore.release();
+                            }
+                        });
+    }
+
+    @Override
+    public CompletableFuture<Void> unlock(ExecutorService executorService) {
+        return distributedLock
+                .unlock()
+                .whenComplete(
+                        (r, err) -> {
+                            if (err == null) {
+                                // unlock memory lock only when distributed lock unlocked
+                                memorySemaphore.release();
+                            }
+                        });
+    }
+
+    @Override
+    public void notifyStateChanged(Notification notification) {
+        distributedLock.notifyStateChanged(notification);
+    }
+}


### PR DESCRIPTION
### Motivation

The existing `LightweightLock` will throw `IllegalLockStateException`exception when you invoke `lock` for existing locked lock by other thread. therefore, this PR is introducing a lock that support threads exclusive.

### Modification

- Rename `LightweightLock` to `SharedSimpleLock`
- Add `ThreadSimpleLock` for supporting threads exclusive.
