### PR TITLE
Fix Dependabot alerts from Shadow plugin's buildscript classpath

### DIFF
--- a/perf-ycsb/build.gradle.kts
+++ b/perf-ycsb/build.gradle.kts
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
+// Force patched versions of Shadow plugin's transitive buildscript deps:
+//   - plexus-utils 4.0.3 fixes CVE-2025-67030 (directory traversal)
+//   - log4j-core 2.25.4 fixes CVE-2026-34477, CVE-2026-34478, CVE-2026-34480
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            force("org.codehaus.plexus:plexus-utils:4.0.3")
+            force("org.apache.logging.log4j:log4j-core:2.25.4")
+            force("org.apache.logging.log4j:log4j-api:2.25.4")
+        }
+    }
+}
+
 plugins {
     application
     alias(libs.plugins.shadow)

--- a/perf/build.gradle.kts
+++ b/perf/build.gradle.kts
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
+// Force patched versions of Shadow plugin's transitive buildscript deps:
+//   - plexus-utils 4.0.3 fixes CVE-2025-67030 (directory traversal)
+//   - log4j-core 2.25.4 fixes CVE-2026-34477, CVE-2026-34478, CVE-2026-34480
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            force("org.codehaus.plexus:plexus-utils:4.0.3")
+            force("org.apache.logging.log4j:log4j-core:2.25.4")
+            force("org.apache.logging.log4j:log4j-api:2.25.4")
+        }
+    }
+}
+
 plugins {
     application
     alias(libs.plugins.shadow)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,15 +18,6 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
-// Force plexus-utils to patched version to fix CVE-2025-67030 (directory traversal)
-buildscript {
-    configurations.configureEach {
-        resolutionStrategy {
-            force("org.codehaus.plexus:plexus-utils:4.0.3")
-        }
-    }
-}
-
 rootProject.name = "oxia-java"
 
 include("client-api")


### PR DESCRIPTION
## Summary

Four open Dependabot alerts point at `log4j-core` and `plexus-utils`, but they are not coming from this project's own compile classpath. They come from the Shadow plugin's buildscript classpath in `:perf` and `:perf-ycsb`, which transitively pulls in:

- `org.apache.logging.log4j:log4j-core:2.25.3`
- `org.codehaus.plexus:plexus-utils:4.0.2`

This PR forces the patched versions on those buildscript configurations:

| Dependency | From | To | CVEs |
| --- | --- | --- | --- |
| log4j-core / log4j-api | 2.25.3 | 2.25.4 | CVE-2026-34477, CVE-2026-34478, CVE-2026-34480 |
| plexus-utils | 4.0.2 | 4.0.3 | CVE-2025-67030 (directory traversal) |

Note that #283 already bumped the project's direct `log4j` dependency in `libs.versions.toml`, but that did not clear the alerts because Dependabot was flagging the Shadow plugin's buildscript copy, not the compile classpath copy.

Also removes the stale `plexus-utils` force from `settings.gradle.kts` that was added in #274 — it was scoped to the settings buildscript classpath (where only `foojay-resolver-convention` lives, which does not use `plexus-utils`), so it was never taking effect on the real vulnerable copy.

## Test plan

- [x] `./gradlew :perf:buildEnvironment :perf-ycsb:buildEnvironment` shows both configurations resolving to the forced versions (`4.0.2 -> 4.0.3`, `2.25.3 -> 2.25.4`)
- [x] `./gradlew build` passes