### PR TITLE
fix(grpc): disable transparent retry

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStub.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/OxiaStub.java
@@ -65,6 +65,7 @@ public class OxiaStub implements AutoCloseable {
                         .keepAliveTime(clientConfig.connectionKeepAliveTime().toMillis(), MILLISECONDS)
                         .keepAliveTimeout(clientConfig.connectionKeepAliveTimeout().toMillis(), MILLISECONDS)
                         .keepAliveWithoutCalls(true)
+                        .disableRetry()
                         .directExecutor()
                         .build(), clientConfig.authentication(), backoffProvider);
     }


### PR DESCRIPTION
### Motivation

Disable GRPC retry to avoid any data inconsistency since we have the write with the delta feature.


### Modification

- disable GRPC retry.