### PR TITLE
api: declare KeyAlreadyExistsException on SyncOxiaClient.put

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/AsyncOxiaClient.java
+++ b/client-api/src/main/java/io/oxia/client/api/AsyncOxiaClient.java
@@ -45,7 +45,9 @@ public interface AsyncOxiaClient extends AutoCloseable {
      * @return The result of the put at the specified key. Supplied via a future that returns the
      *     {@link PutResult}. The future will complete exceptionally with an {@link
      *     UnexpectedVersionIdException} if the versionId at the server did not that match supplied in
-     *     the call.
+     *     the call, or with a {@link io.oxia.client.api.exceptions.KeyAlreadyExistsException
+     *     KeyAlreadyExistsException} if the key already exists on the server and the put was
+     *     conditional on it not existing (via {@link PutOption#IfRecordDoesNotExist}).
      */
     CompletableFuture<PutResult> put(String key, byte[] value, Set<PutOption> options);
 

--- a/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
+++ b/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
@@ -15,6 +15,7 @@
  */
 package io.oxia.client.api;
 
+import io.oxia.client.api.exceptions.KeyAlreadyExistsException;
 import io.oxia.client.api.exceptions.UnexpectedVersionIdException;
 import io.oxia.client.api.options.DeleteOption;
 import io.oxia.client.api.options.DeleteRangeOption;
@@ -44,7 +45,9 @@ public interface SyncOxiaClient extends AutoCloseable {
     /**
      * Conditionally associates a value with a key if the server's versionId of the record is as
      * specified, at the instant when the put is applied. The put will not be applied if the server's
-     * versionId of the record does not match the expectation set in the call.
+     * versionId of the record does not match the expectation set in the call. If you wish the put to
+     * succeed only if the key does not already exist on the server, then pass the {@link
+     * PutOption#IfRecordDoesNotExist} value.
      *
      * @param key The key with which the value should be associated.
      * @param value The value to associate with the key.
@@ -52,9 +55,11 @@ public interface SyncOxiaClient extends AutoCloseable {
      * @return The result of the put at the specified key.
      * @throws UnexpectedVersionIdException The versionId at the server did not that match supplied in
      *     the call.
+     * @throws KeyAlreadyExistsException The key already exists on the server and the put was
+     *     conditional on it not existing (via {@link PutOption#IfRecordDoesNotExist}).
      */
     PutResult put(String key, byte[] value, Set<PutOption> options)
-            throws UnexpectedVersionIdException;
+            throws UnexpectedVersionIdException, KeyAlreadyExistsException;
 
     /**
      * Unconditionally deletes the record associated with the key if the record exists.


### PR DESCRIPTION
## Summary

`SyncOxiaClient.put(String, byte[], Set<PutOption>)` only declared `throws UnexpectedVersionIdException`, but the implementation also throws `KeyAlreadyExistsException` when the call uses `PutOption.IfRecordDoesNotExist` and the key already exists ([Operation.java:145](https://github.com/oxia-db/oxia-client-java/blob/main/client/src/main/java/io/oxia/client/batch/Operation.java#L145)).

The static contract was misleading: callers got no compile-time signal that they needed to handle this case, even though `@SneakyThrows` in `SyncOxiaClientImpl` already lets the exception escape at runtime.

This PR:
- Adds `throws KeyAlreadyExistsException` on the sync-client put signature.
- Updates the javadoc on both sync and async variants to describe the case.

## Compatibility

⚠️ **Source-breaking** for direct callers of `SyncOxiaClient.put(...)` that pass `PutOption.IfRecordDoesNotExist`. They will need to either catch `KeyAlreadyExistsException` (or its supertype `OxiaException`) or re-throw it. Behaviour at runtime is unchanged — the exception was already being thrown via `@SneakyThrows`.

The async variant's signature is unchanged (the future completes exceptionally either way); only the javadoc is updated.

## Test plan

- [x] `./gradlew compileJava compileTestJava` passes
- [x] `./gradlew spotlessCheck` passes
- [x] Existing tests (`OxiaClientIT.put_IfRecordDoesNotExist`, `OperationTest`) already exercise the `KeyAlreadyExistsException` path via the async client and continue to pass