### PR TITLE
Upgrade OpenTelemetry library to 1.44.1

### DIFF
--- a/client-it/pom.xml
+++ b/client-it/pom.xml
@@ -49,9 +49,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry</groupId>
+            <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
-            <version>1.30.1-alpha</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/client-it/src/test/java/io/streamnative/oxia/client/it/NotificationIt.java
+++ b/client-it/src/test/java/io/streamnative/oxia/client/it/NotificationIt.java
@@ -21,7 +21,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import io.streamnative.oxia.client.api.AsyncOxiaClient;
 import io.streamnative.oxia.client.api.Notification;
 import io.streamnative.oxia.client.api.OxiaClientBuilder;

--- a/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientIT.java
+++ b/client-it/src/test/java/io/streamnative/oxia/client/it/OxiaClientIT.java
@@ -32,7 +32,7 @@ import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import io.streamnative.oxia.client.api.AsyncOxiaClient;
 import io.streamnative.oxia.client.api.DeleteOption;
 import io.streamnative.oxia.client.api.DeleteRangeOption;

--- a/perf-ycsb/pom.xml
+++ b/perf-ycsb/pom.xml
@@ -58,12 +58,10 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
-            <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-prometheus</artifactId>
-            <version>${opentelemetry.version}-alpha</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -72,7 +70,6 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-            <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.streamnative.oxia</groupId>

--- a/perf/pom.xml
+++ b/perf/pom.xml
@@ -50,12 +50,10 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
-            <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-prometheus</artifactId>
-            <version>${opentelemetry.version}-alpha</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -64,7 +62,6 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-            <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>io.streamnative.oxia</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,8 @@
         <slf4j.version>1.7.32</slf4j.version>
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
         <mockito.junit.jupiter.version>5.14.2</mockito.junit.jupiter.version>
-        <opentelemetry.version>1.37.0</opentelemetry.version>
+        <opentelemetry.version>1.44.1</opentelemetry.version>
+        <opentelemetry.semconv.version>1.28.0-alpha</opentelemetry.semconv.version>
         <testcontainers.version>1.20.4</testcontainers.version>
         <guava.version>32.1.3-jre</guava.version>
 
@@ -130,6 +131,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${opentelemetry.version}-alpha</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit.jupiter.version}</version>
@@ -147,6 +155,11 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.semconv</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>${opentelemetry.semconv.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
- upgrade to OTel to 1.44.1
- migrate to use io.opentelemetry.semconv:opentelemetry-semconv since the previous dependency is discontinued
- use dependencyManagement to assign versions