### PR TITLE
Submit resolved Gradle dependency graph to Dependabot

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,34 @@
+name: Dependency Submission
+
+# Submits the resolved Gradle dependency graph to GitHub so Dependabot sees
+# the versions actually used at build time (with resolutionStrategy.force and
+# constraints applied) rather than the static, pre-resolution graph parsed
+# from build files. Without this, transitive declarations from plugins like
+# SpotBugs (which still declare older log4j-core versions in their POMs) keep
+# generating false-positive alerts even though the build forces a patched
+# version.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Submit dependency graph
+        uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
## Summary
- Three open Dependabot alerts ([#67](https://github.com/oxia-db/oxia-client-java/security/dependabot/67), [#68](https://github.com/oxia-db/oxia-client-java/security/dependabot/68), [#69](https://github.com/oxia-db/oxia-client-java/security/dependabot/69)) flag log4j-core < 2.25.4 as a transitive dep of the SpotBugs Gradle plugin (which still declares 2.23.1 / 2.24.3 in its POM).
- The build already forces log4j-core 2.25.4 in the `spotbugs` configuration ([build.gradle.kts:113](https://github.com/oxia-db/oxia-client-java/blob/main/build.gradle.kts#L113)), so the resolved classpath is patched. Dependabot's static analysis of the build files cannot see `resolutionStrategy.force`, so the alerts persist.
- Add a workflow that runs `gradle/actions/dependency-submission@v4` on push to main. It resolves every configuration and submits the actual graph to GitHub. Dependabot then sees log4j-core 2.25.4 everywhere and auto-closes these false positives, and any future plugin-POM noise of the same shape.

## Test plan
- [ ] Merge to main and confirm the workflow runs successfully
- [ ] Verify the dependency graph for `settings.gradle.kts` no longer lists `log4j-core: = 2.23.1` (via GraphQL `dependencyGraphManifests` or the repo's Insights → Dependency graph view)
- [ ] Confirm alerts #67, #68, #69 transition to closed