### PR TITLE
Add async retry with backoff for batch operations

### DIFF
--- a/client/src/main/java/io/oxia/client/batch/ReadBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,27 +17,38 @@ package io.oxia.client.batch;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.stub.StreamObserver;
+import io.oxia.client.grpc.OxiaStatus;
 import io.oxia.client.grpc.OxiaStubProvider;
-import io.oxia.proto.GetResponse;
+import io.oxia.client.util.Backoff;
 import io.oxia.proto.ReadRequest;
 import io.oxia.proto.ReadResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
-final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadResponse> {
+@Slf4j
+final class ReadBatch extends BatchBase implements Batch {
 
     private final ReadBatchFactory factory;
 
     @VisibleForTesting final List<Operation.ReadOperation.GetOperation> gets = new ArrayList<>();
 
-    private int responseIndex = 0;
+    private final Duration requestTimeout;
     long startSendTimeNanos;
 
-    ReadBatch(ReadBatchFactory factory, OxiaStubProvider stubProvider, long shardId) {
+    ReadBatch(
+            ReadBatchFactory factory,
+            OxiaStubProvider stubProvider,
+            long shardId,
+            @NonNull Duration requestTimeout) {
         super(stubProvider, shardId);
         this.factory = factory;
+        this.requestTimeout = requestTimeout;
     }
 
     @Override
@@ -59,39 +70,90 @@ final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadRes
     @Override
     public void send() {
         startSendTimeNanos = System.nanoTime();
+        ReadRequest request = toProto();
+        long deadlineNanos = System.nanoTime() + requestTimeout.toNanos();
+
+        doRequestWithRetries(request, deadlineNanos, new Backoff())
+                .thenAccept(
+                        response -> {
+                            factory
+                                    .getReadRequestLatencyHistogram()
+                                    .recordSuccess(System.nanoTime() - startSendTimeNanos);
+
+                            for (int i = 0; i < response.getGetsCount(); i++) {
+                                gets.get(i).complete(response.getGets(i));
+                            }
+                        })
+                .exceptionally(
+                        ex -> {
+                            onError(ex);
+                            return null;
+                        });
+    }
+
+    CompletableFuture<ReadResponse> doRequestWithRetries(
+            ReadRequest request, long deadlineNanos, Backoff backoff) {
+        return doRequest(request)
+                .exceptionallyCompose(
+                        ex -> {
+                            if (!OxiaStatus.isRetriable(ex)) {
+                                return CompletableFuture.failedFuture(ex);
+                            }
+
+                            long remainingMillis =
+                                    TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                            if (remainingMillis <= 0) {
+                                return CompletableFuture.failedFuture(ex);
+                            }
+
+                            long delayMillis = Math.min(backoff.nextDelayMillis(), remainingMillis);
+                            log.warn(
+                                    "Read request failed, retrying. shard={} retry-after={}ms error={}",
+                                    getShardId(),
+                                    delayMillis,
+                                    ex.getMessage());
+
+                            Executor delayed =
+                                    CompletableFuture.delayedExecutor(delayMillis, TimeUnit.MILLISECONDS);
+                            return CompletableFuture.supplyAsync(() -> null, delayed)
+                                    .thenCompose(__ -> doRequestWithRetries(request, deadlineNanos, backoff));
+                        });
+    }
+
+    private CompletableFuture<ReadResponse> doRequest(ReadRequest request) {
+        CompletableFuture<ReadResponse> future = new CompletableFuture<>();
         try {
-            getStub().async().read(toProto(), this);
-        } catch (Throwable t) {
-            onError(t);
+            getStub()
+                    .async()
+                    .read(
+                            request,
+                            new StreamObserver<>() {
+                                ReadResponse result;
+
+                                @Override
+                                public void onNext(ReadResponse response) {
+                                    result = response;
+                                }
+
+                                @Override
+                                public void onError(Throwable t) {
+                                    future.completeExceptionally(t);
+                                }
+
+                                @Override
+                                public void onCompleted() {
+                                    future.complete(result);
+                                }
+                            });
+        } catch (Exception e) {
+            future.completeExceptionally(e);
         }
+        return future;
     }
 
-    @Override
-    public void onNext(ReadResponse response) {
-        for (int i = 0; i < response.getGetsCount(); i++) {
-            GetResponse gr = response.getGets(i);
-            gets.get(responseIndex).complete(gr);
-
-            ++responseIndex;
-        }
-    }
-
-    @Override
     public void onError(Throwable batchError) {
-        gets.forEach(g -> g.fail(batchError));
         factory.getReadRequestLatencyHistogram().recordFailure(System.nanoTime() - startSendTimeNanos);
-    }
-
-    @Override
-    public void onCompleted() {
-        // complete pending request if the server close stream without any response
-        gets.forEach(
-                g -> {
-                    if (!g.callback().isDone()) {
-                        g.fail(new CancellationException());
-                    }
-                });
-        factory.getReadRequestLatencyHistogram().recordSuccess(System.nanoTime() - startSendTimeNanos);
+        gets.forEach(g -> g.fail(batchError));
     }
 
     @NonNull

--- a/client/src/main/java/io/oxia/client/batch/ReadBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,6 @@ class ReadBatchFactory extends BatchFactory {
 
     @Override
     public Batch getBatch(long shardId) {
-        return new ReadBatch(this, stubProvider, shardId);
+        return new ReadBatch(this, stubProvider, shardId, getConfig().requestTimeout());
     }
 }

--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,22 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.oxia.client.grpc.OxiaStatus;
 import io.oxia.client.grpc.OxiaStubProvider;
 import io.oxia.client.session.SessionManager;
+import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
+import io.oxia.proto.WriteResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 final class WriteBatch extends BatchBase implements Batch {
 
     private final WriteBatchFactory factory;
@@ -40,6 +49,7 @@ final class WriteBatch extends BatchBase implements Batch {
 
     private final SessionManager sessionManager;
     private final int maxBatchSize;
+    private final Duration requestTimeout;
     private int byteSize;
     private long bytes;
     private long startSendTimeNanos;
@@ -49,12 +59,14 @@ final class WriteBatch extends BatchBase implements Batch {
             @NonNull OxiaStubProvider stubProvider,
             @NonNull SessionManager sessionManager,
             long shardId,
-            int maxBatchSize) {
+            int maxBatchSize,
+            @NonNull Duration requestTimeout) {
         super(stubProvider, shardId);
         this.factory = factory;
         this.sessionManager = sessionManager;
         this.byteSize = 0;
         this.maxBatchSize = maxBatchSize;
+        this.requestTimeout = requestTimeout;
     }
 
     int sizeOf(@NonNull Operation<?> operation) {
@@ -95,32 +107,62 @@ final class WriteBatch extends BatchBase implements Batch {
     @Override
     public void send() {
         startSendTimeNanos = System.nanoTime();
-        try {
-            getWriteStream()
-                    .send(toProto())
-                    .thenAccept(
-                            response -> {
-                                factory.writeRequestLatencyHistogram.recordSuccess(
-                                        System.nanoTime() - startSendTimeNanos);
+        WriteRequest request = toProto();
+        long deadlineNanos = System.nanoTime() + requestTimeout.toNanos();
 
-                                for (var i = 0; i < deletes.size(); i++) {
-                                    deletes.get(i).complete(response.getDeletes(i));
-                                }
-                                for (var i = 0; i < deleteRanges.size(); i++) {
-                                    deleteRanges.get(i).complete(response.getDeleteRanges(i));
-                                }
-                                for (var i = 0; i < puts.size(); i++) {
-                                    puts.get(i).complete(response.getPuts(i));
-                                }
-                            })
-                    .exceptionally(
-                            ex -> {
-                                handleError(ex);
-                                return null;
-                            });
-        } catch (Throwable t) {
-            handleError(t);
+        doRequestWithRetries(request, deadlineNanos, new Backoff())
+                .thenAccept(
+                        response -> {
+                            factory.writeRequestLatencyHistogram.recordSuccess(
+                                    System.nanoTime() - startSendTimeNanos);
+
+                            for (var i = 0; i < deletes.size(); i++) {
+                                deletes.get(i).complete(response.getDeletes(i));
+                            }
+                            for (var i = 0; i < deleteRanges.size(); i++) {
+                                deleteRanges.get(i).complete(response.getDeleteRanges(i));
+                            }
+                            for (var i = 0; i < puts.size(); i++) {
+                                puts.get(i).complete(response.getPuts(i));
+                            }
+                        })
+                .exceptionally(
+                        ex -> {
+                            handleError(ex);
+                            return null;
+                        });
+    }
+
+    CompletableFuture<WriteResponse> doRequestWithRetries(
+            WriteRequest request, long deadlineNanos, Backoff backoff) {
+        CompletableFuture<WriteResponse> attempt;
+        try {
+            attempt = getWriteStream().send(request);
+        } catch (Exception e) {
+            attempt = CompletableFuture.failedFuture(e);
         }
+        return attempt.exceptionallyCompose(
+                ex -> {
+                    if (!OxiaStatus.isRetriable(ex)) {
+                        return CompletableFuture.failedFuture(ex);
+                    }
+
+                    long remainingMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                    if (remainingMillis <= 0) {
+                        return CompletableFuture.failedFuture(ex);
+                    }
+
+                    long delayMillis = Math.min(backoff.nextDelayMillis(), remainingMillis);
+                    log.warn(
+                            "Write request failed, retrying. shard={} retry-after={}ms error={}",
+                            getShardId(),
+                            delayMillis,
+                            ex.getMessage());
+
+                    Executor delayed = CompletableFuture.delayedExecutor(delayMillis, TimeUnit.MILLISECONDS);
+                    return CompletableFuture.supplyAsync(() -> null, delayed)
+                            .thenCompose(__ -> doRequestWithRetries(request, deadlineNanos, backoff));
+                });
     }
 
     public void handleError(Throwable batchError) {

--- a/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,12 @@ class WriteBatchFactory extends BatchFactory {
 
     @Override
     public Batch getBatch(long shardId) {
-        return new WriteBatch(this, stubProvider, sessionManager, shardId, getConfig().maxBatchSize());
+        return new WriteBatch(
+                this,
+                stubProvider,
+                sessionManager,
+                shardId,
+                getConfig().maxBatchSize(),
+                getConfig().requestTimeout());
     }
 }

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -235,7 +235,14 @@ class BatchTest {
                             mock(SessionManager.class),
                             config,
                             InstrumentProvider.NOOP);
-            batch = new WriteBatch(factory, clientByShardId, sessionManager, shardId, 1024 * 1024);
+            batch =
+                    new WriteBatch(
+                            factory,
+                            clientByShardId,
+                            sessionManager,
+                            shardId,
+                            1024 * 1024,
+                            config.requestTimeout());
         }
 
         @Test
@@ -350,7 +357,8 @@ class BatchTest {
                             stubProvider,
                             sessionManager,
                             shardId,
-                            1024 * 1024);
+                            1024 * 1024,
+                            config.requestTimeout());
             batch.add(put);
             batch.add(delete);
             batch.add(deleteRange);
@@ -406,7 +414,7 @@ class BatchTest {
         void setup() {
             var factory =
                     new ReadBatchFactory(mock(OxiaStubProvider.class), config, InstrumentProvider.NOOP);
-            batch = new ReadBatch(factory, clientByShardId, shardId);
+            batch = new ReadBatch(factory, clientByShardId, shardId, config.requestTimeout());
         }
 
         @Test
@@ -464,7 +472,8 @@ class BatchTest {
                     new ReadBatch(
                             new ReadBatchFactory(mock(OxiaStubProvider.class), config, InstrumentProvider.NOOP),
                             stubProvider,
-                            shardId);
+                            shardId,
+                            config.requestTimeout());
 
             batch.add(get);
             batch.send();


### PR DESCRIPTION
## Summary
- Add async retry with exponential backoff to `WriteBatch` and `ReadBatch` using `CompletableFuture.exceptionallyCompose()`
- Non-blocking: uses `CompletableFuture.delayedExecutor()` instead of `Thread.sleep()` to keep the batcher thread free
- Convert `ReadBatch` from `StreamObserver` callback to `CompletableFuture`-based to support retry composition
- Retries bounded by `requestTimeout` deadline

Depends on #258.

## Test plan
- [x] All 226 existing tests pass (including sendOk, sendFail, sendFailNoClient)
- [x] Retry only triggers for retriable errors (UNAVAILABLE, NODE_IS_NOT_LEADER, INVALID_STATUS, ALREADY_CLOSED)
- [x] Non-retriable errors propagate immediately without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)