### PR TITLE
fix: don't overwrite pre-set Authentication in loadConfig(Properties)

### DIFF
--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -242,11 +242,17 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                 throw new IllegalArgumentException("Invalid configuration property: " + name);
             }
         }
-        // Create the authentication from the configuration.
-        try {
-            this.authentication = AuthenticationFactory.create(authPluginClassName, authParams);
-        } catch (UnsupportedAuthenticationException e) {
-            throw new IllegalArgumentException("Failed to create authentication from configuration.", e);
+        // Create authentication from configuration only when the properties actually specified
+        // it. Otherwise, leave any previously-set authentication instance alone — re-creating
+        // unconditionally would overwrite a caller's `.authentication(myAuth).loadConfig(props)`
+        // chain with `null` whenever `props` doesn't carry the auth keys.
+        if (!Strings.isNullOrEmpty(authPluginClassName)) {
+            try {
+                this.authentication = AuthenticationFactory.create(authPluginClassName, authParams);
+            } catch (UnsupportedAuthenticationException e) {
+                throw new IllegalArgumentException(
+                        "Failed to create authentication from configuration.", e);
+            }
         }
         return this;
     }

--- a/client/src/test/java/io/oxia/client/OxiaClientBuilderTest.java
+++ b/client/src/test/java/io/oxia/client/OxiaClientBuilderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.oxia.client.api.Authentication;
 import io.oxia.client.api.OxiaClientBuilder;
 import io.oxia.client.auth.TokenAuthentication;
 import java.time.Duration;
@@ -131,6 +132,29 @@ class OxiaClientBuilderTest {
         assertThat(metadata).isNotNull();
         String token = metadata.get("Authorization");
         assertThat(token).isEqualTo("Bearer 1234");
+    }
+
+    @Test
+    void loadConfigPreservesPreSetAuthentication() {
+        Authentication preSet =
+                new Authentication() {
+                    @Override
+                    public Map<String, String> generateCredentials() {
+                        return Map.of("X-Pre-Set", "yes");
+                    }
+
+                    @Override
+                    public void configure(String params) {}
+                };
+
+        Properties properties = new Properties();
+        properties.setProperty("requestTimeout", "1");
+
+        builder.authentication(preSet).loadConfig(properties);
+
+        OxiaClientBuilderImpl impl = (OxiaClientBuilderImpl) builder;
+        assertThat(impl.authentication).isSameAs(preSet);
+        assertThat(impl.authentication.generateCredentials()).containsEntry("X-Pre-Set", "yes");
     }
 
     @Test


### PR DESCRIPTION
## Summary

`OxiaClientBuilderImpl.loadConfig(Properties)` unconditionally re-created the authentication instance at the end of the method:

```java
this.authentication = AuthenticationFactory.create(authPluginClassName, authParams);
```

When the properties did **not** carry the `authPluginClassName` / `authParams` keys, `AuthenticationFactory.create(null, null)` returns `null`, silently wiping any authentication the caller had set on the builder before calling `loadConfig`.

This broke the natural pattern of mixing programmatic and file-based config:

```java
builder.authentication(myAuthInstance)
       .loadConfig(propertiesWithoutAuthKeys);   // myAuthInstance was lost
```

## Fix

Only call `AuthenticationFactory.create` when the properties actually specified an `authPluginClassName`. Otherwise leave the previously-set instance alone.

## Test

Added `OxiaClientBuilderTest#loadConfigPreservesPreSetAuthentication`. I confirmed locally that:

- The new test fails on `main` (pinning the bug).
- The new test passes after applying the fix.
- The existing `loadConfigWithProperties` and `loadConfigFromFile` tests still pass (the with-auth-keys path is unchanged).

## Test plan

- [x] `./gradlew :client:test --tests OxiaClientBuilderTest` passes
- [x] `./gradlew spotlessCheck` passes