### PR TITLE
Add leader hint routing to stub provider and write stream manager

### DIFF
--- a/client/src/main/java/io/oxia/client/batch/BatchBase.java
+++ b/client/src/main/java/io/oxia/client/batch/BatchBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.oxia.client.batch;
 import io.oxia.client.grpc.OxiaStub;
 import io.oxia.client.grpc.OxiaStubProvider;
 import io.oxia.client.grpc.WriteStreamWrapper;
+import io.oxia.proto.LeaderHint;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.NonNull;
 
@@ -36,7 +38,15 @@ abstract class BatchBase {
         return stubProvider.getStubForShard(shardId);
     }
 
+    protected OxiaStub getStub(@Nullable LeaderHint leaderHint) {
+        return stubProvider.getStubForShard(shardId, leaderHint);
+    }
+
     protected WriteStreamWrapper getWriteStream() {
         return stubProvider.getWriteStreamForShard(shardId);
+    }
+
+    protected WriteStreamWrapper getWriteStream(@Nullable LeaderHint leaderHint) {
+        return stubProvider.getWriteStreamForShard(shardId, leaderHint);
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStubProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStubProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package io.oxia.client.grpc;
 
 import io.oxia.client.shard.ShardManager;
+import io.oxia.proto.LeaderHint;
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 public class OxiaStubProvider {
@@ -33,11 +35,24 @@ public class OxiaStubProvider {
     }
 
     public OxiaStub getStubForShard(long shardId) {
-        String leader = shardManager.leader(shardId);
-        return stubManager.getStub(leader);
+        return getStubForShard(shardId, null);
+    }
+
+    public OxiaStub getStubForShard(long shardId, @Nullable LeaderHint leaderHint) {
+        String target;
+        if (leaderHint != null && !leaderHint.getLeaderAddress().isEmpty()) {
+            target = leaderHint.getLeaderAddress();
+        } else {
+            target = shardManager.leader(shardId);
+        }
+        return stubManager.getStub(target);
     }
 
     public WriteStreamWrapper getWriteStreamForShard(long shardId) {
-        return writeStreamManager.getWriteStream(shardId);
+        return writeStreamManager.getWriteStream(shardId, null);
+    }
+
+    public WriteStreamWrapper getWriteStreamForShard(long shardId, @Nullable LeaderHint leaderHint) {
+        return writeStreamManager.getWriteStream(shardId, leaderHint);
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/OxiaWriteStreamManager.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaWriteStreamManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ package io.oxia.client.grpc;
 
 import io.grpc.Metadata;
 import io.grpc.stub.MetadataUtils;
+import io.oxia.proto.LeaderHint;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
 
 public final class OxiaWriteStreamManager {
     private final Map<Long, WriteStreamWrapper> writeStreams;
@@ -34,24 +36,32 @@ public final class OxiaWriteStreamManager {
     private static final Metadata.Key<String> SHARD_ID_KEY =
             Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
 
-    public WriteStreamWrapper getWriteStream(long shardId) {
+    public WriteStreamWrapper getWriteStream(long shardId, @Nullable LeaderHint leaderHint) {
         WriteStreamWrapper wrapper = null;
         for (int i = 0; i < 2; i++) {
             wrapper = writeStreams.get(shardId); // lock free first
-            if (wrapper == null) {
-                wrapper =
-                        writeStreams.computeIfAbsent(
-                                shardId,
-                                (__) -> {
-                                    Metadata headers = new Metadata();
-                                    headers.put(NAMESPACE_KEY, provider.getNamespace());
-                                    headers.put(SHARD_ID_KEY, String.format("%d", shardId));
-                                    final var asyncStub = provider.getStubForShard(shardId).async();
-                                    return new WriteStreamWrapper(
-                                            asyncStub.withInterceptors(
-                                                    MetadataUtils.newAttachHeadersInterceptor(headers)));
-                                });
+            // When a leader hint is provided, invalidate the cached stream so we
+            // connect to the hinted leader instead of reusing a stale connection.
+            if (wrapper != null
+                    && wrapper.isValid()
+                    && (leaderHint == null || leaderHint.getLeaderAddress().isEmpty())) {
+                return wrapper;
             }
+            if (wrapper != null) {
+                writeStreams.remove(shardId, wrapper);
+                wrapper = null;
+            }
+            wrapper =
+                    writeStreams.computeIfAbsent(
+                            shardId,
+                            (__) -> {
+                                Metadata headers = new Metadata();
+                                headers.put(NAMESPACE_KEY, provider.getNamespace());
+                                headers.put(SHARD_ID_KEY, String.format("%d", shardId));
+                                final var asyncStub = provider.getStubForShard(shardId, leaderHint).async();
+                                return new WriteStreamWrapper(
+                                        asyncStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers)));
+                            });
             if (wrapper.isValid()) {
                 break;
             }


### PR DESCRIPTION
## Summary
- `OxiaStubProvider.getStubForShard(shardId, leaderHint)`: routes to the hinted leader address when available, falls back to `ShardManager.leader()`
- `OxiaWriteStreamManager.getWriteStream(shardId, leaderHint)`: invalidates cached write stream when a leader hint is present and reconnects to the hinted leader
- `BatchBase`: add `getStub(LeaderHint)` and `getWriteStream(LeaderHint)` overloads for use by batch retry logic

Depends on #255.

## Test plan
- [x] All 222 existing tests pass (no behavior change yet — these overloads are not called until PR 3)
