### PR TITLE
Add Java 21 build support and enable running of pulsar-metadatastore-oxia tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -92,22 +93,24 @@
         <protobuf.version>3.24.0</protobuf.version>
 
         <assertj.version>3.24.1</assertj.version>
-        <awaitility.version>3.0.0</awaitility.version>
-        <lombok.version>1.18.30</lombok.version>
+        <awaitility.version>4.2.2</awaitility.version>
+        <lombok.version>1.18.32</lombok.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <junit.jupiter.version>5.11.0-M1</junit.jupiter.version>
-        <mockito.junit.jupiter.version>5.11.0</mockito.junit.jupiter.version>
+        <junit.jupiter.version>5.11.3</junit.jupiter.version>
+        <mockito.junit.jupiter.version>5.14.2</mockito.junit.jupiter.version>
         <opentelemetry.version>1.37.0</opentelemetry.version>
-        <testcontainers.version>1.19.7</testcontainers.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
         <guava.version>32.1.3-jre</guava.version>
 
         <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
         <license.plugin.version>4.1</license.plugin.version>
-        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
-        <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
-        <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
+        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+        <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
+        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
+        <maven.shade.plugin.version>3.6.0</maven.shade.plugin.version>
         <spotbugs.plugin.version>4.8.1.0</spotbugs.plugin.version>
         <spotless.plugin.version>2.39.0</spotless.plugin.version>
+        <byte-buddy.version>1.15.10</byte-buddy.version>
     </properties>
 
     <dependencyManagement>
@@ -127,6 +130,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
                 <version>${testcontainers.version}</version>
@@ -137,6 +147,36 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.junit.jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -150,44 +190,27 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>${awaitility.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility-proxy</artifactId>
-            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito.junit.jupiter.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pulsar-metadatastore-oxia/pom.xml
+++ b/pulsar-metadatastore-oxia/pom.xml
@@ -315,6 +315,17 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.2.0</version>
@@ -388,17 +399,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${maven.surefire.plugin.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pulsar-metadatastore-oxia/pom.xml
+++ b/pulsar-metadatastore-oxia/pom.xml
@@ -30,23 +30,17 @@
     <name>Oxia Metadatastore implementation for Apache Pulsar</name>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <shade.relocation.package>io.streamnative.pulsarmetadatastoreoxia.shaded</shade.relocation.package>
 
+        <!-- Breaks for 3.0.5 to 3.0.7 due to missing https://github.com/apache/pulsar/pull/21950 -->
         <pulsar.version>3.0.2</pulsar.version>
 
-        <testng.version>7.7.0</testng.version>
+        <testng.version>7.7.1</testng.version>
         <dropwizard.version>4.1.12.1</dropwizard.version>
         <snappy.version>1.1.10.4</snappy.version>
 
-        <license.plugin.version>4.1</license.plugin.version>
-        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
-        <maven.enforcer.plugin.version>3.1.0</maven.enforcer.plugin.version>
-        <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
         <spotbugs.plugin.version>4.8.1.0</spotbugs.plugin.version>
         <spotless.plugin.version>2.39.0</spotless.plugin.version>
     </properties>
@@ -86,6 +80,12 @@
             <artifactId>buildtools</artifactId>
             <version>${pulsar.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.pulsar</groupId>
@@ -388,6 +388,17 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pulsar-metadatastore-oxia/src/main/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStore.java
+++ b/pulsar-metadatastore-oxia/src/main/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStore.java
@@ -269,10 +269,12 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
 
     @Override
     public void close() throws Exception {
-        if (client != null) {
-            client.close();
+        if (isClosed.compareAndSet(false, true)) {
+            if (client != null) {
+                client.close();
+            }
+            super.close();
         }
-        super.close();
     }
 
     public Optional<MetadataEventSynchronizer> getMetadataEventSynchronizer() {

--- a/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStoreTest.java
+++ b/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStoreTest.java
@@ -71,7 +71,8 @@ public class OxiaMetadataStoreTest extends MetadataStoreTest implements OxiaTest
     @Ignore
     @Test(dataProvider = "conditionOfSwitchThread")
     @Override
-    public void testThreadSwitchOfZkMetadataStore(boolean hasSynchronizer, boolean enabledBatch) throws Exception {
+    public void testThreadSwitchOfZkMetadataStore(boolean hasSynchronizer, boolean enabledBatch)
+            throws Exception {
         super.testThreadSwitchOfZkMetadataStore(hasSynchronizer, enabledBatch);
     }
 }

--- a/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStoreTest.java
+++ b/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/OxiaMetadataStoreTest.java
@@ -67,4 +67,11 @@ public class OxiaMetadataStoreTest extends MetadataStoreTest implements OxiaTest
     @Test(dataProvider = "impl")
     public void testDeleteUnusedDirectories(String provider, Supplier<String> urlSupplier)
             throws Exception {}
+
+    @Ignore
+    @Test(dataProvider = "conditionOfSwitchThread")
+    @Override
+    public void testThreadSwitchOfZkMetadataStore(boolean hasSynchronizer, boolean enabledBatch) throws Exception {
+        super.testThreadSwitchOfZkMetadataStore(hasSynchronizer, enabledBatch);
+    }
 }

--- a/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/bookkeeper/OxiaLedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/bookkeeper/OxiaLedgerUnderreplicationManagerTest.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.metadata.bookkeeper.LedgerUnderreplicationManagerTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Ignore;
 
 /** Test the zookeeper implementation of the ledger replication manager. */
 @Slf4j
@@ -39,5 +40,11 @@ public class OxiaLedgerUnderreplicationManagerTest extends LedgerUnderreplicatio
     @DataProvider(name = "impl")
     public Object[][] implementations() {
         return impl();
+    }
+
+    @Ignore
+    @Override
+    public void testZkMetasStoreMarkReplicatedDeleteEmptyParentNodes() throws Exception {
+
     }
 }

--- a/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/bookkeeper/OxiaLedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/bookkeeper/OxiaLedgerUnderreplicationManagerTest.java
@@ -44,7 +44,5 @@ public class OxiaLedgerUnderreplicationManagerTest extends LedgerUnderreplicatio
 
     @Ignore
     @Override
-    public void testZkMetasStoreMarkReplicatedDeleteEmptyParentNodes() throws Exception {
-
-    }
+    public void testZkMetasStoreMarkReplicatedDeleteEmptyParentNodes() throws Exception {}
 }

--- a/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/bookkeeper/OxiaPulsarRegistrationClientTest.java
+++ b/pulsar-metadatastore-oxia/src/test/java/io/streamnative/pulsarmetadatastoreoxia/bookkeeper/OxiaPulsarRegistrationClientTest.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.metadata.bookkeeper.PulsarRegistrationClientTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Ignore;
 
 @Slf4j
 public class OxiaPulsarRegistrationClientTest extends PulsarRegistrationClientTest
@@ -38,5 +39,11 @@ public class OxiaPulsarRegistrationClientTest extends PulsarRegistrationClientTe
     @DataProvider(name = "impl")
     public Object[][] implementations() {
         return impl();
+    }
+
+    @Ignore
+    @Override
+    public void testNetworkDelayWithBkZkManager() throws Throwable {
+        // ignore
     }
 }


### PR DESCRIPTION
- upgrade test dependencies to support building with Java 21
- cleanup build
- enables running pulsar-metadatastore-oxia tests
  - tests were broken which means that they weren't run
  - fix broken tests
    - `OxiaMetadataStore.close` wasn't implemented properly.
    - At shutdown time further operations wouldn't be aborted with `MetadataStoreException.AlreadyClosedException`.
      - addresses this issue