### PR TITLE
feat(stub): support multiple connection per node

### DIFF
--- a/client-api/src/main/java/io/streamnative/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/streamnative/oxia/client/api/OxiaClientBuilder.java
@@ -55,6 +55,8 @@ public interface OxiaClientBuilder {
 
     OxiaClientBuilder connectionBackoff(Duration minDelay, Duration maxDelay);
 
+    OxiaClientBuilder maxConnectionPerNode(int connections);
+
     /**
      * Configure the authentication plugin and its parameters.
      *

--- a/client-it/src/test/java/io/streamnative/oxia/client/it/NotificationIt.java
+++ b/client-it/src/test/java/io/streamnative/oxia/client/it/NotificationIt.java
@@ -29,6 +29,8 @@ import io.streamnative.oxia.testcontainers.OxiaContainer;
 import java.nio.charset.StandardCharsets;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
+
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
@@ -73,6 +75,7 @@ public class NotificationIt {
 
         client =
                 OxiaClientBuilder.create(oxia.getServiceAddress())
+                        .maxConnectionPerNode(ThreadLocalRandom.current().nextInt(10) + 1)
                         .openTelemetry(openTelemetry)
                         .asyncClient()
                         .join();

--- a/client-it/src/test/java/io/streamnative/oxia/client/it/NotificationIt.java
+++ b/client-it/src/test/java/io/streamnative/oxia/client/it/NotificationIt.java
@@ -30,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
-
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;

--- a/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientFailFastIT.java
+++ b/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientFailFastIT.java
@@ -19,6 +19,8 @@ import io.streamnative.oxia.client.api.OxiaClientBuilder;
 import io.streamnative.oxia.client.shard.NamespaceNotFoundException;
 import io.streamnative.oxia.testcontainers.OxiaContainer;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ThreadLocalRandom;
+
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -41,6 +43,7 @@ public class OxiaClientFailFastIT {
         try {
             OxiaClientBuilder.create(oxia.getServiceAddress())
                     .namespace("my-ns-does-not-exist")
+                    .maxConnectionPerNode(ThreadLocalRandom.current().nextInt(10) + 1)
                     .asyncClient()
                     .join();
             Assertions.fail("Unexpected behaviour!");

--- a/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientFailFastIT.java
+++ b/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientFailFastIT.java
@@ -20,7 +20,6 @@ import io.streamnative.oxia.client.shard.NamespaceNotFoundException;
 import io.streamnative.oxia.testcontainers.OxiaContainer;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientIT.java
+++ b/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientIT.java
@@ -102,6 +102,7 @@ public class OxiaClientIT {
         client =
                 OxiaClientBuilder.create(oxia.getServiceAddress())
                         .openTelemetry(openTelemetry)
+                        .maxConnectionPerNode(10)
                         .asyncClient()
                         .join();
         client.notifications(notifications::add);

--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -79,7 +79,10 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                 OxiaBackoffProvider.create(
                         config.connectionBackoffMinDelay(), config.connectionBackoffMaxDelay());
         var stubManager =
-                new OxiaStubManager(config.authentication(), config.enableTls(), oxiaBackoffProvider,
+                new OxiaStubManager(
+                        config.authentication(),
+                        config.enableTls(),
+                        oxiaBackoffProvider,
                         config.maxConnectionPerNode());
 
         var instrumentProvider = new InstrumentProvider(config.openTelemetry(), config.namespace());
@@ -89,7 +92,8 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         var notificationManager =
                 new NotificationManager(executor, stubManager, shardManager, instrumentProvider);
 
-        OxiaStubProvider stubProvider = new OxiaStubProvider(config.namespace(), stubManager, shardManager);
+        OxiaStubProvider stubProvider =
+                new OxiaStubProvider(config.namespace(), stubManager, shardManager);
 
         shardManager.addCallback(notificationManager);
         var readBatchManager =

--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -79,8 +79,8 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                 OxiaBackoffProvider.create(
                         config.connectionBackoffMinDelay(), config.connectionBackoffMaxDelay());
         var stubManager =
-                new OxiaStubManager(
-                        config.namespace(), config.authentication(), config.enableTls(), oxiaBackoffProvider);
+                new OxiaStubManager(config.authentication(), config.enableTls(), oxiaBackoffProvider,
+                        config.maxConnectionPerNode());
 
         var instrumentProvider = new InstrumentProvider(config.openTelemetry(), config.namespace());
         var serviceAddrStub = stubManager.getStub(config.serviceAddress());
@@ -89,7 +89,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         var notificationManager =
                 new NotificationManager(executor, stubManager, shardManager, instrumentProvider);
 
-        OxiaStubProvider stubProvider = new OxiaStubProvider(stubManager, shardManager);
+        OxiaStubProvider stubProvider = new OxiaStubProvider(config.namespace(), stubManager, shardManager);
 
         shardManager.addCallback(notificationManager);
         var readBatchManager =

--- a/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
@@ -35,5 +35,4 @@ public record ClientConfig(
         boolean enableTls,
         @NonNull Duration connectionBackoffMinDelay,
         @NonNull Duration connectionBackoffMaxDelay,
-        int maxConnectionPerNode
-) {}
+        int maxConnectionPerNode) {}

--- a/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/streamnative/oxia/client/ClientConfig.java
@@ -34,4 +34,6 @@ public record ClientConfig(
         @Nullable Authentication authentication,
         boolean enableTls,
         @NonNull Duration connectionBackoffMinDelay,
-        @NonNull Duration connectionBackoffMaxDelay) {}
+        @NonNull Duration connectionBackoffMaxDelay,
+        int maxConnectionPerNode
+) {}

--- a/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilderImpl.java
@@ -50,7 +50,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     public static final Duration DefaultSessionTimeout = Duration.ofSeconds(15);
     public static final String DefaultNamespace = "default";
     public static final boolean DefaultEnableTls = false;
-    public static final int DefaultMaxConnectionPerNode =1;
+    public static final int DefaultMaxConnectionPerNode = 1;
 
     @NonNull protected final String serviceAddress;
     @NonNull protected Duration requestTimeout = DefaultRequestTimeout;

--- a/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/OxiaClientBuilderImpl.java
@@ -50,6 +50,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     public static final Duration DefaultSessionTimeout = Duration.ofSeconds(15);
     public static final String DefaultNamespace = "default";
     public static final boolean DefaultEnableTls = false;
+    public static final int DefaultMaxConnectionPerNode =1;
 
     @NonNull protected final String serviceAddress;
     @NonNull protected Duration requestTimeout = DefaultRequestTimeout;
@@ -69,6 +70,8 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
 
     @NonNull protected Duration connectionBackoffMinDelay = Duration.ofMillis(100);
     @NonNull protected Duration connectionBackoffMaxDelay = Duration.ofSeconds(30);
+
+    protected int maxConnectionsPerNode = DefaultMaxConnectionPerNode;
 
     @Override
     public @NonNull OxiaClientBuilder requestTimeout(@NonNull Duration requestTimeout) {
@@ -148,6 +151,16 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     public OxiaClientBuilder connectionBackoff(Duration minDelay, Duration maxDelay) {
         this.connectionBackoffMinDelay = minDelay;
         this.connectionBackoffMaxDelay = maxDelay;
+        return this;
+    }
+
+    @Override
+    public OxiaClientBuilder maxConnectionPerNode(int connections) {
+        if (connections <= 0) {
+            throw new IllegalArgumentException(
+                    "maxConnectionPerNode must be greater than zero: " + connections);
+        }
+        this.maxConnectionsPerNode = connections;
         return this;
     }
 
@@ -239,7 +252,8 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                         authentication,
                         enableTls,
                         connectionBackoffMinDelay,
-                        connectionBackoffMaxDelay);
+                        connectionBackoffMaxDelay,
+                        maxConnectionsPerNode);
         return AsyncOxiaClientImpl.newInstance(config);
     }
 

--- a/client/src/main/java/io/streamnative/oxia/client/batch/BatchBase.java
+++ b/client/src/main/java/io/streamnative/oxia/client/batch/BatchBase.java
@@ -17,6 +17,7 @@ package io.streamnative.oxia.client.batch;
 
 import io.streamnative.oxia.client.grpc.OxiaStub;
 import io.streamnative.oxia.client.grpc.OxiaStubProvider;
+import io.streamnative.oxia.client.grpc.WriteStreamWrapper;
 import lombok.Getter;
 import lombok.NonNull;
 
@@ -33,5 +34,9 @@ abstract class BatchBase {
 
     protected OxiaStub getStub() {
         return stubProvider.getStubForShard(shardId);
+    }
+
+    protected WriteStreamWrapper getWriteStream() {
+        return stubProvider.getWriteStreamForShard(shardId);
     }
 }

--- a/client/src/main/java/io/streamnative/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/streamnative/oxia/client/batch/WriteBatch.java
@@ -97,8 +97,7 @@ final class WriteBatch extends BatchBase implements Batch {
     public void send() {
         startSendTimeNanos = System.nanoTime();
         try {
-            getStub()
-                    .writeStream(getShardId())
+            getWriteStream()
                     .send(toProto())
                     .thenAccept(
                             response -> {

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubManager.java
@@ -15,34 +15,44 @@
  */
 package io.streamnative.oxia.client.grpc;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.internal.BackoffPolicy;
+import io.streamnative.oxia.client.ClientConfig;
 import io.streamnative.oxia.client.api.Authentication;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 
 public class OxiaStubManager implements AutoCloseable {
-    private final Map<String, OxiaStub> stubs = new ConcurrentHashMap<>();
+    @VisibleForTesting
+    final Map<Key, OxiaStub> stubs = new ConcurrentHashMap<>();
 
-    private final String namespace;
     @Nullable private final Authentication authentication;
     private final boolean enableTls;
     @Nullable private final BackoffPolicy.Provider backoffProvider;
 
+    private final int maxConnectionPerNode;
+
     public OxiaStubManager(
-            String namespace,
             @Nullable Authentication authentication,
             boolean enableTls,
-            @Nullable BackoffPolicy.Provider backoffProvider) {
-        this.namespace = namespace;
+            @Nullable BackoffPolicy.Provider backoffProvider,
+            int maxConnectionPerNode) {
         this.authentication = authentication;
         this.enableTls = enableTls;
         this.backoffProvider = backoffProvider;
+        this.maxConnectionPerNode = maxConnectionPerNode;
     }
 
     public OxiaStub getStub(String address) {
+        final var random = ThreadLocalRandom.current().nextInt();
+        var modKey = random % maxConnectionPerNode;
+        if (modKey < 0) {
+            modKey += maxConnectionPerNode;
+        }
         return stubs.computeIfAbsent(
-                address, addr -> new OxiaStub(addr, namespace, authentication, enableTls, backoffProvider));
+                new Key(address, modKey), key -> new OxiaStub(key.address, authentication, enableTls, backoffProvider));
     }
 
     @Override
@@ -50,5 +60,8 @@ public class OxiaStubManager implements AutoCloseable {
         for (OxiaStub stub : stubs.values()) {
             stub.close();
         }
+    }
+
+    record Key(String address, int random){
     }
 }

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubManager.java
@@ -17,7 +17,6 @@ package io.streamnative.oxia.client.grpc;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.internal.BackoffPolicy;
-import io.streamnative.oxia.client.ClientConfig;
 import io.streamnative.oxia.client.api.Authentication;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,8 +24,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 
 public class OxiaStubManager implements AutoCloseable {
-    @VisibleForTesting
-    final Map<Key, OxiaStub> stubs = new ConcurrentHashMap<>();
+    @VisibleForTesting final Map<Key, OxiaStub> stubs = new ConcurrentHashMap<>();
 
     @Nullable private final Authentication authentication;
     private final boolean enableTls;
@@ -52,7 +50,8 @@ public class OxiaStubManager implements AutoCloseable {
             modKey += maxConnectionPerNode;
         }
         return stubs.computeIfAbsent(
-                new Key(address, modKey), key -> new OxiaStub(key.address, authentication, enableTls, backoffProvider));
+                new Key(address, modKey),
+                key -> new OxiaStub(key.address, authentication, enableTls, backoffProvider));
     }
 
     @Override
@@ -62,6 +61,5 @@ public class OxiaStubManager implements AutoCloseable {
         }
     }
 
-    record Key(String address, int random){
-    }
+    record Key(String address, int random) {}
 }

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubProvider.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubProvider.java
@@ -19,13 +19,13 @@ import io.streamnative.oxia.client.shard.ShardManager;
 import lombok.Getter;
 
 public class OxiaStubProvider {
-    @Getter
-    private final String namespace;
+    @Getter private final String namespace;
     private final OxiaStubManager stubManager;
     private final ShardManager shardManager;
     private final OxiaWriteStreamManager writeStreamManager;
 
-    public OxiaStubProvider(String namespace, OxiaStubManager stubManager, ShardManager shardManager) {
+    public OxiaStubProvider(
+            String namespace, OxiaStubManager stubManager, ShardManager shardManager) {
         this.namespace = namespace;
         this.stubManager = stubManager;
         this.shardManager = shardManager;

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubProvider.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubProvider.java
@@ -16,19 +16,28 @@
 package io.streamnative.oxia.client.grpc;
 
 import io.streamnative.oxia.client.shard.ShardManager;
+import lombok.Getter;
 
 public class OxiaStubProvider {
-
+    @Getter
+    private final String namespace;
     private final OxiaStubManager stubManager;
     private final ShardManager shardManager;
+    private final OxiaWriteStreamManager writeStreamManager;
 
-    public OxiaStubProvider(OxiaStubManager stubManager, ShardManager shardManager) {
+    public OxiaStubProvider(String namespace, OxiaStubManager stubManager, ShardManager shardManager) {
+        this.namespace = namespace;
         this.stubManager = stubManager;
         this.shardManager = shardManager;
+        this.writeStreamManager = new OxiaWriteStreamManager(this);
     }
 
     public OxiaStub getStubForShard(long shardId) {
         String leader = shardManager.leader(shardId);
         return stubManager.getStub(leader);
+    }
+
+    public WriteStreamWrapper getWriteStreamForShard(long shardId) {
+        return writeStreamManager.writeStream(shardId);
     }
 }

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubProvider.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStubProvider.java
@@ -38,6 +38,6 @@ public class OxiaStubProvider {
     }
 
     public WriteStreamWrapper getWriteStreamForShard(long shardId) {
-        return writeStreamManager.writeStream(shardId);
+        return writeStreamManager.getWriteStream(shardId);
     }
 }

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaWriteStreamManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaWriteStreamManager.java
@@ -24,7 +24,7 @@ public final class OxiaWriteStreamManager {
     private final Map<Long, WriteStreamWrapper> writeStreams = new ConcurrentHashMap<>();
     private final OxiaStubProvider provider;
 
-    OxiaWriteStreamManager(OxiaStubProvider provider) {
+    public OxiaWriteStreamManager(OxiaStubProvider provider) {
         this.provider = provider;
     }
 
@@ -33,7 +33,7 @@ public final class OxiaWriteStreamManager {
     private static final Metadata.Key<String> SHARD_ID_KEY =
             Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
 
-    public WriteStreamWrapper writeStream(long shardId) {
+    public WriteStreamWrapper getWriteStream(long shardId) {
         return writeStreams.compute(
                 shardId,
                 (key, stream) -> {

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaWriteStreamManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaWriteStreamManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022-2024 StreamNative Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.oxia.client.grpc;
 
 import io.grpc.Metadata;
@@ -9,7 +24,6 @@ public final class OxiaWriteStreamManager {
     private final Map<Long, WriteStreamWrapper> writeStreams = new ConcurrentHashMap<>();
     private final OxiaStubProvider provider;
 
-
     OxiaWriteStreamManager(OxiaStubProvider provider) {
         this.provider = provider;
     }
@@ -18,7 +32,6 @@ public final class OxiaWriteStreamManager {
             Metadata.Key.of("namespace", Metadata.ASCII_STRING_MARSHALLER);
     private static final Metadata.Key<String> SHARD_ID_KEY =
             Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
-
 
     public WriteStreamWrapper writeStream(long shardId) {
         return writeStreams.compute(
@@ -29,8 +42,8 @@ public final class OxiaWriteStreamManager {
                         headers.put(NAMESPACE_KEY, provider.getNamespace());
                         headers.put(SHARD_ID_KEY, String.format("%d", shardId));
                         final var asyncStub = provider.getStubForShard(shardId).async();
-                        return new WriteStreamWrapper(asyncStub
-                                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers)));
+                        return new WriteStreamWrapper(
+                                asyncStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers)));
                     }
                     return stream;
                 });

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaWriteStreamManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaWriteStreamManager.java
@@ -1,0 +1,38 @@
+package io.streamnative.oxia.client.grpc;
+
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class OxiaWriteStreamManager {
+    private final Map<Long, WriteStreamWrapper> writeStreams = new ConcurrentHashMap<>();
+    private final OxiaStubProvider provider;
+
+
+    OxiaWriteStreamManager(OxiaStubProvider provider) {
+        this.provider = provider;
+    }
+
+    private static final Metadata.Key<String> NAMESPACE_KEY =
+            Metadata.Key.of("namespace", Metadata.ASCII_STRING_MARSHALLER);
+    private static final Metadata.Key<String> SHARD_ID_KEY =
+            Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
+
+
+    public WriteStreamWrapper writeStream(long shardId) {
+        return writeStreams.compute(
+                shardId,
+                (key, stream) -> {
+                    if (stream == null || !stream.isValid()) {
+                        Metadata headers = new Metadata();
+                        headers.put(NAMESPACE_KEY, provider.getNamespace());
+                        headers.put(SHARD_ID_KEY, String.format("%d", shardId));
+                        final var asyncStub = provider.getStubForShard(shardId).async();
+                        return new WriteStreamWrapper(asyncStub
+                                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers)));
+                    }
+                    return stream;
+                });
+    }
+}

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamKey.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamKey.java
@@ -1,3 +1,0 @@
-package io.streamnative.oxia.client.grpc;
-
-public record WriteStreamKey(long shard, int mod) {}

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamKey.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamKey.java
@@ -1,0 +1,3 @@
+package io.streamnative.oxia.client.grpc;
+
+public record WriteStreamKey(long shard, int mod) {}

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.streamnative.oxia.client.batch;
+package io.streamnative.oxia.client.grpc;
 
 import io.grpc.stub.StreamObserver;
 import io.streamnative.oxia.proto.OxiaClientGrpc;

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
@@ -105,7 +105,8 @@ class BatchTest {
                     authentication,
                     authentication != null,
                     Duration.ofMillis(100),
-                    Duration.ofSeconds(30));
+                    Duration.ofSeconds(30),
+                    1);
 
     private final OxiaClientImplBase serviceImpl =
             mock(
@@ -170,7 +171,6 @@ class BatchTest {
         stub =
                 new OxiaStub(
                         InProcessChannelBuilder.forName(serverName).directExecutor().build(),
-                        "default",
                         authentication,
                         OxiaBackoffProvider.DEFAULT);
         clientByShardId = mock(OxiaStubProvider.class);
@@ -494,7 +494,8 @@ class BatchTest {
                         null,
                         false,
                         Duration.ofMillis(100),
-                        Duration.ofSeconds(30));
+                        Duration.ofSeconds(30),
+                        1);
 
         @Nested
         @DisplayName("Tests of write batch factory")

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatchTest.java
@@ -174,7 +174,9 @@ class BatchTest {
         final WriteStreamWrapper writeStreamWrapper = new WriteStreamWrapper(stub.async());
         clientByShardId = mock(OxiaStubProvider.class);
         lenient().when(clientByShardId.getStubForShard(anyLong())).thenReturn(stub);
-        lenient().when(clientByShardId.getWriteStreamForShard(anyLong())).thenReturn(writeStreamWrapper);
+        lenient()
+                .when(clientByShardId.getWriteStreamForShard(anyLong()))
+                .thenReturn(writeStreamWrapper);
     }
 
     @AfterEach
@@ -328,7 +330,8 @@ class BatchTest {
         @Test
         public void sendFailNoClient() {
             var stubProvider = mock(OxiaStubProvider.class);
-            when(stubProvider.getWriteStreamForShard(anyLong())).thenThrow(new NoShardAvailableException(1));
+            when(stubProvider.getWriteStreamForShard(anyLong()))
+                    .thenThrow(new NoShardAvailableException(1));
 
             batch =
                     new WriteBatch(

--- a/client/src/test/java/io/streamnative/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/batch/BatcherTest.java
@@ -65,7 +65,8 @@ class BatcherTest {
                     null,
                     false,
                     Duration.ofMillis(100),
-                    Duration.ofSeconds(30));
+                    Duration.ofSeconds(30),
+                    1);
 
     BatchedArrayBlockingQueue<Operation<?>> queue;
     Batcher batcher;

--- a/client/src/test/java/io/streamnative/oxia/client/grpc/OxiaStubTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/grpc/OxiaStubTest.java
@@ -21,7 +21,6 @@ import io.streamnative.oxia.proto.ReadRequest;
 import io.streamnative.oxia.proto.ReadResponse;
 import io.streamnative.oxia.testcontainers.OxiaContainer;
 import java.util.concurrent.CompletableFuture;
-
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -129,10 +128,10 @@ public class OxiaStubTest {
     @Test
     @SneakyThrows
     public void testMaxConnectionPerNode() {
-        final var maxConnectionPerNode =10;
+        final var maxConnectionPerNode = 10;
         @Cleanup
-        var stubManager = new OxiaStubManager(null, false,
-                OxiaBackoffProvider.DEFAULT, maxConnectionPerNode);
+        var stubManager =
+                new OxiaStubManager(null, false, OxiaBackoffProvider.DEFAULT, maxConnectionPerNode);
         for (int i = 0; i < 1000; i++) {
             stubManager.getStub(oxia.getServiceAddress());
         }

--- a/client/src/test/java/io/streamnative/oxia/client/notify/NotificationManagerTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/notify/NotificationManagerTest.java
@@ -295,8 +295,8 @@ class NotificationManagerTest {
                             .start();
             channel1 = InProcessChannelBuilder.forName(serverName1).directExecutor().build();
             channel2 = InProcessChannelBuilder.forName(serverName2).directExecutor().build();
-            var stub1 = new OxiaStub(channel1, "default");
-            var stub2 = new OxiaStub(channel2, "default");
+            var stub1 = new OxiaStub(channel1);
+            var stub2 = new OxiaStub(channel2);
             when(stubManager.getStub("leader1")).thenReturn(stub1);
             when(stubManager.getStub("leader2")).thenReturn(stub2);
         }

--- a/client/src/test/java/io/streamnative/oxia/client/notify/ShardNotificationReceiverTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/notify/ShardNotificationReceiverTest.java
@@ -103,9 +103,7 @@ class ShardNotificationReceiverTest {
                         .addService(serviceImpl)
                         .build()
                         .start();
-        stub =
-                new OxiaStub(
-                        InProcessChannelBuilder.forName(serverName).directExecutor().build());
+        stub = new OxiaStub(InProcessChannelBuilder.forName(serverName).directExecutor().build());
     }
 
     @AfterEach

--- a/client/src/test/java/io/streamnative/oxia/client/notify/ShardNotificationReceiverTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/notify/ShardNotificationReceiverTest.java
@@ -105,7 +105,7 @@ class ShardNotificationReceiverTest {
                         .start();
         stub =
                 new OxiaStub(
-                        InProcessChannelBuilder.forName(serverName).directExecutor().build(), "default");
+                        InProcessChannelBuilder.forName(serverName).directExecutor().build());
     }
 
     @AfterEach

--- a/client/src/test/java/io/streamnative/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/session/SessionTest.java
@@ -82,7 +82,7 @@ class SessionTest {
                         false,
                         Duration.ofMillis(100),
                         Duration.ofSeconds(30),
-                1);
+                        1);
 
         String serverName = InProcessServerBuilder.generateName();
         service = new TestService();
@@ -92,8 +92,7 @@ class SessionTest {
                         .addService(service)
                         .build()
                         .start();
-        stub =
-                new OxiaStub(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+        stub = new OxiaStub(InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
         stubProvider = mock(OxiaStubProvider.class);
         lenient().when(stubProvider.getStubForShard(anyLong())).thenReturn(stub);

--- a/client/src/test/java/io/streamnative/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/session/SessionTest.java
@@ -81,7 +81,8 @@ class SessionTest {
                         null,
                         false,
                         Duration.ofMillis(100),
-                        Duration.ofSeconds(30));
+                        Duration.ofSeconds(30),
+                1);
 
         String serverName = InProcessServerBuilder.generateName();
         service = new TestService();
@@ -92,8 +93,7 @@ class SessionTest {
                         .build()
                         .start();
         stub =
-                new OxiaStub(
-                        InProcessChannelBuilder.forName(serverName).directExecutor().build(), "default");
+                new OxiaStub(InProcessChannelBuilder.forName(serverName).directExecutor().build());
 
         stubProvider = mock(OxiaStubProvider.class);
         lenient().when(stubProvider.getStubForShard(anyLong())).thenReturn(stub);

--- a/client/src/test/java/io/streamnative/oxia/client/shard/ShardManagerGrpcTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/shard/ShardManagerGrpcTest.java
@@ -105,8 +105,7 @@ class ShardManagerGrpcTest {
                         .start();
 
         stub =
-                new OxiaStub(
-                        InProcessChannelBuilder.forName(serverName).directExecutor().build(), "default");
+                new OxiaStub(InProcessChannelBuilder.forName(serverName).directExecutor().build());
     }
 
     @AfterEach

--- a/client/src/test/java/io/streamnative/oxia/client/shard/ShardManagerGrpcTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/shard/ShardManagerGrpcTest.java
@@ -104,8 +104,7 @@ class ShardManagerGrpcTest {
                         .build()
                         .start();
 
-        stub =
-                new OxiaStub(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+        stub = new OxiaStub(InProcessChannelBuilder.forName(serverName).directExecutor().build());
     }
 
     @AfterEach


### PR DESCRIPTION
### Motivation

Currently, we are using `directExecutor`(Transport executor) to do the RPC callback. And every node only has a single channel with a single thread. That is easily exhausted. We can use multiple channels for better performance improvement.

### Modification

- support `maxConnectionPerNode` configuration
- extract write stream logic and make it not bind with specific stub.
- set multiple connection per node for some integration tests.