### PR TITLE
feat: avoid lock and add check when complete

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaWriteStreamManager.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaWriteStreamManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2024 StreamNative Inc.
+ * Copyright © 2022-2025 StreamNative Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -123,16 +123,16 @@ public final class WriteStreamWrapper implements StreamObserver<WriteResponse> {
                     Optional.ofNullable(completedException).orElseGet(CancellationException::new));
         }
         final var future = new CompletableFuture<WriteResponse>();
-        if (log.isDebugEnabled()) {
-            log.debug("Sending request {}", request);
-        }
         final long stamp = statusLock.writeLock();
         try {
             if (completed) {
                 return CompletableFuture.failedFuture(
                         Optional.ofNullable(completedException).orElseGet(CancellationException::new));
             }
-            clientStream.onNext(request);
+            if (log.isDebugEnabled()) {
+                log.debug("Sending request {}", request);
+            }
+                clientStream.onNext(request);
             pendingWrites.add(future);
             return future;
         } catch (Exception ex) {

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -93,7 +93,7 @@ public final class WriteStreamWrapper implements StreamObserver<WriteResponse> {
                         pendingWrites.size(),
                         completedException);
             }
-            pendingWrites.forEach(f -> f.completeExceptionally(ex));
+            pendingWrites.forEach(f -> f.completeExceptionally(completedException));
             pendingWrites.clear();
         } finally {
             statusLock.unlockWrite(stamp);

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -41,7 +41,9 @@ public final class WriteStreamWrapper implements StreamObserver<WriteResponse> {
     public WriteStreamWrapper(OxiaClientGrpc.OxiaClientStub stub) {
         this.clientStream = stub.writeStream(this);
         this.pendingWrites = new ArrayDeque<>();
+        this.completed = false;
         this.statusLock = new StampedLock();
+        this.completedException = null;
     }
 
     public boolean isValid() {

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2024 StreamNative Inc.
+ * Copyright © 2022-2025 StreamNative Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.streamnative.oxia.client.grpc;
 
 import io.grpc.stub.StreamObserver;

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -38,7 +38,8 @@ public final class WriteStreamWrapper implements StreamObserver<WriteResponse> {
     public WriteStreamWrapper(OxiaClientGrpc.OxiaClientStub stub) {
         this.clientStream = stub.writeStream(this);
         this.pendingWrites = new ArrayDeque<>();
-
+        this.completed = false;
+        this.completedException = null;
     }
 
     public boolean isValid() {

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -132,7 +132,7 @@ public final class WriteStreamWrapper implements StreamObserver<WriteResponse> {
             if (log.isDebugEnabled()) {
                 log.debug("Sending request {}", request);
             }
-                clientStream.onNext(request);
+            clientStream.onNext(request);
             pendingWrites.add(future);
             return future;
         } catch (Exception ex) {

--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -21,6 +21,7 @@ import io.streamnative.oxia.proto.WriteRequest;
 import io.streamnative.oxia.proto.WriteResponse;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
@@ -88,11 +89,13 @@ public final class WriteStreamWrapper implements StreamObserver<WriteResponse> {
 
     public CompletableFuture<WriteResponse> send(WriteRequest request) {
         if (completed) {
-            return CompletableFuture.failedFuture(completedException);
+            return CompletableFuture.failedFuture(
+                    Optional.ofNullable(completedException).orElseGet(CancellationException::new));
         }
         synchronized (WriteStreamWrapper.this) {
             if (completed) {
-                return CompletableFuture.failedFuture(completedException);
+                return CompletableFuture.failedFuture(
+                        Optional.ofNullable(completedException).orElseGet(CancellationException::new));
             }
             final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
             try {


### PR DESCRIPTION
### Motivation

This PR will improve the logic to avoid unnecessary locks and add a check when the stream is complete.


### Modification

- lock-free first when getting the stream.
- Add check when the stream complete
