### PR TITLE
Add request retry with leader hint support for batch operations

### DIFF
--- a/client/src/main/java/io/oxia/client/batch/BatchBase.java
+++ b/client/src/main/java/io/oxia/client/batch/BatchBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.oxia.client.batch;
 import io.oxia.client.grpc.OxiaStub;
 import io.oxia.client.grpc.OxiaStubProvider;
 import io.oxia.client.grpc.WriteStreamWrapper;
+import io.oxia.proto.LeaderHint;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.NonNull;
 
@@ -36,7 +38,15 @@ abstract class BatchBase {
         return stubProvider.getStubForShard(shardId);
     }
 
+    protected OxiaStub getStub(@Nullable LeaderHint leaderHint) {
+        return stubProvider.getStubForShard(shardId, leaderHint);
+    }
+
     protected WriteStreamWrapper getWriteStream() {
         return stubProvider.getWriteStreamForShard(shardId);
+    }
+
+    protected WriteStreamWrapper getWriteStream(@Nullable LeaderHint leaderHint) {
+        return stubProvider.getWriteStreamForShard(shardId, leaderHint);
     }
 }

--- a/client/src/main/java/io/oxia/client/batch/ReadBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,27 +17,40 @@ package io.oxia.client.batch;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.stub.StreamObserver;
+import io.oxia.client.grpc.GrpcErrors;
 import io.oxia.client.grpc.OxiaStubProvider;
-import io.oxia.proto.GetResponse;
+import io.oxia.client.util.Backoff;
+import io.oxia.proto.LeaderHint;
 import io.oxia.proto.ReadRequest;
 import io.oxia.proto.ReadResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
-final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadResponse> {
+@Slf4j
+final class ReadBatch extends BatchBase implements Batch {
 
     private final ReadBatchFactory factory;
 
     @VisibleForTesting final List<Operation.ReadOperation.GetOperation> gets = new ArrayList<>();
 
-    private int responseIndex = 0;
+    private final Duration requestTimeout;
     long startSendTimeNanos;
 
-    ReadBatch(ReadBatchFactory factory, OxiaStubProvider stubProvider, long shardId) {
+    ReadBatch(
+            ReadBatchFactory factory,
+            OxiaStubProvider stubProvider,
+            long shardId,
+            Duration requestTimeout) {
         super(stubProvider, shardId);
         this.factory = factory;
+        this.requestTimeout = requestTimeout;
     }
 
     @Override
@@ -59,39 +72,108 @@ final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadRes
     @Override
     public void send() {
         startSendTimeNanos = System.nanoTime();
+        ReadRequest request = toProto();
+
         try {
-            getStub().async().read(toProto(), this);
+            ReadResponse response = doRequestWithRetries(request);
+            factory
+                    .getReadRequestLatencyHistogram()
+                    .recordSuccess(System.nanoTime() - startSendTimeNanos);
+            handle(response);
         } catch (Throwable t) {
             onError(t);
         }
     }
 
-    @Override
-    public void onNext(ReadResponse response) {
-        for (int i = 0; i < response.getGetsCount(); i++) {
-            GetResponse gr = response.getGets(i);
-            gets.get(responseIndex).complete(gr);
+    ReadResponse doRequestWithRetries(ReadRequest request) throws Exception {
+        long deadlineNanos = System.nanoTime() + requestTimeout.toNanos();
+        Backoff backoff = new Backoff();
+        LeaderHint hint = null;
 
-            ++responseIndex;
+        while (true) {
+            try {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    throw new TimeoutException("Request timed out after " + requestTimeout);
+                }
+                return doRequest(request, hint, remainingNanos);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (!GrpcErrors.isRetriable(cause)) {
+                    throw e;
+                }
+                LeaderHint leaderHint = GrpcErrors.findLeaderHint(cause);
+                if (leaderHint != null) {
+                    hint = leaderHint;
+                }
+
+                long delayMillis = backoff.nextDelayMillis();
+                long remainingMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                if (remainingMillis <= 0) {
+                    throw e;
+                }
+
+                log.warn(
+                        "Failed to perform read request, retrying later. shard={} retry-after={}ms error={}",
+                        getShardId(),
+                        Math.min(delayMillis, remainingMillis),
+                        cause.getMessage());
+
+                Thread.sleep(Math.min(delayMillis, remainingMillis));
+            } catch (TimeoutException e) {
+                throw e;
+            }
         }
     }
 
-    @Override
-    public void onError(Throwable batchError) {
-        gets.forEach(g -> g.fail(batchError));
+    private ReadResponse doRequest(ReadRequest request, LeaderHint hint, long remainingNanos)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        CompletableFuture<ReadResponse> future = new CompletableFuture<>();
+        ReadResponse accumulated = ReadResponse.newBuilder().build();
+
+        getStub(hint)
+                .async()
+                .read(
+                        request,
+                        new StreamObserver<>() {
+                            private ReadResponse.Builder builder = ReadResponse.newBuilder();
+
+                            @Override
+                            public void onNext(ReadResponse response) {
+                                builder.addAllGets(response.getGetsList());
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                future.completeExceptionally(t);
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                future.complete(builder.build());
+                            }
+                        });
+
+        return future.get(remainingNanos, TimeUnit.NANOSECONDS);
+    }
+
+    void onError(Throwable batchError) {
+        Throwable error = unwrap(batchError);
+        gets.forEach(g -> g.fail(error));
         factory.getReadRequestLatencyHistogram().recordFailure(System.nanoTime() - startSendTimeNanos);
     }
 
-    @Override
-    public void onCompleted() {
-        // complete pending request if the server close stream without any response
-        gets.forEach(
-                g -> {
-                    if (!g.callback().isDone()) {
-                        g.fail(new CancellationException());
-                    }
-                });
-        factory.getReadRequestLatencyHistogram().recordSuccess(System.nanoTime() - startSendTimeNanos);
+    private static Throwable unwrap(Throwable t) {
+        if (t instanceof ExecutionException && t.getCause() != null) {
+            return t.getCause();
+        }
+        return t;
+    }
+
+    private void handle(ReadResponse response) {
+        for (int i = 0; i < gets.size(); i++) {
+            gets.get(i).complete(response.getGets(i));
+        }
     }
 
     @NonNull

--- a/client/src/main/java/io/oxia/client/batch/ReadBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,6 @@ class ReadBatchFactory extends BatchFactory {
 
     @Override
     public Batch getBatch(long shardId) {
-        return new ReadBatch(this, stubProvider, shardId);
+        return new ReadBatch(this, stubProvider, shardId, getConfig().requestTimeout());
     }
 }

--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,23 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.oxia.client.grpc.GrpcErrors;
 import io.oxia.client.grpc.OxiaStubProvider;
 import io.oxia.client.session.SessionManager;
+import io.oxia.client.util.Backoff;
+import io.oxia.proto.LeaderHint;
 import io.oxia.proto.WriteRequest;
+import io.oxia.proto.WriteResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 final class WriteBatch extends BatchBase implements Batch {
 
     private final WriteBatchFactory factory;
@@ -40,6 +50,7 @@ final class WriteBatch extends BatchBase implements Batch {
 
     private final SessionManager sessionManager;
     private final int maxBatchSize;
+    private final Duration requestTimeout;
     private int byteSize;
     private long bytes;
     private long startSendTimeNanos;
@@ -49,12 +60,14 @@ final class WriteBatch extends BatchBase implements Batch {
             @NonNull OxiaStubProvider stubProvider,
             @NonNull SessionManager sessionManager,
             long shardId,
-            int maxBatchSize) {
+            int maxBatchSize,
+            @NonNull Duration requestTimeout) {
         super(stubProvider, shardId);
         this.factory = factory;
         this.sessionManager = sessionManager;
         this.byteSize = 0;
         this.maxBatchSize = maxBatchSize;
+        this.requestTimeout = requestTimeout;
     }
 
     int sizeOf(@NonNull Operation<?> operation) {
@@ -95,39 +108,80 @@ final class WriteBatch extends BatchBase implements Batch {
     @Override
     public void send() {
         startSendTimeNanos = System.nanoTime();
-        try {
-            getWriteStream()
-                    .send(toProto())
-                    .thenAccept(
-                            response -> {
-                                factory.writeRequestLatencyHistogram.recordSuccess(
-                                        System.nanoTime() - startSendTimeNanos);
+        WriteRequest request = toProto();
 
-                                for (var i = 0; i < deletes.size(); i++) {
-                                    deletes.get(i).complete(response.getDeletes(i));
-                                }
-                                for (var i = 0; i < deleteRanges.size(); i++) {
-                                    deleteRanges.get(i).complete(response.getDeleteRanges(i));
-                                }
-                                for (var i = 0; i < puts.size(); i++) {
-                                    puts.get(i).complete(response.getPuts(i));
-                                }
-                            })
-                    .exceptionally(
-                            ex -> {
-                                handleError(ex);
-                                return null;
-                            });
+        try {
+            WriteResponse response = doRequestWithRetries(request);
+            factory.writeRequestLatencyHistogram.recordSuccess(System.nanoTime() - startSendTimeNanos);
+
+            for (var i = 0; i < deletes.size(); i++) {
+                deletes.get(i).complete(response.getDeletes(i));
+            }
+            for (var i = 0; i < deleteRanges.size(); i++) {
+                deleteRanges.get(i).complete(response.getDeleteRanges(i));
+            }
+            for (var i = 0; i < puts.size(); i++) {
+                puts.get(i).complete(response.getPuts(i));
+            }
         } catch (Throwable t) {
             handleError(t);
         }
     }
 
+    WriteResponse doRequestWithRetries(WriteRequest request) throws Exception {
+        long deadlineNanos = System.nanoTime() + requestTimeout.toNanos();
+        Backoff backoff = new Backoff();
+        LeaderHint hint = null;
+
+        while (true) {
+            try {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    throw new TimeoutException("Request timed out after " + requestTimeout);
+                }
+                return getWriteStream(hint).send(request).get(remainingNanos, TimeUnit.NANOSECONDS);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (!GrpcErrors.isRetriable(cause)) {
+                    throw e;
+                }
+                LeaderHint leaderHint = GrpcErrors.findLeaderHint(cause);
+                if (leaderHint != null) {
+                    hint = leaderHint;
+                }
+
+                long delayMillis = backoff.nextDelayMillis();
+                long remainingMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                if (remainingMillis <= 0) {
+                    throw e;
+                }
+
+                log.warn(
+                        "Failed to perform write request, retrying later. shard={} retry-after={}ms error={}",
+                        getShardId(),
+                        Math.min(delayMillis, remainingMillis),
+                        cause.getMessage());
+
+                Thread.sleep(Math.min(delayMillis, remainingMillis));
+            } catch (TimeoutException e) {
+                throw e;
+            }
+        }
+    }
+
     public void handleError(Throwable batchError) {
         factory.writeRequestLatencyHistogram.recordFailure(System.nanoTime() - startSendTimeNanos);
-        deletes.forEach(d -> d.fail(batchError));
-        deleteRanges.forEach(f -> f.fail(batchError));
-        puts.forEach(p -> p.fail(batchError));
+        Throwable error = unwrap(batchError);
+        deletes.forEach(d -> d.fail(error));
+        deleteRanges.forEach(f -> f.fail(error));
+        puts.forEach(p -> p.fail(error));
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        if (t instanceof ExecutionException && t.getCause() != null) {
+            return t.getCause();
+        }
+        return t;
     }
 
     @NonNull

--- a/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,12 @@ class WriteBatchFactory extends BatchFactory {
 
     @Override
     public Batch getBatch(long shardId) {
-        return new WriteBatch(this, stubProvider, sessionManager, shardId, getConfig().maxBatchSize());
+        return new WriteBatch(
+                this,
+                stubProvider,
+                sessionManager,
+                shardId,
+                getConfig().maxBatchSize(),
+                getConfig().requestTimeout());
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/GrpcErrors.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcErrors.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2022-2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
+import io.oxia.proto.LeaderHint;
+import javax.annotation.Nullable;
+
+public final class GrpcErrors {
+
+    // Custom Oxia gRPC status codes (must match the Go server definitions)
+    public static final int CODE_INVALID_STATUS = 102;
+    public static final int CODE_ALREADY_CLOSED = 104;
+    public static final int CODE_NODE_IS_NOT_LEADER = 106;
+
+    private static final Metadata.Key<com.google.rpc.Status> STATUS_DETAILS_KEY =
+            Metadata.Key.of(
+                    "grpc-status-details-bin",
+                    ProtoUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance()));
+
+    private GrpcErrors() {}
+
+    public static boolean isRetriable(@Nullable Throwable err) {
+        if (err == null) {
+            return false;
+        }
+
+        Status status = statusFromThrowable(err);
+        if (status == null) {
+            return false;
+        }
+
+        // Standard gRPC UNAVAILABLE: connection failure, ok to re-attempt
+        if (status.getCode() == Status.Code.UNAVAILABLE) {
+            return true;
+        }
+
+        // Custom Oxia codes are transmitted in the grpc-status-details-bin trailer.
+        int rawCode = rawCodeFromThrowable(err);
+        return switch (rawCode) {
+            case CODE_INVALID_STATUS, // Leader fenced the shard; new leader expected
+                    CODE_ALREADY_CLOSED, // Leader closing; new leader expected
+                    CODE_NODE_IS_NOT_LEADER -> // Request sent to non-leader; retry to new leader
+                    true;
+            default -> false;
+        };
+    }
+
+    @Nullable
+    public static LeaderHint findLeaderHint(@Nullable Throwable err) {
+        com.google.rpc.Status rpcStatus = rpcStatusFromThrowable(err);
+        if (rpcStatus == null) {
+            return null;
+        }
+
+        for (Any detail : rpcStatus.getDetailsList()) {
+            if (detail.is(LeaderHint.class)) {
+                try {
+                    return detail.unpack(LeaderHint.class);
+                } catch (InvalidProtocolBufferException e) {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static com.google.rpc.Status rpcStatusFromThrowable(@Nullable Throwable err) {
+        if (err == null) {
+            return null;
+        }
+        Metadata trailers = trailersFromThrowable(err);
+        if (trailers != null) {
+            com.google.rpc.Status status = trailers.get(STATUS_DETAILS_KEY);
+            if (status != null) {
+                return status;
+            }
+        }
+        // Unwrap
+        Throwable cause = err.getCause();
+        if (cause != null && cause != err) {
+            return rpcStatusFromThrowable(cause);
+        }
+        return null;
+    }
+
+    private static int rawCodeFromThrowable(@Nullable Throwable err) {
+        com.google.rpc.Status rpcStatus = rpcStatusFromThrowable(err);
+        return rpcStatus != null ? rpcStatus.getCode() : -1;
+    }
+
+    @Nullable
+    private static Status statusFromThrowable(@Nullable Throwable err) {
+        if (err instanceof StatusRuntimeException sre) {
+            return sre.getStatus();
+        } else if (err instanceof StatusException se) {
+            return se.getStatus();
+        }
+        // Unwrap CompletionException/ExecutionException
+        Throwable cause = err.getCause();
+        if (cause != null && cause != err) {
+            return statusFromThrowable(cause);
+        }
+        return null;
+    }
+
+    @Nullable
+    private static Metadata trailersFromThrowable(@Nullable Throwable err) {
+        if (err instanceof StatusRuntimeException sre) {
+            return sre.getTrailers();
+        } else if (err instanceof StatusException se) {
+            return se.getTrailers();
+        }
+        return null;
+    }
+}

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStubProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStubProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package io.oxia.client.grpc;
 
 import io.oxia.client.shard.ShardManager;
+import io.oxia.proto.LeaderHint;
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 public class OxiaStubProvider {
@@ -33,11 +35,24 @@ public class OxiaStubProvider {
     }
 
     public OxiaStub getStubForShard(long shardId) {
-        String leader = shardManager.leader(shardId);
-        return stubManager.getStub(leader);
+        return getStubForShard(shardId, null);
+    }
+
+    public OxiaStub getStubForShard(long shardId, @Nullable LeaderHint leaderHint) {
+        String target;
+        if (leaderHint != null && !leaderHint.getLeaderAddress().isEmpty()) {
+            target = leaderHint.getLeaderAddress();
+        } else {
+            target = shardManager.leader(shardId);
+        }
+        return stubManager.getStub(target);
     }
 
     public WriteStreamWrapper getWriteStreamForShard(long shardId) {
-        return writeStreamManager.getWriteStream(shardId);
+        return writeStreamManager.getWriteStream(shardId, null);
+    }
+
+    public WriteStreamWrapper getWriteStreamForShard(long shardId, @Nullable LeaderHint leaderHint) {
+        return writeStreamManager.getWriteStream(shardId, leaderHint);
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/OxiaWriteStreamManager.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaWriteStreamManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ package io.oxia.client.grpc;
 
 import io.grpc.Metadata;
 import io.grpc.stub.MetadataUtils;
+import io.oxia.proto.LeaderHint;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
 
 public final class OxiaWriteStreamManager {
     private final Map<Long, WriteStreamWrapper> writeStreams;
@@ -34,24 +36,32 @@ public final class OxiaWriteStreamManager {
     private static final Metadata.Key<String> SHARD_ID_KEY =
             Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
 
-    public WriteStreamWrapper getWriteStream(long shardId) {
+    public WriteStreamWrapper getWriteStream(long shardId, @Nullable LeaderHint leaderHint) {
         WriteStreamWrapper wrapper = null;
         for (int i = 0; i < 2; i++) {
             wrapper = writeStreams.get(shardId); // lock free first
-            if (wrapper == null) {
-                wrapper =
-                        writeStreams.computeIfAbsent(
-                                shardId,
-                                (__) -> {
-                                    Metadata headers = new Metadata();
-                                    headers.put(NAMESPACE_KEY, provider.getNamespace());
-                                    headers.put(SHARD_ID_KEY, String.format("%d", shardId));
-                                    final var asyncStub = provider.getStubForShard(shardId).async();
-                                    return new WriteStreamWrapper(
-                                            asyncStub.withInterceptors(
-                                                    MetadataUtils.newAttachHeadersInterceptor(headers)));
-                                });
+            // When a leader hint is provided, invalidate the cached stream so we
+            // connect to the hinted leader instead of reusing a stale connection.
+            if (wrapper != null
+                    && wrapper.isValid()
+                    && (leaderHint == null || leaderHint.getLeaderAddress().isEmpty())) {
+                return wrapper;
             }
+            if (wrapper != null) {
+                writeStreams.remove(shardId, wrapper);
+                wrapper = null;
+            }
+            wrapper =
+                    writeStreams.computeIfAbsent(
+                            shardId,
+                            (__) -> {
+                                Metadata headers = new Metadata();
+                                headers.put(NAMESPACE_KEY, provider.getNamespace());
+                                headers.put(SHARD_ID_KEY, String.format("%d", shardId));
+                                final var asyncStub = provider.getStubForShard(shardId, leaderHint).async();
+                                return new WriteStreamWrapper(
+                                        asyncStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers)));
+                            });
             if (wrapper.isValid()) {
                 break;
             }

--- a/client/src/main/proto/io/streamnative/oxia/client.proto
+++ b/client/src/main/proto/io/streamnative/oxia/client.proto
@@ -514,3 +514,8 @@ message Notification {
 
   optional string key_range_last = 3;
 }
+
+message LeaderHint {
+  int64 shard = 1;
+  string leader_address = 2;
+}

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -24,6 +24,7 @@ import static java.time.Duration.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -95,7 +96,7 @@ class BatchTest {
     static ClientConfig config =
             new ClientConfig(
                     "address",
-                    Duration.ofMillis(100),
+                    Duration.ofSeconds(5),
                     Duration.ofMillis(1000),
                     10,
                     1024 * 1024,
@@ -177,8 +178,12 @@ class BatchTest {
         final WriteStreamWrapper writeStreamWrapper = new WriteStreamWrapper(stub.async());
         clientByShardId = mock(OxiaStubProvider.class);
         lenient().when(clientByShardId.getStubForShard(anyLong())).thenReturn(stub);
+        lenient().when(clientByShardId.getStubForShard(anyLong(), any())).thenReturn(stub);
         lenient()
                 .when(clientByShardId.getWriteStreamForShard(anyLong()))
+                .thenReturn(writeStreamWrapper);
+        lenient()
+                .when(clientByShardId.getWriteStreamForShard(anyLong(), any()))
                 .thenReturn(writeStreamWrapper);
     }
 
@@ -235,7 +240,14 @@ class BatchTest {
                             mock(SessionManager.class),
                             config,
                             InstrumentProvider.NOOP);
-            batch = new WriteBatch(factory, clientByShardId, sessionManager, shardId, 1024 * 1024);
+            batch =
+                    new WriteBatch(
+                            factory,
+                            clientByShardId,
+                            sessionManager,
+                            shardId,
+                            1024 * 1024,
+                            config.requestTimeout());
         }
 
         @Test
@@ -337,7 +349,7 @@ class BatchTest {
         @Test
         public void sendFailNoClient() {
             var stubProvider = mock(OxiaStubProvider.class);
-            when(stubProvider.getWriteStreamForShard(anyLong()))
+            when(stubProvider.getWriteStreamForShard(anyLong(), any()))
                     .thenThrow(new NoShardAvailableException(1));
 
             batch =
@@ -350,7 +362,8 @@ class BatchTest {
                             stubProvider,
                             sessionManager,
                             shardId,
-                            1024 * 1024);
+                            1024 * 1024,
+                            config.requestTimeout());
             batch.add(put);
             batch.add(delete);
             batch.add(deleteRange);
@@ -406,7 +419,7 @@ class BatchTest {
         void setup() {
             var factory =
                     new ReadBatchFactory(mock(OxiaStubProvider.class), config, InstrumentProvider.NOOP);
-            batch = new ReadBatch(factory, clientByShardId, shardId);
+            batch = new ReadBatch(factory, clientByShardId, shardId, config.requestTimeout());
         }
 
         @Test
@@ -459,12 +472,14 @@ class BatchTest {
         @Test
         public void sendFailNoClient() {
             var stubProvider = mock(OxiaStubProvider.class);
-            when(stubProvider.getStubForShard(anyLong())).thenThrow(new NoShardAvailableException(1));
+            when(stubProvider.getStubForShard(anyLong(), any()))
+                    .thenThrow(new NoShardAvailableException(1));
             batch =
                     new ReadBatch(
                             new ReadBatchFactory(mock(OxiaStubProvider.class), config, InstrumentProvider.NOOP),
                             stubProvider,
-                            shardId);
+                            shardId,
+                            config.requestTimeout());
 
             batch.add(get);
             batch.send();

--- a/client/src/test/java/io/oxia/client/grpc/GrpcErrorsTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcErrorsTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2022-2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.Any;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
+import io.oxia.proto.LeaderHint;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GrpcErrorsTest {
+
+    // The trailer key where gRPC stores the full google.rpc.Status proto
+    private static final Metadata.Key<com.google.rpc.Status> STATUS_DETAILS_KEY =
+            Metadata.Key.of(
+                    "grpc-status-details-bin",
+                    ProtoUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance()));
+
+    /**
+     * Creates a StatusRuntimeException that simulates what the Go gRPC server sends for custom Oxia
+     * status codes. The Go server sets a custom code in google.rpc.Status and transmits it via the
+     * grpc-status-details-bin trailer. The gRPC framework maps unknown codes to UNKNOWN.
+     */
+    private static StatusRuntimeException customStatusError(int code, String message) {
+        var rpcStatus = com.google.rpc.Status.newBuilder().setCode(code).setMessage(message).build();
+        Metadata trailers = new Metadata();
+        trailers.put(STATUS_DETAILS_KEY, rpcStatus);
+        return Status.UNKNOWN.withDescription(message).asRuntimeException(trailers);
+    }
+
+    private static StatusRuntimeException customStatusErrorWithHint(
+            int code, String message, LeaderHint hint) {
+        var rpcStatus =
+                com.google.rpc.Status.newBuilder()
+                        .setCode(code)
+                        .setMessage(message)
+                        .addDetails(Any.pack(hint))
+                        .build();
+        Metadata trailers = new Metadata();
+        trailers.put(STATUS_DETAILS_KEY, rpcStatus);
+        return Status.UNKNOWN.withDescription(message).asRuntimeException(trailers);
+    }
+
+    @Nested
+    class IsRetriable {
+
+        @Test
+        void nullIsNotRetriable() {
+            assertThat(GrpcErrors.isRetriable(null)).isFalse();
+        }
+
+        @Test
+        void unavailableIsRetriable() {
+            var err = Status.UNAVAILABLE.withDescription("connection refused").asRuntimeException();
+            assertThat(GrpcErrors.isRetriable(err)).isTrue();
+        }
+
+        @Test
+        void unknownIsNotRetriable() {
+            var err = Status.UNKNOWN.asRuntimeException();
+            assertThat(GrpcErrors.isRetriable(err)).isFalse();
+        }
+
+        @Test
+        void notFoundIsNotRetriable() {
+            var err = Status.NOT_FOUND.asRuntimeException();
+            assertThat(GrpcErrors.isRetriable(err)).isFalse();
+        }
+
+        @Test
+        void nodeIsNotLeaderIsRetriable() {
+            var err =
+                    customStatusError(GrpcErrors.CODE_NODE_IS_NOT_LEADER, "node is not leader for shard 0");
+            assertThat(GrpcErrors.isRetriable(err)).isTrue();
+        }
+
+        @Test
+        void invalidStatusIsRetriable() {
+            var err = customStatusError(GrpcErrors.CODE_INVALID_STATUS, "oxia: invalid status");
+            assertThat(GrpcErrors.isRetriable(err)).isTrue();
+        }
+
+        @Test
+        void alreadyClosedIsRetriable() {
+            var err =
+                    customStatusError(GrpcErrors.CODE_ALREADY_CLOSED, "oxia: resource is already closed");
+            assertThat(GrpcErrors.isRetriable(err)).isTrue();
+        }
+
+        @Test
+        void sessionNotFoundIsNotRetriable() {
+            var err = customStatusError(108, "oxia: session not found");
+            assertThat(GrpcErrors.isRetriable(err)).isFalse();
+        }
+    }
+
+    @Nested
+    class FindLeaderHintTests {
+
+        @Test
+        void nullReturnsNull() {
+            assertThat(GrpcErrors.findLeaderHint(null)).isNull();
+        }
+
+        @Test
+        void noDetailsReturnsNull() {
+            var err = Status.UNKNOWN.asRuntimeException();
+            assertThat(GrpcErrors.findLeaderHint(err)).isNull();
+        }
+
+        @Test
+        void extractsLeaderHintFromDetails() {
+            var hint = LeaderHint.newBuilder().setShard(42).setLeaderAddress("leader:6648").build();
+            var err =
+                    customStatusErrorWithHint(
+                            GrpcErrors.CODE_NODE_IS_NOT_LEADER, "node is not leader for shard 42", hint);
+
+            LeaderHint extracted = GrpcErrors.findLeaderHint(err);
+            assertThat(extracted).isNotNull();
+            assertThat(extracted.getShard()).isEqualTo(42);
+            assertThat(extracted.getLeaderAddress()).isEqualTo("leader:6648");
+        }
+
+        @Test
+        void returnsNullWhenNoLeaderHintInDetails() {
+            var err =
+                    customStatusError(GrpcErrors.CODE_NODE_IS_NOT_LEADER, "node is not leader for shard 0");
+            assertThat(GrpcErrors.findLeaderHint(err)).isNull();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Port the retry and leader hint logic from the [Go client](https://github.com/streamnative/oxia) to the Java client
- Add `LeaderHint` protobuf message and `GrpcErrors` utility for retriable error classification (UNAVAILABLE, CodeInvalidStatus/102, CodeAlreadyClosed/104, CodeNodeIsNotLeader/106) and leader hint extraction from gRPC status details
- Add retry loop with exponential backoff to `WriteBatch` and `ReadBatch`, bounded by request timeout
- Update `OxiaStubProvider` and `OxiaWriteStreamManager` to accept `LeaderHint` for routing to the hinted leader and invalidating cached write streams

## Retriable errors (matching Go client `isRetriable`)
| Code | Meaning |
|---|---|
| `UNAVAILABLE` | Connection failure |
| `CodeInvalidStatus` (102) | Leader fenced the shard; new leader expected |
| `CodeAlreadyClosed` (104) | Leader closing; new leader expected |
| `CodeNodeIsNotLeader` (106) | Request sent to non-leader; retry with leader hint |

## Test plan
- [x] Added 12 unit tests for `GrpcErrors` (retriable classification + leader hint extraction)
- [x] Updated existing `BatchTest` tests — all 222 tests pass
- [ ] Integration test with oxia server for leader failover scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)