### PR TITLE
fix: range scan more than one onError callback

### DIFF
--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -784,21 +784,21 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             RangeScanConsumer consumer) {
         final Set<Long> shardIds = shardManager.allShardIds();
         final RangeScanConsumer multiShardConsumer =
-                new ShardingRangeScanConsumer(shardIds.size(), consumer);
+                new SharedRangeScanConsumer(shardIds.size(), consumer);
         for (long shardId : shardIds) {
             internalShardRangeScan(
                     shardId, startKeyInclusive, endKeyExclusive, secondaryIndexName, multiShardConsumer);
         }
     }
 
-    static class ShardingRangeScanConsumer implements RangeScanConsumer {
+    static class SharedRangeScanConsumer implements RangeScanConsumer {
         private final RangeScanConsumer delegate;
 
         private int pendingCompletedRequests;
         private boolean completed = false;
         private Throwable completedException = null;
 
-        ShardingRangeScanConsumer(int shards, RangeScanConsumer delegate) {
+        SharedRangeScanConsumer(int shards, RangeScanConsumer delegate) {
             this.pendingCompletedRequests = shards;
             this.delegate = delegate;
         }

--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -784,21 +784,21 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             RangeScanConsumer consumer) {
         final Set<Long> shardIds = shardManager.allShardIds();
         final RangeScanConsumer multiShardConsumer =
-                new ShardRangeScanConsumer(shardIds.size(), consumer);
+                new ShardingRangeScanConsumer(shardIds.size(), consumer);
         for (long shardId : shardIds) {
             internalShardRangeScan(
                     shardId, startKeyInclusive, endKeyExclusive, secondaryIndexName, multiShardConsumer);
         }
     }
 
-    static class ShardRangeScanConsumer implements RangeScanConsumer {
+    static class ShardingRangeScanConsumer implements RangeScanConsumer {
         private final RangeScanConsumer delegate;
 
         private int pendingCompletedRequests;
         private boolean completed = false;
         private Throwable completedException = null;
 
-        ShardRangeScanConsumer(int shards, RangeScanConsumer delegate) {
+        ShardingRangeScanConsumer(int shards, RangeScanConsumer delegate) {
             this.pendingCompletedRequests = shards;
             this.delegate = delegate;
         }

--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -751,10 +751,6 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                 .rangeScan(
                         request,
                         new StreamObserver<>() {
-                            // using those two fields to help debug with heap dump
-                            private boolean completed = false;
-                            private Throwable completedException = null;
-
                             @Override
                             public void onNext(RangeScanResponse response) {
                                 for (int i = 0; i < response.getRecordsCount(); i++) {
@@ -764,14 +760,11 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
 
                             @Override
                             public void onError(Throwable t) {
-                                completed = true;
-                                completedException = t;
                                 consumer.onError(t);
                             }
 
                             @Override
                             public void onCompleted() {
-                                completed = true;
                                 consumer.onCompleted();
                             }
                         });

--- a/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/streamnative/oxia/client/AsyncOxiaClientImpl.java
@@ -783,7 +783,8 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             Optional<String> secondaryIndexName,
             RangeScanConsumer consumer) {
         final Set<Long> shardIds = shardManager.allShardIds();
-        final RangeScanConsumer multiShardConsumer = new ShardRangeScanConsumer(shardIds.size(), consumer);
+        final RangeScanConsumer multiShardConsumer =
+                new ShardRangeScanConsumer(shardIds.size(), consumer);
         for (long shardId : shardIds) {
             internalShardRangeScan(
                     shardId, startKeyInclusive, endKeyExclusive, secondaryIndexName, multiShardConsumer);
@@ -792,7 +793,6 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
 
     static class ShardRangeScanConsumer implements RangeScanConsumer {
         private final RangeScanConsumer delegate;
-
 
         private int pendingCompletedRequests;
         private boolean completed = false;
@@ -836,7 +836,6 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                 delegate.onCompleted();
             }
         }
-
     }
 
     @Override

--- a/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
@@ -32,6 +32,7 @@ import io.grpc.stub.StreamObserver;
 import io.streamnative.oxia.client.api.DeleteOption;
 import io.streamnative.oxia.client.api.GetResult;
 import io.streamnative.oxia.client.api.PutResult;
+import io.streamnative.oxia.client.api.RangeScanConsumer;
 import io.streamnative.oxia.client.api.Version;
 import io.streamnative.oxia.client.batch.BatchManager;
 import io.streamnative.oxia.client.batch.Batcher;
@@ -49,10 +50,18 @@ import io.streamnative.oxia.proto.ListRequest;
 import io.streamnative.oxia.proto.ListResponse;
 import io.streamnative.oxia.proto.OxiaClientGrpc;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -565,5 +574,101 @@ class AsyncOxiaClientImplTest {
         inOrder.verify(shardManager).close();
         inOrder.verify(stubManager).close();
         client = null;
+    }
+
+
+    @Test
+    void testShardShardRangeScanConsumer() {
+        final int shards = 5;
+        final List<GetResult> results = new ArrayList<>();
+        final AtomicInteger onErrorCount = new AtomicInteger(0);
+        final AtomicInteger onCompletedCount = new AtomicInteger(0);
+        final Supplier<RangeScanConsumer> newShardRangeScanConsumer = () -> new AsyncOxiaClientImpl.ShardRangeScanConsumer(5, new RangeScanConsumer() {
+            @Override
+            public void onNext(GetResult result) {
+                results.add(result);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                onErrorCount.incrementAndGet();
+            }
+
+            @Override
+            public void onCompleted() {
+                onCompletedCount.incrementAndGet();
+            }
+        });
+        final var tasks = new ArrayList<ForkJoinTask<?>>();
+
+        // (1) complete ok
+        final var shardRangeScanConsumer1 = newShardRangeScanConsumer.get();
+        for (int i = 0; i < shards; i++) {
+            final int fi = i;
+            final ForkJoinTask<?> task = ForkJoinPool.commonPool().submit(() -> {
+                shardRangeScanConsumer1.onNext(new GetResult("shard-" + fi + "-0",
+                        new byte[10],
+                        new Version(1, 2, 3, 4, empty(), empty())));
+                shardRangeScanConsumer1.onNext(new GetResult("shard-" + fi + "-1",
+                        new byte[10],
+                        new Version(1, 2, 3, 4, empty(), empty())));
+                shardRangeScanConsumer1.onCompleted();
+            });
+            tasks.add(task);
+        }
+        tasks.forEach(ForkJoinTask::join);
+        var keys = results.stream().map(GetResult::getKey).toList();
+        for (int i = 0; i < shards; i++) {
+            Assertions.assertTrue(keys.contains("shard-" + i + "-0"));
+            Assertions.assertTrue(keys.contains("shard-" + i + "-1"));
+        }
+        Assertions.assertEquals(0, onErrorCount.get());
+        Assertions.assertEquals(1, onCompletedCount.get());
+
+        tasks.clear();
+        onErrorCount.set(0);
+        onCompletedCount.set(0);
+        results.clear();
+
+
+        // (2) complete partial exception
+        final var shardRangeScanConsumer2 = newShardRangeScanConsumer.get();
+        for (int i = 0; i < shards; i++) {
+            final int fi = i;
+            final ForkJoinTask<?> task = ForkJoinPool.commonPool().submit(() -> {
+                if (fi %2 == 0) {
+                    shardRangeScanConsumer2.onError(new IllegalStateException());
+                    return;
+                }
+                shardRangeScanConsumer2.onNext(new GetResult("shard-" + fi + "-0",
+                        new byte[10],
+                        new Version(1, 2, 3, 4, empty(), empty())));
+                shardRangeScanConsumer2.onNext(new GetResult("shard-" + fi + "-1",
+                        new byte[10],
+                        new Version(1, 2, 3, 4, empty(), empty())));
+                shardRangeScanConsumer2.onCompleted();
+            });
+            tasks.add(task);
+        }
+        tasks.forEach(ForkJoinTask::join);
+
+        Assertions.assertEquals(1, onErrorCount.get());
+        Assertions.assertEquals(0, onCompletedCount.get());
+
+        tasks.clear();
+        onErrorCount.set(0);
+        onCompletedCount.set(0);
+        results.clear();
+
+        // (3) complete all exception
+        final var shardRangeScanConsumer3 = newShardRangeScanConsumer.get();
+        for (int i = 0; i < shards; i++) {
+            final ForkJoinTask<?> task = ForkJoinPool.commonPool().submit(() -> shardRangeScanConsumer3.onError(new IllegalStateException()));
+            tasks.add(task);
+        }
+        tasks.forEach(ForkJoinTask::join);
+        Assertions.assertEquals(1, onErrorCount.get());
+        Assertions.assertEquals(0, onCompletedCount.get());
+        Assertions.assertEquals(0, results.size());
     }
 }

--- a/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
@@ -584,7 +584,7 @@ class AsyncOxiaClientImplTest {
         final AtomicInteger onCompletedCount = new AtomicInteger(0);
         final Supplier<RangeScanConsumer> newShardRangeScanConsumer =
                 () ->
-                        new AsyncOxiaClientImpl.ShardRangeScanConsumer(
+                        new AsyncOxiaClientImpl.ShardingRangeScanConsumer(
                                 5,
                                 new RangeScanConsumer() {
                                     @Override

--- a/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
@@ -576,44 +576,54 @@ class AsyncOxiaClientImplTest {
         client = null;
     }
 
-
     @Test
     void testShardShardRangeScanConsumer() {
         final int shards = 5;
         final List<GetResult> results = new ArrayList<>();
         final AtomicInteger onErrorCount = new AtomicInteger(0);
         final AtomicInteger onCompletedCount = new AtomicInteger(0);
-        final Supplier<RangeScanConsumer> newShardRangeScanConsumer = () -> new AsyncOxiaClientImpl.ShardRangeScanConsumer(5, new RangeScanConsumer() {
-            @Override
-            public void onNext(GetResult result) {
-                results.add(result);
-            }
+        final Supplier<RangeScanConsumer> newShardRangeScanConsumer =
+                () ->
+                        new AsyncOxiaClientImpl.ShardRangeScanConsumer(
+                                5,
+                                new RangeScanConsumer() {
+                                    @Override
+                                    public void onNext(GetResult result) {
+                                        results.add(result);
+                                    }
 
-            @Override
-            public void onError(Throwable throwable) {
-                onErrorCount.incrementAndGet();
-            }
+                                    @Override
+                                    public void onError(Throwable throwable) {
+                                        onErrorCount.incrementAndGet();
+                                    }
 
-            @Override
-            public void onCompleted() {
-                onCompletedCount.incrementAndGet();
-            }
-        });
+                                    @Override
+                                    public void onCompleted() {
+                                        onCompletedCount.incrementAndGet();
+                                    }
+                                });
         final var tasks = new ArrayList<ForkJoinTask<?>>();
 
         // (1) complete ok
         final var shardRangeScanConsumer1 = newShardRangeScanConsumer.get();
         for (int i = 0; i < shards; i++) {
             final int fi = i;
-            final ForkJoinTask<?> task = ForkJoinPool.commonPool().submit(() -> {
-                shardRangeScanConsumer1.onNext(new GetResult("shard-" + fi + "-0",
-                        new byte[10],
-                        new Version(1, 2, 3, 4, empty(), empty())));
-                shardRangeScanConsumer1.onNext(new GetResult("shard-" + fi + "-1",
-                        new byte[10],
-                        new Version(1, 2, 3, 4, empty(), empty())));
-                shardRangeScanConsumer1.onCompleted();
-            });
+            final ForkJoinTask<?> task =
+                    ForkJoinPool.commonPool()
+                            .submit(
+                                    () -> {
+                                        shardRangeScanConsumer1.onNext(
+                                                new GetResult(
+                                                        "shard-" + fi + "-0",
+                                                        new byte[10],
+                                                        new Version(1, 2, 3, 4, empty(), empty())));
+                                        shardRangeScanConsumer1.onNext(
+                                                new GetResult(
+                                                        "shard-" + fi + "-1",
+                                                        new byte[10],
+                                                        new Version(1, 2, 3, 4, empty(), empty())));
+                                        shardRangeScanConsumer1.onCompleted();
+                                    });
             tasks.add(task);
         }
         tasks.forEach(ForkJoinTask::join);
@@ -630,24 +640,30 @@ class AsyncOxiaClientImplTest {
         onCompletedCount.set(0);
         results.clear();
 
-
         // (2) complete partial exception
         final var shardRangeScanConsumer2 = newShardRangeScanConsumer.get();
         for (int i = 0; i < shards; i++) {
             final int fi = i;
-            final ForkJoinTask<?> task = ForkJoinPool.commonPool().submit(() -> {
-                if (fi %2 == 0) {
-                    shardRangeScanConsumer2.onError(new IllegalStateException());
-                    return;
-                }
-                shardRangeScanConsumer2.onNext(new GetResult("shard-" + fi + "-0",
-                        new byte[10],
-                        new Version(1, 2, 3, 4, empty(), empty())));
-                shardRangeScanConsumer2.onNext(new GetResult("shard-" + fi + "-1",
-                        new byte[10],
-                        new Version(1, 2, 3, 4, empty(), empty())));
-                shardRangeScanConsumer2.onCompleted();
-            });
+            final ForkJoinTask<?> task =
+                    ForkJoinPool.commonPool()
+                            .submit(
+                                    () -> {
+                                        if (fi % 2 == 0) {
+                                            shardRangeScanConsumer2.onError(new IllegalStateException());
+                                            return;
+                                        }
+                                        shardRangeScanConsumer2.onNext(
+                                                new GetResult(
+                                                        "shard-" + fi + "-0",
+                                                        new byte[10],
+                                                        new Version(1, 2, 3, 4, empty(), empty())));
+                                        shardRangeScanConsumer2.onNext(
+                                                new GetResult(
+                                                        "shard-" + fi + "-1",
+                                                        new byte[10],
+                                                        new Version(1, 2, 3, 4, empty(), empty())));
+                                        shardRangeScanConsumer2.onCompleted();
+                                    });
             tasks.add(task);
         }
         tasks.forEach(ForkJoinTask::join);
@@ -663,7 +679,9 @@ class AsyncOxiaClientImplTest {
         // (3) complete all exception
         final var shardRangeScanConsumer3 = newShardRangeScanConsumer.get();
         for (int i = 0; i < shards; i++) {
-            final ForkJoinTask<?> task = ForkJoinPool.commonPool().submit(() -> shardRangeScanConsumer3.onError(new IllegalStateException()));
+            final ForkJoinTask<?> task =
+                    ForkJoinPool.commonPool()
+                            .submit(() -> shardRangeScanConsumer3.onError(new IllegalStateException()));
             tasks.add(task);
         }
         tasks.forEach(ForkJoinTask::join);

--- a/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/streamnative/oxia/client/AsyncOxiaClientImplTest.java
@@ -584,7 +584,7 @@ class AsyncOxiaClientImplTest {
         final AtomicInteger onCompletedCount = new AtomicInteger(0);
         final Supplier<RangeScanConsumer> newShardRangeScanConsumer =
                 () ->
-                        new AsyncOxiaClientImpl.ShardingRangeScanConsumer(
+                        new AsyncOxiaClientImpl.SharedRangeScanConsumer(
                                 5,
                                 new RangeScanConsumer() {
                                     @Override


### PR DESCRIPTION
### Motivation

Fix more than one `onError` callback from `rangeScan` interface. You can check [example.ranscan.callback](https://github.com/streamnative/oxia-java/tree/example.ranscan.callback) for reproduce.


### Modification

- Be sure to call only once between `onCompleted` and `onError`.
- Reduce the code complexity.