### PR TITLE
Allow callers to stop a range scan early

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/CloseableIterable.java
+++ b/client-api/src/main/java/io/oxia/client/api/CloseableIterable.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2022-2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.api;
+
+/**
+ * An {@link Iterable} that holds resources which must be released by calling {@link #close()}.
+ *
+ * <p>Intended for use with try-with-resources:
+ *
+ * <pre>{@code
+ * try (CloseableIterable<GetResult> scan = client.rangeScan(start, end)) {
+ *     for (GetResult r : scan) {
+ *         if (done) break;
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <T> the element type
+ */
+public interface CloseableIterable<T> extends Iterable<T>, AutoCloseable {
+
+    /** Releases any resources held by this iterable, cancelling iteration in progress. */
+    @Override
+    void close();
+}

--- a/client-api/src/main/java/io/oxia/client/api/RangeScanConsumer.java
+++ b/client-api/src/main/java/io/oxia/client/api/RangeScanConsumer.java
@@ -25,8 +25,11 @@ public interface RangeScanConsumer {
      * Invoked for each record returned by the range scan operation.
      *
      * @param result The GetResult for the record.
+     * @return {@code true} to keep receiving records, {@code false} to stop the iteration. When
+     *     {@code false} is returned, the underlying server stream is cancelled, no further {@link
+     *     #onNext} invocations will be made, and {@link #onCompleted()} will be invoked once.
      */
-    void onNext(GetResult result);
+    boolean onNext(GetResult result);
 
     /**
      * Invoked when an error occurs during the range scan operation.

--- a/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
+++ b/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
@@ -160,8 +160,8 @@ public interface SyncOxiaClient extends AutoCloseable {
      * Scan any existing records within the specified range of keys.
      *
      * <p>The returned iterable holds an active server stream and should be closed (e.g. via
-     * try-with-resources) when iteration is abandoned before completion, otherwise the stream is
-     * only torn down when iteration runs to its natural end.
+     * try-with-resources) when iteration is abandoned before completion, otherwise the stream is only
+     * torn down when iteration runs to its natural end.
      *
      * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
      *     the range.
@@ -175,8 +175,8 @@ public interface SyncOxiaClient extends AutoCloseable {
      * Scan any existing records within the specified range of keys.
      *
      * <p>The returned iterable holds an active server stream and should be closed (e.g. via
-     * try-with-resources) when iteration is abandoned before completion, otherwise the stream is
-     * only torn down when iteration runs to its natural end.
+     * try-with-resources) when iteration is abandoned before completion, otherwise the stream is only
+     * torn down when iteration runs to its natural end.
      *
      * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
      *     the range.

--- a/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
+++ b/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
@@ -159,16 +159,24 @@ public interface SyncOxiaClient extends AutoCloseable {
     /**
      * Scan any existing records within the specified range of keys.
      *
+     * <p>The returned iterable holds an active server stream and should be closed (e.g. via
+     * try-with-resources) when iteration is abandoned before completion, otherwise the stream is
+     * only torn down when iteration runs to its natural end.
+     *
      * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
      *     the range.
      * @param endKeyExclusive The key that declares the end of the range, and is <b>excluded</b> from
      *     the range.
      * @return An iterable object that will provide all the records and their version objects.
      */
-    Iterable<GetResult> rangeScan(String startKeyInclusive, String endKeyExclusive);
+    CloseableIterable<GetResult> rangeScan(String startKeyInclusive, String endKeyExclusive);
 
     /**
      * Scan any existing records within the specified range of keys.
+     *
+     * <p>The returned iterable holds an active server stream and should be closed (e.g. via
+     * try-with-resources) when iteration is abandoned before completion, otherwise the stream is
+     * only torn down when iteration runs to its natural end.
      *
      * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
      *     the range.
@@ -177,7 +185,7 @@ public interface SyncOxiaClient extends AutoCloseable {
      * @param options the range scan options
      * @return An iterable object that will provide all the records and their version objects.
      */
-    Iterable<GetResult> rangeScan(
+    CloseableIterable<GetResult> rangeScan(
             String startKeyInclusive, String endKeyExclusive, Set<RangeScanOption> options);
 
     /**

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -67,7 +67,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import lombok.NonNull;
@@ -739,12 +738,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             if (partitionKey.isPresent()) {
                 long shardId = shardManager.getShardForKey(partitionKey.get());
                 internalShardRangeScan(
-                        shardId,
-                        startKeyInclusive,
-                        endKeyExclusive,
-                        secondaryIndexName,
-                        timedConsumer,
-                        null);
+                        shardId, startKeyInclusive, endKeyExclusive, secondaryIndexName, timedConsumer, null);
             } else {
                 internalRangeScanMultiShards(
                         startKeyInclusive, endKeyExclusive, secondaryIndexName, timedConsumer);
@@ -775,8 +769,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                             volatile boolean cancelled = false;
 
                             @Override
-                            public void beforeStart(
-                                    ClientCallStreamObserver<RangeScanRequest> requestStream) {
+                            public void beforeStart(ClientCallStreamObserver<RangeScanRequest> requestStream) {
                                 this.requestStream = requestStream;
                                 if (cancelRegistrar != null) {
                                     cancelRegistrar.accept(this::cancelStream);
@@ -797,8 +790,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                                     return;
                                 }
                                 for (int i = 0; i < response.getRecordsCount(); i++) {
-                                    if (!consumer.onNext(
-                                            ProtoUtil.getResultFromProto("", response.getRecordAt(i)))) {
+                                    if (!consumer.onNext(ProtoUtil.getResultFromProto("", response.getRecordAt(i)))) {
                                         cancelStream();
                                         consumer.onCompleted();
                                         return;

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -16,6 +16,8 @@
 package io.oxia.client;
 
 import io.grpc.netty.shaded.io.netty.util.concurrent.DefaultThreadFactory;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -65,6 +67,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import lombok.NonNull;
@@ -705,9 +708,9 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                     final AtomicLong totalSize = new AtomicLong();
 
                     @Override
-                    public void onNext(GetResult result) {
+                    public boolean onNext(GetResult result) {
                         totalSize.addAndGet(result.value().length);
-                        consumer.onNext(result);
+                        return consumer.onNext(result);
                     }
 
                     @Override
@@ -736,7 +739,12 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             if (partitionKey.isPresent()) {
                 long shardId = shardManager.getShardForKey(partitionKey.get());
                 internalShardRangeScan(
-                        shardId, startKeyInclusive, endKeyExclusive, secondaryIndexName, timedConsumer);
+                        shardId,
+                        startKeyInclusive,
+                        endKeyExclusive,
+                        secondaryIndexName,
+                        timedConsumer,
+                        null);
             } else {
                 internalRangeScanMultiShards(
                         startKeyInclusive, endKeyExclusive, secondaryIndexName, timedConsumer);
@@ -751,7 +759,8 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             String startKeyInclusive,
             String endKeyExclusive,
             Optional<String> secondaryIndexName,
-            RangeScanConsumer consumer) {
+            RangeScanConsumer consumer,
+            Consumer<Runnable> cancelRegistrar) {
         var leader = shardManager.leader(shardId);
         var stub = stubManager.getStub(leader);
         var request = new RangeScanRequest();
@@ -761,21 +770,55 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         stub.async()
                 .rangeScan(
                         request,
-                        new StreamObserver<>() {
+                        new ClientResponseObserver<RangeScanRequest, RangeScanResponse>() {
+                            ClientCallStreamObserver<RangeScanRequest> requestStream;
+                            volatile boolean cancelled = false;
+
+                            @Override
+                            public void beforeStart(
+                                    ClientCallStreamObserver<RangeScanRequest> requestStream) {
+                                this.requestStream = requestStream;
+                                if (cancelRegistrar != null) {
+                                    cancelRegistrar.accept(this::cancelStream);
+                                }
+                            }
+
+                            private void cancelStream() {
+                                if (cancelled) {
+                                    return;
+                                }
+                                cancelled = true;
+                                requestStream.cancel("Range scan cancelled", null);
+                            }
+
                             @Override
                             public void onNext(RangeScanResponse response) {
+                                if (cancelled) {
+                                    return;
+                                }
                                 for (int i = 0; i < response.getRecordsCount(); i++) {
-                                    consumer.onNext(ProtoUtil.getResultFromProto("", response.getRecordAt(i)));
+                                    if (!consumer.onNext(
+                                            ProtoUtil.getResultFromProto("", response.getRecordAt(i)))) {
+                                        cancelStream();
+                                        consumer.onCompleted();
+                                        return;
+                                    }
                                 }
                             }
 
                             @Override
                             public void onError(Throwable t) {
+                                if (cancelled) {
+                                    return;
+                                }
                                 consumer.onError(t);
                             }
 
                             @Override
                             public void onCompleted() {
+                                if (cancelled) {
+                                    return;
+                                }
                                 consumer.onCompleted();
                             }
                         });
@@ -787,16 +830,22 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             Optional<String> secondaryIndexName,
             RangeScanConsumer consumer) {
         final Set<Long> shardIds = shardManager.allShardIds();
-        final RangeScanConsumer multiShardConsumer =
+        final SharedRangeScanConsumer multiShardConsumer =
                 new SharedRangeScanConsumer(shardIds.size(), consumer);
         for (long shardId : shardIds) {
             internalShardRangeScan(
-                    shardId, startKeyInclusive, endKeyExclusive, secondaryIndexName, multiShardConsumer);
+                    shardId,
+                    startKeyInclusive,
+                    endKeyExclusive,
+                    secondaryIndexName,
+                    multiShardConsumer,
+                    multiShardConsumer::registerCancelHandler);
         }
     }
 
     static class SharedRangeScanConsumer implements RangeScanConsumer {
         private final RangeScanConsumer delegate;
+        private final List<Runnable> cancelHandlers = new ArrayList<>();
 
         private int pendingCompletedRequests;
         private boolean completed = false;
@@ -807,12 +856,32 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             this.delegate = delegate;
         }
 
-        @Override
-        public synchronized void onNext(GetResult result) {
+        synchronized void registerCancelHandler(Runnable handler) {
             if (completed) {
+                handler.run();
                 return;
             }
-            delegate.onNext(result);
+            cancelHandlers.add(handler);
+        }
+
+        @Override
+        public synchronized boolean onNext(GetResult result) {
+            if (completed) {
+                return false;
+            }
+            if (delegate.onNext(result)) {
+                return true;
+            }
+            completed = true;
+            for (Runnable h : cancelHandlers) {
+                try {
+                    h.run();
+                } catch (Throwable ignored) {
+                }
+            }
+            cancelHandlers.clear();
+            delegate.onCompleted();
+            return false;
         }
 
         @Override

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -761,59 +761,60 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         request.setShard(shardId).setStartInclusive(startKeyInclusive).setEndExclusive(endKeyExclusive);
         secondaryIndexName.ifPresent(request::setSecondaryIndexName);
 
-        stub.async()
-                .rangeScan(
-                        request,
-                        new ClientResponseObserver<RangeScanRequest, RangeScanResponse>() {
-                            ClientCallStreamObserver<RangeScanRequest> requestStream;
-                            volatile boolean cancelled = false;
+        var observer =
+                new ClientResponseObserver<RangeScanRequest, RangeScanResponse>() {
+                    ClientCallStreamObserver<RangeScanRequest> requestStream;
+                    volatile boolean cancelled = false;
 
-                            @Override
-                            public void beforeStart(ClientCallStreamObserver<RangeScanRequest> requestStream) {
-                                this.requestStream = requestStream;
-                                if (cancelRegistrar != null) {
-                                    cancelRegistrar.accept(this::cancelStream);
-                                }
-                            }
+                    @Override
+                    public void beforeStart(ClientCallStreamObserver<RangeScanRequest> requestStream) {
+                        this.requestStream = requestStream;
+                    }
 
-                            private void cancelStream() {
-                                if (cancelled) {
-                                    return;
-                                }
-                                cancelled = true;
-                                requestStream.cancel("Range scan cancelled", null);
-                            }
+                    void cancelStream() {
+                        if (cancelled) {
+                            return;
+                        }
+                        cancelled = true;
+                        requestStream.cancel("Range scan cancelled", null);
+                    }
 
-                            @Override
-                            public void onNext(RangeScanResponse response) {
-                                if (cancelled) {
-                                    return;
-                                }
-                                for (int i = 0; i < response.getRecordsCount(); i++) {
-                                    if (!consumer.onNext(ProtoUtil.getResultFromProto("", response.getRecordAt(i)))) {
-                                        cancelStream();
-                                        consumer.onCompleted();
-                                        return;
-                                    }
-                                }
-                            }
-
-                            @Override
-                            public void onError(Throwable t) {
-                                if (cancelled) {
-                                    return;
-                                }
-                                consumer.onError(t);
-                            }
-
-                            @Override
-                            public void onCompleted() {
-                                if (cancelled) {
-                                    return;
-                                }
+                    @Override
+                    public void onNext(RangeScanResponse response) {
+                        if (cancelled) {
+                            return;
+                        }
+                        for (int i = 0; i < response.getRecordsCount(); i++) {
+                            if (!consumer.onNext(ProtoUtil.getResultFromProto("", response.getRecordAt(i)))) {
+                                cancelStream();
                                 consumer.onCompleted();
+                                return;
                             }
-                        });
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        if (cancelled) {
+                            return;
+                        }
+                        consumer.onError(t);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        if (cancelled) {
+                            return;
+                        }
+                        consumer.onCompleted();
+                    }
+                };
+
+        stub.async().rangeScan(request, observer);
+
+        if (cancelRegistrar != null) {
+            cancelRegistrar.accept(observer::cancelStream);
+        }
     }
 
     private void internalRangeScanMultiShards(

--- a/client/src/main/java/io/oxia/client/GetResultIterator.java
+++ b/client/src/main/java/io/oxia/client/GetResultIterator.java
@@ -21,21 +21,28 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import lombok.SneakyThrows;
 
-public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer {
+public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer, AutoCloseable {
 
     private GetResult pendingResult;
     private Throwable error = null;
     private boolean completed = false;
+    private boolean closed = false;
 
     @Override
     @SneakyThrows
-    public synchronized void onNext(GetResult result) {
-        while (pendingResult != null) {
+    public synchronized boolean onNext(GetResult result) {
+        if (closed) {
+            return false;
+        }
+        while (pendingResult != null && !closed) {
             wait();
         }
-
+        if (closed) {
+            return false;
+        }
         pendingResult = result;
         notifyAll();
+        return true;
     }
 
     @Override
@@ -53,7 +60,7 @@ public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer
     @Override
     @SneakyThrows
     public synchronized boolean hasNext() {
-        while (error == null && !completed && pendingResult == null) {
+        while (error == null && !completed && pendingResult == null && !closed) {
             wait();
         }
 
@@ -67,7 +74,7 @@ public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer
     @Override
     @SneakyThrows
     public synchronized GetResult next() {
-        while (error == null && !completed && pendingResult == null) {
+        while (error == null && !completed && pendingResult == null && !closed) {
             wait();
         }
 
@@ -83,5 +90,14 @@ public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer
         }
 
         throw new NoSuchElementException();
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        notifyAll();
     }
 }

--- a/client/src/main/java/io/oxia/client/SyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/SyncOxiaClientImpl.java
@@ -16,6 +16,7 @@
 package io.oxia.client;
 
 import io.oxia.client.api.AsyncOxiaClient;
+import io.oxia.client.api.CloseableIterable;
 import io.oxia.client.api.GetResult;
 import io.oxia.client.api.Notification;
 import io.oxia.client.api.PutResult;
@@ -29,7 +30,9 @@ import io.oxia.client.api.options.ListOption;
 import io.oxia.client.api.options.PutOption;
 import io.oxia.client.api.options.RangeScanOption;
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -160,20 +163,42 @@ class SyncOxiaClientImpl implements SyncOxiaClient {
     }
 
     @Override
-    public Iterable<GetResult> rangeScan(
+    public CloseableIterable<GetResult> rangeScan(
             @NonNull String startKeyInclusive, @NonNull String endKeyExclusive) {
         return rangeScan(startKeyInclusive, endKeyExclusive, Collections.emptySet());
     }
 
     @Override
-    public Iterable<GetResult> rangeScan(
+    public CloseableIterable<GetResult> rangeScan(
             @NonNull String startKeyInclusive,
             @NonNull String endKeyExclusive,
             Set<RangeScanOption> options) {
-        return () -> {
-            GetResultIterator gri = new GetResultIterator();
-            asyncClient.rangeScan(startKeyInclusive, endKeyExclusive, gri, options);
-            return gri;
+        return new CloseableIterable<>() {
+            private final List<GetResultIterator> active = new ArrayList<>();
+            private boolean closed = false;
+
+            @Override
+            public synchronized Iterator<GetResult> iterator() {
+                if (closed) {
+                    throw new IllegalStateException("Range scan iterable is closed");
+                }
+                GetResultIterator gri = new GetResultIterator();
+                active.add(gri);
+                asyncClient.rangeScan(startKeyInclusive, endKeyExclusive, gri, options);
+                return gri;
+            }
+
+            @Override
+            public synchronized void close() {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                for (GetResultIterator gri : active) {
+                    gri.close();
+                }
+                active.clear();
+            }
         };
     }
 

--- a/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
@@ -589,8 +589,9 @@ class AsyncOxiaClientImplTest {
                                 5,
                                 new RangeScanConsumer() {
                                     @Override
-                                    public void onNext(GetResult result) {
+                                    public boolean onNext(GetResult result) {
                                         results.add(result);
+                                        return true;
                                     }
 
                                     @Override
@@ -689,5 +690,98 @@ class AsyncOxiaClientImplTest {
         Assertions.assertEquals(1, onErrorCount.get());
         Assertions.assertEquals(0, onCompletedCount.get());
         Assertions.assertEquals(0, results.size());
+    }
+
+    @Test
+    void testSharedRangeScanConsumerEarlyStop() {
+        final int shards = 3;
+        final int stopAfter = 2;
+        final List<GetResult> results = new ArrayList<>();
+        final AtomicInteger onErrorCount = new AtomicInteger(0);
+        final AtomicInteger onCompletedCount = new AtomicInteger(0);
+
+        final RangeScanConsumer userConsumer =
+                new RangeScanConsumer() {
+                    @Override
+                    public boolean onNext(GetResult result) {
+                        results.add(result);
+                        return results.size() < stopAfter;
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        onErrorCount.incrementAndGet();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        onCompletedCount.incrementAndGet();
+                    }
+                };
+
+        final var shared = new AsyncOxiaClientImpl.SharedRangeScanConsumer(shards, userConsumer);
+        final var cancelCounts = new ArrayList<AtomicInteger>();
+        for (int i = 0; i < shards; i++) {
+            final AtomicInteger c = new AtomicInteger(0);
+            cancelCounts.add(c);
+            shared.registerCancelHandler(c::incrementAndGet);
+        }
+
+        // First onNext returns true.
+        Assertions.assertTrue(
+                shared.onNext(
+                        new GetResult("k1", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
+        // Second onNext returns false (user requested stop).
+        Assertions.assertFalse(
+                shared.onNext(
+                        new GetResult("k2", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
+
+        // All cancel handlers should have been invoked exactly once.
+        for (AtomicInteger c : cancelCounts) {
+            Assertions.assertEquals(1, c.get());
+        }
+        // onCompleted was called exactly once on the user consumer.
+        Assertions.assertEquals(1, onCompletedCount.get());
+        Assertions.assertEquals(0, onErrorCount.get());
+        Assertions.assertEquals(stopAfter, results.size());
+
+        // Subsequent shard onNext calls are dropped (return false).
+        Assertions.assertFalse(
+                shared.onNext(
+                        new GetResult("k3", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
+        Assertions.assertEquals(stopAfter, results.size());
+
+        // Subsequent per-shard onCompleted calls (e.g., from cancel-induced errors) do not
+        // re-trigger user onCompleted.
+        shared.onCompleted();
+        shared.onCompleted();
+        Assertions.assertEquals(1, onCompletedCount.get());
+    }
+
+    @Test
+    void testSharedRangeScanConsumerLateCancelHandler() {
+        // A cancel handler registered after the scan has been stopped must run immediately.
+        final RangeScanConsumer userConsumer =
+                new RangeScanConsumer() {
+                    @Override
+                    public boolean onNext(GetResult result) {
+                        return false;
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {}
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        final var shared = new AsyncOxiaClientImpl.SharedRangeScanConsumer(2, userConsumer);
+        Assertions.assertFalse(
+                shared.onNext(
+                        new GetResult("k", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
+
+        final AtomicInteger lateCancel = new AtomicInteger(0);
+        shared.registerCancelHandler(lateCancel::incrementAndGet);
+        Assertions.assertEquals(1, lateCancel.get());
     }
 }

--- a/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
@@ -729,12 +729,10 @@ class AsyncOxiaClientImplTest {
 
         // First onNext returns true.
         Assertions.assertTrue(
-                shared.onNext(
-                        new GetResult("k1", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
+                shared.onNext(new GetResult("k1", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
         // Second onNext returns false (user requested stop).
         Assertions.assertFalse(
-                shared.onNext(
-                        new GetResult("k2", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
+                shared.onNext(new GetResult("k2", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
 
         // All cancel handlers should have been invoked exactly once.
         for (AtomicInteger c : cancelCounts) {
@@ -747,8 +745,7 @@ class AsyncOxiaClientImplTest {
 
         // Subsequent shard onNext calls are dropped (return false).
         Assertions.assertFalse(
-                shared.onNext(
-                        new GetResult("k3", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
+                shared.onNext(new GetResult("k3", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
         Assertions.assertEquals(stopAfter, results.size());
 
         // Subsequent per-shard onCompleted calls (e.g., from cancel-induced errors) do not
@@ -777,8 +774,7 @@ class AsyncOxiaClientImplTest {
 
         final var shared = new AsyncOxiaClientImpl.SharedRangeScanConsumer(2, userConsumer);
         Assertions.assertFalse(
-                shared.onNext(
-                        new GetResult("k", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
+                shared.onNext(new GetResult("k", new byte[1], new Version(1, 2, 3, 4, empty(), empty()))));
 
         final AtomicInteger lateCancel = new AtomicInteger(0);
         shared.registerCancelHandler(lateCancel::incrementAndGet);

--- a/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
+++ b/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
@@ -577,11 +577,10 @@ class OxiaClientIT {
         try (SyncOxiaClient syncClient =
                 OxiaClientBuilder.create(oxia.getServiceAddress()).syncClient()) {
             for (int i = 0; i < 30; i++) {
-                syncClient.put(String.format("range-scan-close-%02d", i), Integer.toString(i).getBytes());
+                syncClient.put(String.format("rs-close-%02d", i), Integer.toString(i).getBytes());
             }
 
-            try (CloseableIterable<GetResult> scan =
-                    syncClient.rangeScan("range-scan-close-", "range-scan-close-~")) {
+            try (CloseableIterable<GetResult> scan = syncClient.rangeScan("rs-close-", "rs-close-~")) {
                 int count = 0;
                 for (GetResult ignored : scan) {
                     count++;
@@ -591,8 +590,7 @@ class OxiaClientIT {
             }
 
             // After close, the iterable can no longer be iterated.
-            CloseableIterable<GetResult> scan =
-                    syncClient.rangeScan("range-scan-close-", "range-scan-close-~");
+            CloseableIterable<GetResult> scan = syncClient.rangeScan("rs-close-", "rs-close-~");
             scan.close();
             assertThatThrownBy(scan::iterator).isInstanceOf(IllegalStateException.class);
         }
@@ -601,7 +599,7 @@ class OxiaClientIT {
     @Test
     void testRangeScanEarlyStop() throws Exception {
         for (int i = 0; i < 20; i++) {
-            client.put(String.format("range-scan-stop-%02d", i), Integer.toString(i).getBytes()).get();
+            client.put(String.format("rs-stop-%02d", i), Integer.toString(i).getBytes()).get();
         }
 
         int stopAfter = 3;
@@ -611,8 +609,8 @@ class OxiaClientIT {
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
         client.rangeScan(
-                "range-scan-stop-",
-                "range-scan-stop-~",
+                "rs-stop-",
+                "rs-stop-~",
                 new RangeScanConsumer() {
                     @Override
                     public boolean onNext(GetResult result) {

--- a/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
+++ b/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
@@ -577,8 +577,7 @@ class OxiaClientIT {
         try (SyncOxiaClient syncClient =
                 OxiaClientBuilder.create(oxia.getServiceAddress()).syncClient()) {
             for (int i = 0; i < 30; i++) {
-                syncClient.put(
-                        String.format("range-scan-close-%02d", i), Integer.toString(i).getBytes());
+                syncClient.put(String.format("range-scan-close-%02d", i), Integer.toString(i).getBytes());
             }
 
             try (CloseableIterable<GetResult> scan =

--- a/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
+++ b/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
@@ -36,6 +36,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.oxia.client.api.AsyncOxiaClient;
+import io.oxia.client.api.CloseableIterable;
 import io.oxia.client.api.GetResult;
 import io.oxia.client.api.Notification;
 import io.oxia.client.api.Notification.KeyCreated;
@@ -43,6 +44,7 @@ import io.oxia.client.api.Notification.KeyDeleted;
 import io.oxia.client.api.Notification.KeyModified;
 import io.oxia.client.api.OxiaClientBuilder;
 import io.oxia.client.api.PutResult;
+import io.oxia.client.api.RangeScanConsumer;
 import io.oxia.client.api.SyncOxiaClient;
 import io.oxia.client.api.exceptions.KeyAlreadyExistsException;
 import io.oxia.client.api.exceptions.UnexpectedVersionIdException;
@@ -62,8 +64,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.AfterAll;
@@ -565,6 +570,76 @@ class OxiaClientIT {
                     StreamSupport.stream(iterable.spliterator(), false).map(GetResult::key).sorted().toList();
             assertThat(sameKeys).isEqualTo(keys);
         }
+    }
+
+    @Test
+    void testRangeScanCloseStopsIteration() throws Exception {
+        try (SyncOxiaClient syncClient =
+                OxiaClientBuilder.create(oxia.getServiceAddress()).syncClient()) {
+            for (int i = 0; i < 30; i++) {
+                syncClient.put(
+                        String.format("range-scan-close-%02d", i), Integer.toString(i).getBytes());
+            }
+
+            try (CloseableIterable<GetResult> scan =
+                    syncClient.rangeScan("range-scan-close-", "range-scan-close-~")) {
+                int count = 0;
+                for (GetResult ignored : scan) {
+                    count++;
+                    if (count == 3) break;
+                }
+                assertThat(count).isEqualTo(3);
+            }
+
+            // After close, the iterable can no longer be iterated.
+            CloseableIterable<GetResult> scan =
+                    syncClient.rangeScan("range-scan-close-", "range-scan-close-~");
+            scan.close();
+            assertThatThrownBy(scan::iterator).isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Test
+    void testRangeScanEarlyStop() throws Exception {
+        for (int i = 0; i < 20; i++) {
+            client.put(String.format("range-scan-stop-%02d", i), Integer.toString(i).getBytes()).get();
+        }
+
+        int stopAfter = 3;
+        List<String> received = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger onNextCalls = new AtomicInteger();
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+        client.rangeScan(
+                "range-scan-stop-",
+                "range-scan-stop-~",
+                new RangeScanConsumer() {
+                    @Override
+                    public boolean onNext(GetResult result) {
+                        onNextCalls.incrementAndGet();
+                        received.add(result.key());
+                        return received.size() < stopAfter;
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        errorRef.set(throwable);
+                        completed.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        completed.countDown();
+                    }
+                });
+
+        assertThat(completed.await(30, TimeUnit.SECONDS)).isTrue();
+        assertThat(errorRef.get()).isNull();
+        assertThat(received).hasSize(stopAfter);
+        // Give a moment for any in-flight onNext from cancelled streams to be ignored.
+        Thread.sleep(200);
+        assertThat(onNextCalls.get()).isEqualTo(stopAfter);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `RangeScanConsumer.onNext` now returns a `boolean`. Returning `false` cancels the underlying gRPC stream (`ClientCallStreamObserver.cancel`) and, for multi-shard scans, propagates the cancel to every peer shard via `SharedRangeScanConsumer`. `onCompleted` still fires exactly once.
- `SyncOxiaClient.rangeScan` now returns a new `CloseableIterable<GetResult>` (in `client-api`); `GetResultIterator` is `AutoCloseable`. Closing the iterable causes the next `onNext` from the server to return `false`, which engages the same cancellation path — so an abandoned sync scan can be torn down via try-with-resources.
- These are breaking API changes in `client-api`.

## Test plan

- [x] `./gradlew :client:test` — all unit tests pass, including new `SharedRangeScanConsumer` cancel-propagation tests
- [ ] Run the new IT cases (`testRangeScanEarlyStop`, `testRangeScanCloseStopsIteration`) in an environment with a working Docker daemon (Testcontainers couldn't start locally)
- [ ] Confirm downstream callers are migrated for the new boolean `onNext` and `CloseableIterable` return types