### PR TITLE
feat(stream): fail pending request if server close stream without response

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/batch/ReadBatch.java
+++ b/client/src/main/java/io/streamnative/oxia/client/batch/ReadBatch.java
@@ -24,7 +24,6 @@ import io.streamnative.oxia.proto.ReadResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
-
 import lombok.NonNull;
 
 final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadResponse> {
@@ -86,11 +85,12 @@ final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadRes
     @Override
     public void onCompleted() {
         // complete pending request if the server close stream without any response
-        gets.forEach(g -> {
-            if (!g.callback().isDone()) {
-                g.fail(new CancellationException());
-            }
-        });
+        gets.forEach(
+                g -> {
+                    if (!g.callback().isDone()) {
+                        g.fail(new CancellationException());
+                    }
+                });
         factory.getReadRequestLatencyHistogram().recordSuccess(System.nanoTime() - startSendTimeNanos);
     }
 

--- a/client/src/main/java/io/streamnative/oxia/client/batch/ReadBatch.java
+++ b/client/src/main/java/io/streamnative/oxia/client/batch/ReadBatch.java
@@ -23,6 +23,8 @@ import io.streamnative.oxia.proto.ReadRequest;
 import io.streamnative.oxia.proto.ReadResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
+
 import lombok.NonNull;
 
 final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadResponse> {
@@ -83,6 +85,12 @@ final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadRes
 
     @Override
     public void onCompleted() {
+        // complete pending request if the server close stream without any response
+        gets.forEach(g -> {
+            if (!g.callback().isDone()) {
+                g.fail(new CancellationException());
+            }
+        });
         factory.getReadRequestLatencyHistogram().recordSuccess(System.nanoTime() - startSendTimeNanos);
     }
 

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -67,11 +67,12 @@ public final class WriteStreamWrapper implements StreamObserver<WriteResponse> {
     public void onCompleted() {
         synchronized (WriteStreamWrapper.this) {
             // complete pending request if the server close stream without any response
-            pendingWrites.forEach(f -> {
-                if (!f.isDone()) {
-                    f.completeExceptionally(new CancellationException());
-                }
-            });
+            pendingWrites.forEach(
+                    f -> {
+                        if (!f.isDone()) {
+                            f.completeExceptionally(new CancellationException());
+                        }
+                    });
         }
     }
 


### PR DESCRIPTION
### Motivation

in the GRPC stream, if the server normally closes the stream without a response. the client will have a pending request forever. we can fast fail that request in the case.

