### PR TITLE
Add retry loop with leader hint to WriteBatch and ReadBatch

### DIFF
--- a/client/src/main/java/io/oxia/client/batch/ReadBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,27 +17,40 @@ package io.oxia.client.batch;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.stub.StreamObserver;
+import io.oxia.client.grpc.OxiaStatus;
 import io.oxia.client.grpc.OxiaStubProvider;
-import io.oxia.proto.GetResponse;
+import io.oxia.client.util.Backoff;
+import io.oxia.proto.LeaderHint;
 import io.oxia.proto.ReadRequest;
 import io.oxia.proto.ReadResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
-final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadResponse> {
+@Slf4j
+final class ReadBatch extends BatchBase implements Batch {
 
     private final ReadBatchFactory factory;
 
     @VisibleForTesting final List<Operation.ReadOperation.GetOperation> gets = new ArrayList<>();
 
-    private int responseIndex = 0;
+    private final Duration requestTimeout;
     long startSendTimeNanos;
 
-    ReadBatch(ReadBatchFactory factory, OxiaStubProvider stubProvider, long shardId) {
+    ReadBatch(
+            ReadBatchFactory factory,
+            OxiaStubProvider stubProvider,
+            long shardId,
+            Duration requestTimeout) {
         super(stubProvider, shardId);
         this.factory = factory;
+        this.requestTimeout = requestTimeout;
     }
 
     @Override
@@ -59,39 +72,108 @@ final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadRes
     @Override
     public void send() {
         startSendTimeNanos = System.nanoTime();
+        ReadRequest request = toProto();
+
         try {
-            getStub().async().read(toProto(), this);
+            ReadResponse response = doRequestWithRetries(request);
+            factory
+                    .getReadRequestLatencyHistogram()
+                    .recordSuccess(System.nanoTime() - startSendTimeNanos);
+            handle(response);
         } catch (Throwable t) {
             onError(t);
         }
     }
 
-    @Override
-    public void onNext(ReadResponse response) {
-        for (int i = 0; i < response.getGetsCount(); i++) {
-            GetResponse gr = response.getGets(i);
-            gets.get(responseIndex).complete(gr);
+    ReadResponse doRequestWithRetries(ReadRequest request) throws Exception {
+        long deadlineNanos = System.nanoTime() + requestTimeout.toNanos();
+        Backoff backoff = new Backoff();
+        LeaderHint hint = null;
 
-            ++responseIndex;
+        while (true) {
+            try {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    throw new TimeoutException("Request timed out after " + requestTimeout);
+                }
+                return doRequest(request, hint, remainingNanos);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (!OxiaStatus.isRetriable(cause)) {
+                    throw e;
+                }
+                LeaderHint leaderHint = OxiaStatus.findLeaderHint(cause);
+                if (leaderHint != null) {
+                    hint = leaderHint;
+                }
+
+                long delayMillis = backoff.nextDelayMillis();
+                long remainingMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                if (remainingMillis <= 0) {
+                    throw e;
+                }
+
+                log.warn(
+                        "Failed to perform read request, retrying later. shard={} retry-after={}ms error={}",
+                        getShardId(),
+                        Math.min(delayMillis, remainingMillis),
+                        cause.getMessage());
+
+                Thread.sleep(Math.min(delayMillis, remainingMillis));
+            } catch (TimeoutException e) {
+                throw e;
+            }
         }
     }
 
-    @Override
-    public void onError(Throwable batchError) {
-        gets.forEach(g -> g.fail(batchError));
+    private ReadResponse doRequest(ReadRequest request, LeaderHint hint, long remainingNanos)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        CompletableFuture<ReadResponse> future = new CompletableFuture<>();
+        ReadResponse accumulated = ReadResponse.newBuilder().build();
+
+        getStub(hint)
+                .async()
+                .read(
+                        request,
+                        new StreamObserver<>() {
+                            private ReadResponse.Builder builder = ReadResponse.newBuilder();
+
+                            @Override
+                            public void onNext(ReadResponse response) {
+                                builder.addAllGets(response.getGetsList());
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                future.completeExceptionally(t);
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                future.complete(builder.build());
+                            }
+                        });
+
+        return future.get(remainingNanos, TimeUnit.NANOSECONDS);
+    }
+
+    void onError(Throwable batchError) {
+        Throwable error = unwrap(batchError);
+        gets.forEach(g -> g.fail(error));
         factory.getReadRequestLatencyHistogram().recordFailure(System.nanoTime() - startSendTimeNanos);
     }
 
-    @Override
-    public void onCompleted() {
-        // complete pending request if the server close stream without any response
-        gets.forEach(
-                g -> {
-                    if (!g.callback().isDone()) {
-                        g.fail(new CancellationException());
-                    }
-                });
-        factory.getReadRequestLatencyHistogram().recordSuccess(System.nanoTime() - startSendTimeNanos);
+    private static Throwable unwrap(Throwable t) {
+        if (t instanceof ExecutionException && t.getCause() != null) {
+            return t.getCause();
+        }
+        return t;
+    }
+
+    private void handle(ReadResponse response) {
+        for (int i = 0; i < gets.size(); i++) {
+            gets.get(i).complete(response.getGets(i));
+        }
     }
 
     @NonNull

--- a/client/src/main/java/io/oxia/client/batch/ReadBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,6 @@ class ReadBatchFactory extends BatchFactory {
 
     @Override
     public Batch getBatch(long shardId) {
-        return new ReadBatch(this, stubProvider, shardId);
+        return new ReadBatch(this, stubProvider, shardId, getConfig().requestTimeout());
     }
 }

--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,23 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.oxia.client.grpc.OxiaStatus;
 import io.oxia.client.grpc.OxiaStubProvider;
 import io.oxia.client.session.SessionManager;
+import io.oxia.client.util.Backoff;
+import io.oxia.proto.LeaderHint;
 import io.oxia.proto.WriteRequest;
+import io.oxia.proto.WriteResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 final class WriteBatch extends BatchBase implements Batch {
 
     private final WriteBatchFactory factory;
@@ -40,6 +50,7 @@ final class WriteBatch extends BatchBase implements Batch {
 
     private final SessionManager sessionManager;
     private final int maxBatchSize;
+    private final Duration requestTimeout;
     private int byteSize;
     private long bytes;
     private long startSendTimeNanos;
@@ -49,12 +60,14 @@ final class WriteBatch extends BatchBase implements Batch {
             @NonNull OxiaStubProvider stubProvider,
             @NonNull SessionManager sessionManager,
             long shardId,
-            int maxBatchSize) {
+            int maxBatchSize,
+            @NonNull Duration requestTimeout) {
         super(stubProvider, shardId);
         this.factory = factory;
         this.sessionManager = sessionManager;
         this.byteSize = 0;
         this.maxBatchSize = maxBatchSize;
+        this.requestTimeout = requestTimeout;
     }
 
     int sizeOf(@NonNull Operation<?> operation) {
@@ -95,39 +108,80 @@ final class WriteBatch extends BatchBase implements Batch {
     @Override
     public void send() {
         startSendTimeNanos = System.nanoTime();
-        try {
-            getWriteStream()
-                    .send(toProto())
-                    .thenAccept(
-                            response -> {
-                                factory.writeRequestLatencyHistogram.recordSuccess(
-                                        System.nanoTime() - startSendTimeNanos);
+        WriteRequest request = toProto();
 
-                                for (var i = 0; i < deletes.size(); i++) {
-                                    deletes.get(i).complete(response.getDeletes(i));
-                                }
-                                for (var i = 0; i < deleteRanges.size(); i++) {
-                                    deleteRanges.get(i).complete(response.getDeleteRanges(i));
-                                }
-                                for (var i = 0; i < puts.size(); i++) {
-                                    puts.get(i).complete(response.getPuts(i));
-                                }
-                            })
-                    .exceptionally(
-                            ex -> {
-                                handleError(ex);
-                                return null;
-                            });
+        try {
+            WriteResponse response = doRequestWithRetries(request);
+            factory.writeRequestLatencyHistogram.recordSuccess(System.nanoTime() - startSendTimeNanos);
+
+            for (var i = 0; i < deletes.size(); i++) {
+                deletes.get(i).complete(response.getDeletes(i));
+            }
+            for (var i = 0; i < deleteRanges.size(); i++) {
+                deleteRanges.get(i).complete(response.getDeleteRanges(i));
+            }
+            for (var i = 0; i < puts.size(); i++) {
+                puts.get(i).complete(response.getPuts(i));
+            }
         } catch (Throwable t) {
             handleError(t);
         }
     }
 
+    WriteResponse doRequestWithRetries(WriteRequest request) throws Exception {
+        long deadlineNanos = System.nanoTime() + requestTimeout.toNanos();
+        Backoff backoff = new Backoff();
+        LeaderHint hint = null;
+
+        while (true) {
+            try {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    throw new TimeoutException("Request timed out after " + requestTimeout);
+                }
+                return getWriteStream(hint).send(request).get(remainingNanos, TimeUnit.NANOSECONDS);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (!OxiaStatus.isRetriable(cause)) {
+                    throw e;
+                }
+                LeaderHint leaderHint = OxiaStatus.findLeaderHint(cause);
+                if (leaderHint != null) {
+                    hint = leaderHint;
+                }
+
+                long delayMillis = backoff.nextDelayMillis();
+                long remainingMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                if (remainingMillis <= 0) {
+                    throw e;
+                }
+
+                log.warn(
+                        "Failed to perform write request, retrying later. shard={} retry-after={}ms error={}",
+                        getShardId(),
+                        Math.min(delayMillis, remainingMillis),
+                        cause.getMessage());
+
+                Thread.sleep(Math.min(delayMillis, remainingMillis));
+            } catch (TimeoutException e) {
+                throw e;
+            }
+        }
+    }
+
     public void handleError(Throwable batchError) {
         factory.writeRequestLatencyHistogram.recordFailure(System.nanoTime() - startSendTimeNanos);
-        deletes.forEach(d -> d.fail(batchError));
-        deleteRanges.forEach(f -> f.fail(batchError));
-        puts.forEach(p -> p.fail(batchError));
+        Throwable error = unwrap(batchError);
+        deletes.forEach(d -> d.fail(error));
+        deleteRanges.forEach(f -> f.fail(error));
+        puts.forEach(p -> p.fail(error));
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        if (t instanceof ExecutionException && t.getCause() != null) {
+            return t.getCause();
+        }
+        return t;
     }
 
     @NonNull

--- a/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,12 @@ class WriteBatchFactory extends BatchFactory {
 
     @Override
     public Batch getBatch(long shardId) {
-        return new WriteBatch(this, stubProvider, sessionManager, shardId, getConfig().maxBatchSize());
+        return new WriteBatch(
+                this,
+                stubProvider,
+                sessionManager,
+                shardId,
+                getConfig().maxBatchSize(),
+                getConfig().requestTimeout());
     }
 }

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -24,6 +24,7 @@ import static java.time.Duration.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -95,7 +96,7 @@ class BatchTest {
     static ClientConfig config =
             new ClientConfig(
                     "address",
-                    Duration.ofMillis(100),
+                    Duration.ofSeconds(5),
                     Duration.ofMillis(1000),
                     10,
                     1024 * 1024,
@@ -177,8 +178,12 @@ class BatchTest {
         final WriteStreamWrapper writeStreamWrapper = new WriteStreamWrapper(stub.async());
         clientByShardId = mock(OxiaStubProvider.class);
         lenient().when(clientByShardId.getStubForShard(anyLong())).thenReturn(stub);
+        lenient().when(clientByShardId.getStubForShard(anyLong(), any())).thenReturn(stub);
         lenient()
                 .when(clientByShardId.getWriteStreamForShard(anyLong()))
+                .thenReturn(writeStreamWrapper);
+        lenient()
+                .when(clientByShardId.getWriteStreamForShard(anyLong(), any()))
                 .thenReturn(writeStreamWrapper);
     }
 
@@ -235,7 +240,14 @@ class BatchTest {
                             mock(SessionManager.class),
                             config,
                             InstrumentProvider.NOOP);
-            batch = new WriteBatch(factory, clientByShardId, sessionManager, shardId, 1024 * 1024);
+            batch =
+                    new WriteBatch(
+                            factory,
+                            clientByShardId,
+                            sessionManager,
+                            shardId,
+                            1024 * 1024,
+                            config.requestTimeout());
         }
 
         @Test
@@ -337,7 +349,7 @@ class BatchTest {
         @Test
         public void sendFailNoClient() {
             var stubProvider = mock(OxiaStubProvider.class);
-            when(stubProvider.getWriteStreamForShard(anyLong()))
+            when(stubProvider.getWriteStreamForShard(anyLong(), any()))
                     .thenThrow(new NoShardAvailableException(1));
 
             batch =
@@ -350,7 +362,8 @@ class BatchTest {
                             stubProvider,
                             sessionManager,
                             shardId,
-                            1024 * 1024);
+                            1024 * 1024,
+                            config.requestTimeout());
             batch.add(put);
             batch.add(delete);
             batch.add(deleteRange);
@@ -406,7 +419,7 @@ class BatchTest {
         void setup() {
             var factory =
                     new ReadBatchFactory(mock(OxiaStubProvider.class), config, InstrumentProvider.NOOP);
-            batch = new ReadBatch(factory, clientByShardId, shardId);
+            batch = new ReadBatch(factory, clientByShardId, shardId, config.requestTimeout());
         }
 
         @Test
@@ -459,12 +472,14 @@ class BatchTest {
         @Test
         public void sendFailNoClient() {
             var stubProvider = mock(OxiaStubProvider.class);
-            when(stubProvider.getStubForShard(anyLong())).thenThrow(new NoShardAvailableException(1));
+            when(stubProvider.getStubForShard(anyLong(), any()))
+                    .thenThrow(new NoShardAvailableException(1));
             batch =
                     new ReadBatch(
                             new ReadBatchFactory(mock(OxiaStubProvider.class), config, InstrumentProvider.NOOP),
                             stubProvider,
-                            shardId);
+                            shardId,
+                            config.requestTimeout());
 
             batch.add(get);
             batch.send();

--- a/client/src/test/java/io/oxia/client/batch/RetryWithLeaderHintTest.java
+++ b/client/src/test/java/io/oxia/client/batch/RetryWithLeaderHintTest.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright © 2022-2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.Any;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.stub.StreamObserver;
+import io.oxia.client.ClientConfig;
+import io.oxia.client.OxiaClientBuilderImpl;
+import io.oxia.client.api.GetResult;
+import io.oxia.client.api.PutResult;
+import io.oxia.client.batch.Operation.ReadOperation.GetOperation;
+import io.oxia.client.batch.Operation.WriteOperation.PutOperation;
+import io.oxia.client.grpc.OxiaStatus;
+import io.oxia.client.grpc.OxiaStub;
+import io.oxia.client.grpc.OxiaStubProvider;
+import io.oxia.client.grpc.WriteStreamWrapper;
+import io.oxia.client.metrics.InstrumentProvider;
+import io.oxia.client.options.GetOptions;
+import io.oxia.client.session.SessionManager;
+import io.oxia.proto.GetResponse;
+import io.oxia.proto.KeyComparisonType;
+import io.oxia.proto.LeaderHint;
+import io.oxia.proto.OxiaClientGrpc;
+import io.oxia.proto.PutResponse;
+import io.oxia.proto.ReadRequest;
+import io.oxia.proto.ReadResponse;
+import io.oxia.proto.WriteRequest;
+import io.oxia.proto.WriteResponse;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests that verify retry behavior with leader hint extraction, simulating the scenario where the
+ * server returns NODE_IS_NOT_LEADER with a LeaderHint pointing to the correct leader.
+ */
+@ExtendWith(MockitoExtension.class)
+class RetryWithLeaderHintTest {
+
+    private static final Metadata.Key<com.google.rpc.Status> STATUS_DETAILS_KEY =
+            Metadata.Key.of(
+                    "grpc-status-details-bin",
+                    ProtoUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance()));
+
+    static ClientConfig config =
+            new ClientConfig(
+                    "address",
+                    Duration.ofSeconds(5),
+                    Duration.ofMillis(1000),
+                    10,
+                    1024 * 1024,
+                    Duration.ofMillis(1000),
+                    "client_id",
+                    null,
+                    OxiaClientBuilderImpl.DefaultNamespace,
+                    null,
+                    false,
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(10),
+                    Duration.ofSeconds(5),
+                    1);
+
+    long shardId = 1L;
+
+    @Nested
+    @DisplayName("Write retry with leader hint")
+    class WriteRetryTests {
+
+        @Mock SessionManager sessionManager;
+
+        private Server leaderServer;
+        private Server followerServer;
+        private OxiaStub leaderStub;
+        private OxiaStub followerStub;
+        private AtomicInteger followerCallCount = new AtomicInteger(0);
+        private AtomicInteger leaderCallCount = new AtomicInteger(0);
+
+        @BeforeEach
+        void setup() throws Exception {
+            String leaderName = InProcessServerBuilder.generateName();
+            String followerName = InProcessServerBuilder.generateName();
+
+            // Leader server: responds successfully
+            leaderServer =
+                    InProcessServerBuilder.forName(leaderName)
+                            .directExecutor()
+                            .addService(
+                                    new OxiaClientGrpc.OxiaClientImplBase() {
+                                        @Override
+                                        public StreamObserver<WriteRequest> writeStream(
+                                                StreamObserver<WriteResponse> responseObserver) {
+                                            return new StreamObserver<>() {
+                                                @Override
+                                                public void onNext(WriteRequest request) {
+                                                    leaderCallCount.incrementAndGet();
+                                                    responseObserver.onNext(
+                                                            WriteResponse.newBuilder()
+                                                                    .addPuts(
+                                                                            PutResponse.newBuilder()
+                                                                                    .setStatus(io.oxia.proto.Status.OK)
+                                                                                    .build())
+                                                                    .build());
+                                                }
+
+                                                @Override
+                                                public void onError(Throwable t) {}
+
+                                                @Override
+                                                public void onCompleted() {
+                                                    responseObserver.onCompleted();
+                                                }
+                                            };
+                                        }
+                                    })
+                            .build()
+                            .start();
+
+            // Follower server: returns NODE_IS_NOT_LEADER with leader hint
+            followerServer =
+                    InProcessServerBuilder.forName(followerName)
+                            .directExecutor()
+                            .addService(
+                                    new OxiaClientGrpc.OxiaClientImplBase() {
+                                        @Override
+                                        public StreamObserver<WriteRequest> writeStream(
+                                                StreamObserver<WriteResponse> responseObserver) {
+                                            return new StreamObserver<>() {
+                                                @Override
+                                                public void onNext(WriteRequest request) {
+                                                    followerCallCount.incrementAndGet();
+                                                    var hint =
+                                                            LeaderHint.newBuilder()
+                                                                    .setShard(shardId)
+                                                                    .setLeaderAddress(leaderName)
+                                                                    .build();
+                                                    var rpcStatus =
+                                                            com.google.rpc.Status.newBuilder()
+                                                                    .setCode(OxiaStatus.NODE_IS_NOT_LEADER.code())
+                                                                    .setMessage("node is not leader for shard " + shardId)
+                                                                    .addDetails(Any.pack(hint))
+                                                                    .build();
+                                                    Metadata trailers = new Metadata();
+                                                    trailers.put(STATUS_DETAILS_KEY, rpcStatus);
+                                                    responseObserver.onError(
+                                                            Status.UNKNOWN
+                                                                    .withDescription("node is not leader for shard " + shardId)
+                                                                    .asRuntimeException(trailers));
+                                                }
+
+                                                @Override
+                                                public void onError(Throwable t) {}
+
+                                                @Override
+                                                public void onCompleted() {
+                                                    responseObserver.onCompleted();
+                                                }
+                                            };
+                                        }
+                                    })
+                            .build()
+                            .start();
+
+            leaderStub = new OxiaStub(InProcessChannelBuilder.forName(leaderName).build());
+            followerStub = new OxiaStub(InProcessChannelBuilder.forName(followerName).build());
+        }
+
+        @AfterEach
+        void tearDown() throws Exception {
+            leaderServer.shutdownNow();
+            followerServer.shutdownNow();
+            leaderStub.close();
+            followerStub.close();
+        }
+
+        @Test
+        @DisplayName("Write retries to leader after receiving NOT_LEADER with hint")
+        void writeRetriesWithLeaderHint() {
+            // StubProvider that initially returns follower, then leader when hint is provided
+            OxiaStubProvider stubProvider =
+                    new OxiaStubProvider("default", null, null) {
+                        @Override
+                        public WriteStreamWrapper getWriteStreamForShard(long shardId, LeaderHint leaderHint) {
+                            if (leaderHint != null && !leaderHint.getLeaderAddress().isEmpty()) {
+                                return new WriteStreamWrapper(leaderStub.async());
+                            }
+                            return new WriteStreamWrapper(followerStub.async());
+                        }
+                    };
+
+            var factory =
+                    new WriteBatchFactory(stubProvider, sessionManager, config, InstrumentProvider.NOOP);
+            var batch =
+                    new WriteBatch(
+                            factory, stubProvider, sessionManager, shardId, 1024 * 1024, config.requestTimeout());
+
+            CompletableFuture<PutResult> putFuture = new CompletableFuture<>();
+            var put =
+                    new PutOperation(
+                            putFuture,
+                            "key1",
+                            Optional.empty(),
+                            Optional.empty(),
+                            "value".getBytes(),
+                            OptionalLong.empty(),
+                            OptionalLong.empty(),
+                            Optional.empty(),
+                            Collections.emptyList(),
+                            OptionalLong.empty(),
+                            OptionalLong.empty());
+
+            batch.add(put);
+            batch.send();
+
+            assertThat(putFuture).isCompleted();
+            assertThat(followerCallCount.get()).isEqualTo(1);
+            assertThat(leaderCallCount.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Read retry with leader hint")
+    class ReadRetryTests {
+
+        private Server leaderServer;
+        private Server followerServer;
+        private OxiaStub leaderStub;
+        private OxiaStub followerStub;
+        private AtomicInteger followerCallCount = new AtomicInteger(0);
+        private AtomicInteger leaderCallCount = new AtomicInteger(0);
+
+        @BeforeEach
+        void setup() throws Exception {
+            String leaderName = InProcessServerBuilder.generateName();
+            String followerName = InProcessServerBuilder.generateName();
+
+            // Leader server: responds successfully
+            leaderServer =
+                    InProcessServerBuilder.forName(leaderName)
+                            .directExecutor()
+                            .addService(
+                                    new OxiaClientGrpc.OxiaClientImplBase() {
+                                        @Override
+                                        public void read(
+                                                ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+                                            leaderCallCount.incrementAndGet();
+                                            responseObserver.onNext(
+                                                    ReadResponse.newBuilder()
+                                                            .addGets(
+                                                                    GetResponse.newBuilder()
+                                                                            .setStatus(io.oxia.proto.Status.OK)
+                                                                            .build())
+                                                            .build());
+                                            responseObserver.onCompleted();
+                                        }
+                                    })
+                            .build()
+                            .start();
+
+            // Follower server: returns NODE_IS_NOT_LEADER with leader hint
+            followerServer =
+                    InProcessServerBuilder.forName(followerName)
+                            .directExecutor()
+                            .addService(
+                                    new OxiaClientGrpc.OxiaClientImplBase() {
+                                        @Override
+                                        public void read(
+                                                ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+                                            followerCallCount.incrementAndGet();
+                                            var hint =
+                                                    LeaderHint.newBuilder()
+                                                            .setShard(shardId)
+                                                            .setLeaderAddress(leaderName)
+                                                            .build();
+                                            var rpcStatus =
+                                                    com.google.rpc.Status.newBuilder()
+                                                            .setCode(OxiaStatus.NODE_IS_NOT_LEADER.code())
+                                                            .setMessage("node is not leader for shard " + shardId)
+                                                            .addDetails(Any.pack(hint))
+                                                            .build();
+                                            Metadata trailers = new Metadata();
+                                            trailers.put(STATUS_DETAILS_KEY, rpcStatus);
+                                            responseObserver.onError(
+                                                    Status.UNKNOWN
+                                                            .withDescription("node is not leader for shard " + shardId)
+                                                            .asRuntimeException(trailers));
+                                        }
+                                    })
+                            .build()
+                            .start();
+
+            leaderStub = new OxiaStub(InProcessChannelBuilder.forName(leaderName).build());
+            followerStub = new OxiaStub(InProcessChannelBuilder.forName(followerName).build());
+        }
+
+        @AfterEach
+        void tearDown() throws Exception {
+            leaderServer.shutdownNow();
+            followerServer.shutdownNow();
+            leaderStub.close();
+            followerStub.close();
+        }
+
+        @Test
+        @DisplayName("Read retries to leader after receiving NOT_LEADER with hint")
+        void readRetriesWithLeaderHint() {
+            // StubProvider that initially returns follower, then leader when hint is provided
+            OxiaStubProvider stubProvider =
+                    new OxiaStubProvider("default", null, null) {
+                        @Override
+                        public OxiaStub getStubForShard(long shardId, LeaderHint leaderHint) {
+                            if (leaderHint != null && !leaderHint.getLeaderAddress().isEmpty()) {
+                                return leaderStub;
+                            }
+                            return followerStub;
+                        }
+                    };
+
+            var factory = new ReadBatchFactory(stubProvider, config, InstrumentProvider.NOOP);
+            var batch = new ReadBatch(factory, stubProvider, shardId, config.requestTimeout());
+
+            CompletableFuture<GetResult> getFuture = new CompletableFuture<>();
+            var get =
+                    new GetOperation(
+                            getFuture, "key1", new GetOptions(null, true, KeyComparisonType.EQUAL, null));
+
+            batch.add(get);
+            batch.send();
+
+            assertThat(getFuture).isCompleted();
+            assertThat(followerCallCount.get()).isEqualTo(1);
+            assertThat(leaderCallCount.get()).isEqualTo(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `doRequestWithRetries()` to both `WriteBatch` and `ReadBatch`, porting the retry logic from the [Go client](https://github.com/streamnative/oxia/blob/main/oxia/internal/batch/write_batch.go)
- Retry on retriable errors with exponential backoff, bounded by request timeout
- Extract leader hint from gRPC error details and route retries to the hinted leader
- Convert `ReadBatch` from async `StreamObserver` to synchronous `CompletableFuture`-based flow to support the retry loop
- Unwrap `ExecutionException` to preserve original error types for callers

Depends on #256.

## Test plan
- [x] All 222 tests pass including updated `BatchTest` tests
- [ ] Integration test with oxia server for leader failover scenario
