### PR TITLE
docs: correct sessionTimeout default in OxiaClientBuilder javadoc

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -103,7 +103,7 @@ public interface OxiaClientBuilder {
     /**
      * Specify the session timeout for this client instance.
      *
-     * <p>Default is <code>30 secs</code>.
+     * <p>Default is <code>15 secs</code>.
      *
      * @see <a href="https://oxia-db.github.io/docs/features/ephemerals">Oxia Ephemeral Records</a>
      * @param sessionTimeout the session timeout duration


### PR DESCRIPTION
## Summary

The javadoc on `OxiaClientBuilder.sessionTimeout` said the default is `30 secs`, but `OxiaClientBuilderImpl.DefaultSessionTimeout` is actually `15 secs` (matching the Go SDK's `DefaultSessionTimeout`). Fix the javadoc.

## Test plan

- [x] No code change; javadoc-only.