### PR TITLE
Replace javax.annotations with jakarta.annotations

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <caffeine.version>3.1.4</caffeine.version>
         <grpc-test.version>1.2.2</grpc-test.version>
-        <javax.annotation.version>1.3.2</javax.annotation.version>
+        <jakarta.annotation.version>1.3.5</jakarta.annotation.version>
         <zah.version>0.16</zah.version>
     </properties>
 
@@ -69,9 +69,9 @@
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>${javax.annotation.version}</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation.version}</version>
         </dependency>
         <dependency>
             <groupId>net.openhft</groupId>

--- a/pulsar-metadatastore-oxia/pom.xml
+++ b/pulsar-metadatastore-oxia/pom.xml
@@ -67,6 +67,10 @@
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -97,6 +101,10 @@
                 <exclusion>
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
- javax.annotation:javax.annotation-api is deprecated
- replaces javax.annotation:javax.annotation-api with jakarta.annotation:jakarta.annotation-api