### PR TITLE
fix: completed status overrided by fail-fast stream

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
+++ b/client/src/main/java/io/streamnative/oxia/client/grpc/WriteStreamWrapper.java
@@ -36,10 +36,10 @@ public final class WriteStreamWrapper implements StreamObserver<WriteResponse> {
     private volatile Throwable completedException;
 
     public WriteStreamWrapper(OxiaClientGrpc.OxiaClientStub stub) {
-        this.clientStream = stub.writeStream(this);
         this.pendingWrites = new ArrayDeque<>();
         this.completed = false;
         this.completedException = null;
+        this.clientStream = stub.writeStream(this);
     }
 
     public boolean isValid() {


### PR DESCRIPTION
### Motivation

The internal `completed` status might overridden by the fail-fast stream. We should always make the `stub.writeStream(this)` at the end of the init logic. 


### Modification

- Move the `stub.writeStream(this);` at the end of the init logic.