### PR TITLE
Add Javadoc entry-point docs and examples for client-api

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/AsyncOxiaClient.java
+++ b/client-api/src/main/java/io/oxia/client/api/AsyncOxiaClient.java
@@ -29,7 +29,31 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-/** Asynchronous client for the Oxia service. */
+/**
+ * Non-blocking client for the Oxia service.
+ *
+ * <p>Each method returns immediately and reports its outcome on a {@link CompletableFuture}.
+ * Failures complete the future exceptionally; checked exceptions defined for the corresponding
+ * {@link SyncOxiaClient} method are wrapped in the future's failure rather than being thrown by the
+ * call itself.
+ *
+ * <p>Instances are created via {@link OxiaClientBuilder#asyncClient()} and are safe to share across
+ * threads. Always close the client when done.
+ *
+ * <pre>{@code
+ * AsyncOxiaClient client = OxiaClientBuilder.create("localhost:6648").asyncClient().join();
+ *
+ * client.put("k", "v".getBytes(StandardCharsets.UTF_8))
+ *         .thenCompose(p -> client.get("k"))
+ *         .thenAccept(r -> System.out.println(new String(r.value(), StandardCharsets.UTF_8)));
+ * }</pre>
+ *
+ * <p>Operation options (e.g. {@link PutOption}, {@link GetOption}) are passed as a {@link Set}.
+ * Pass an empty set or use the no-options overload when no options are needed.
+ *
+ * @see SyncOxiaClient
+ * @see OxiaClientBuilder
+ */
 public interface AsyncOxiaClient extends AutoCloseable {
 
     /**

--- a/client-api/src/main/java/io/oxia/client/api/GetResult.java
+++ b/client-api/src/main/java/io/oxia/client/api/GetResult.java
@@ -19,11 +19,16 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * The result of a client get request.
+ * The result of a successful get / range-scan operation.
  *
- * @param key The key associated with the record.
- * @param value The value associated with the key specified in the call.
- * @param version Metadata for the record associated with the key specified in the call.
+ * <p>A {@code null} {@code GetResult} from a {@code get} call signals that no record exists for the
+ * requested key. When {@link io.oxia.client.api.options.GetOption#ExcludeValue} is used, the {@code
+ * value} field will be {@code null} but {@code key} and {@code version} are still populated.
+ *
+ * @param key the key of the record returned by the server (may differ from the key supplied to
+ *     {@code get} when a non-equal {@link io.oxia.client.api.options.GetOption comparison} is used)
+ * @param value the record's value, or {@code null} if the value was not requested
+ * @param version metadata describing the record at the time it was read
  */
 public record GetResult(String key, byte[] value, Version version) {
 

--- a/client-api/src/main/java/io/oxia/client/api/Notification.java
+++ b/client-api/src/main/java/io/oxia/client/api/Notification.java
@@ -15,7 +15,24 @@
  */
 package io.oxia.client.api;
 
-/** A notification from an Oxia server indicating a change to a record associated with a key. */
+/**
+ * A notification from an Oxia server indicating a change to a record associated with a key.
+ *
+ * <p>Register a callback through {@link SyncOxiaClient#notifications(java.util.function.Consumer)}
+ * or {@link AsyncOxiaClient#notifications(java.util.function.Consumer)} and dispatch on the sealed
+ * subtypes:
+ *
+ * <pre>{@code
+ * client.notifications(n -> {
+ *     switch (n) {
+ *         case Notification.KeyCreated c     -> onCreated(c.key(), c.version());
+ *         case Notification.KeyModified m    -> onModified(m.key(), m.version());
+ *         case Notification.KeyDeleted d     -> onDeleted(d.key());
+ *         case Notification.KeyRangeDelete r -> onRangeDeleted(r.startKeyInclusive(), r.endKeyExclusive());
+ *     }
+ * });
+ * }</pre>
+ */
 public sealed interface Notification
         permits Notification.KeyCreated,
                 Notification.KeyDeleted,

--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -25,7 +25,23 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-/** Builder for {@link SyncOxiaClient} and {@link AsyncOxiaClient}. */
+/**
+ * Entry point for creating an Oxia client.
+ *
+ * <p>Obtain a builder via {@link #create(String)} with the address of an Oxia server, configure it
+ * fluently, and then call {@link #syncClient()} or {@link #asyncClient()} to produce a {@link
+ * SyncOxiaClient} or {@link AsyncOxiaClient}.
+ *
+ * <pre>{@code
+ * SyncOxiaClient client = OxiaClientBuilder.create("localhost:6648")
+ *         .namespace("my-namespace")
+ *         .requestTimeout(Duration.ofSeconds(10))
+ *         .syncClient();
+ * }</pre>
+ *
+ * <p>Most settings have defaults that work well for typical workloads — only override what you
+ * need.
+ */
 public interface OxiaClientBuilder {
 
     /**

--- a/client-api/src/main/java/io/oxia/client/api/PutResult.java
+++ b/client-api/src/main/java/io/oxia/client/api/PutResult.java
@@ -16,9 +16,15 @@
 package io.oxia.client.api;
 
 /**
- * The result of a client get request.
+ * The result of a successful put operation.
+ *
+ * <p>The {@code key} returned here is the effective key stored on the server. It usually matches
+ * the key supplied to the put call; with {@link
+ * io.oxia.client.api.options.PutOption#SequenceKeysDeltas sequence-key} options the server assigns
+ * the key, so callers must use this value to read the record back.
  *
  * @param key the effective key stored in Oxia
- * @param version Metadata for the record associated with the key specified in the call.
+ * @param version metadata describing the record after the put was applied (use {@link
+ *     Version#versionId()} for subsequent conditional writes)
  */
 public record PutResult(String key, Version version) {}

--- a/client-api/src/main/java/io/oxia/client/api/RangeScanConsumer.java
+++ b/client-api/src/main/java/io/oxia/client/api/RangeScanConsumer.java
@@ -16,8 +16,27 @@
 package io.oxia.client.api;
 
 /**
- * Interface defining a consumer for Range Scan operations, allowing handling of chunked results,
- * errors, or completion signals for a range scan process.
+ * Callback used by {@link AsyncOxiaClient#rangeScan(String, String, RangeScanConsumer)} to deliver
+ * records, errors, and the completion signal for a streaming range scan.
+ *
+ * <p>Exactly one of {@link #onError(Throwable)} or {@link #onCompleted()} is invoked per scan, and
+ * always after the final {@link #onNext(GetResult)} call. Returning {@code false} from {@code
+ * onNext} stops iteration early; the underlying server stream is cancelled and {@link
+ * #onCompleted()} is invoked once.
+ *
+ * <pre>{@code
+ * client.rangeScan("a", "z", new RangeScanConsumer() {
+ *     public boolean onNext(GetResult result) {
+ *         process(result);
+ *         return true; // return false to abort iteration early
+ *     }
+ *     public void onError(Throwable t) { log.warn("scan failed", t); }
+ *     public void onCompleted() { log.info("scan finished"); }
+ * });
+ * }</pre>
+ *
+ * <p>For a synchronous, iterator-style alternative, see {@link SyncOxiaClient#rangeScan(String,
+ * String)} which returns a {@link CloseableIterable}.
  */
 public interface RangeScanConsumer {
 

--- a/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
+++ b/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
@@ -29,7 +29,31 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
-/** Synchronous client for the Oxia service. */
+/**
+ * Blocking client for the Oxia service.
+ *
+ * <p>Each method blocks the calling thread until the operation completes, fails, or the configured
+ * request timeout elapses. Errors surface either as a checked {@link
+ * io.oxia.client.api.exceptions.OxiaException} subtype (e.g. {@link
+ * io.oxia.client.api.exceptions.UnexpectedVersionIdException}) or as a {@link RuntimeException} for
+ * transport / unrecoverable failures.
+ *
+ * <p>Instances are created via {@link OxiaClientBuilder#syncClient()} and are safe to share across
+ * threads. Always close the client when done — preferably via try-with-resources:
+ *
+ * <pre>{@code
+ * try (SyncOxiaClient client = OxiaClientBuilder.create("localhost:6648").syncClient()) {
+ *     client.put("k", "v".getBytes(StandardCharsets.UTF_8));
+ *     GetResult r = client.get("k");
+ * }
+ * }</pre>
+ *
+ * <p>Operation options (e.g. {@link PutOption}, {@link GetOption}) are passed as a {@link Set}.
+ * Pass an empty set or use the no-options overload when no options are needed.
+ *
+ * @see AsyncOxiaClient
+ * @see OxiaClientBuilder
+ */
 public interface SyncOxiaClient extends AutoCloseable {
 
     /**

--- a/client-api/src/main/java/io/oxia/client/api/Version.java
+++ b/client-api/src/main/java/io/oxia/client/api/Version.java
@@ -18,14 +18,22 @@ package io.oxia.client.api;
 import java.util.Optional;
 
 /**
- * Oxia record metadata.
+ * Metadata associated with an Oxia record.
  *
- * @param versionId The current versionId of the record.
- * @param createdTimestamp The instant at which the record was created. In epoch milliseconds.
- * @param modifiedTimestamp The instant at which the record was last updated. In epoch milliseconds.
- * @param modificationsCount The number of modifications since the record was last created.
- * @param sessionId The session to which this record is scoped.
- * @param clientIdentifier The client to which this record was scoped.
+ * <p>The {@code versionId} is the value that drives optimistic concurrency control: pass it back
+ * via {@link io.oxia.client.api.options.PutOption#IfVersionIdEquals(long)} or {@link
+ * io.oxia.client.api.options.DeleteOption#IfVersionIdEquals(long)} to make a write conditional on
+ * the record not having changed since it was read.
+ *
+ * <p>{@link #sessionId()} and {@link #clientIdentifier()} are present only on ephemeral records —
+ * see {@link io.oxia.client.api.options.PutOption#AsEphemeralRecord}.
+ *
+ * @param versionId the current versionId of the record (monotonically increasing per record)
+ * @param createdTimestamp the instant at which the record was first created, in epoch milliseconds
+ * @param modifiedTimestamp the instant at which the record was last updated, in epoch milliseconds
+ * @param modificationsCount the number of modifications since the record was created
+ * @param sessionId for ephemeral records, the session to which the record is scoped
+ * @param clientIdentifier for ephemeral records, the client to which the record is scoped
  */
 public record Version(
         long versionId,

--- a/client-api/src/main/java/io/oxia/client/api/exceptions/package-info.java
+++ b/client-api/src/main/java/io/oxia/client/api/exceptions/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Defines the exceptions that can be thrown by the Oxia client. */
+/**
+ * Checked exceptions raised by the Oxia client.
+ *
+ * <p>All client-side errors extend the abstract {@link
+ * io.oxia.client.api.exceptions.OxiaException}. The synchronous client throws them directly; the
+ * asynchronous client surfaces them by completing the returned {@link
+ * java.util.concurrent.CompletableFuture} exceptionally.
+ *
+ * <ul>
+ *   <li>{@link io.oxia.client.api.exceptions.UnexpectedVersionIdException} — a conditional put or
+ *       delete failed because the server's versionId does not match the expected one.
+ *   <li>{@link io.oxia.client.api.exceptions.KeyAlreadyExistsException} — a put with {@code
+ *       IfRecordDoesNotExist} found an existing record.
+ *   <li>{@link io.oxia.client.api.exceptions.SessionDoesNotExistException} — an operation tied to
+ *       an ephemeral session was attempted after the session expired.
+ *   <li>{@link io.oxia.client.api.exceptions.UnsupportedAuthenticationException} — the configured
+ *       authentication plugin could not be loaded.
+ * </ul>
+ */
 package io.oxia.client.api.exceptions;

--- a/client-api/src/main/java/io/oxia/client/api/options/package-info.java
+++ b/client-api/src/main/java/io/oxia/client/api/options/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** The definitions for options that can be passed to the Oxia client operations. */
+/**
+ * Per-operation options for the Oxia client.
+ *
+ * <p>Every option is a marker or a value type implementing one of the operation-specific marker
+ * interfaces ({@link io.oxia.client.api.options.PutOption}, {@link
+ * io.oxia.client.api.options.GetOption}, {@link io.oxia.client.api.options.DeleteOption}, {@link
+ * io.oxia.client.api.options.DeleteRangeOption}, {@link io.oxia.client.api.options.ListOption},
+ * {@link io.oxia.client.api.options.RangeScanOption}, {@link
+ * io.oxia.client.api.options.GetSequenceUpdatesOption}). They are passed to client methods as a
+ * {@link java.util.Set}, so multiple compatible options can be combined.
+ *
+ * <h2>Examples</h2>
+ *
+ * <pre>{@code
+ * // Insert only if the key is new.
+ * client.put("k", value, Set.of(PutOption.IfRecordDoesNotExist));
+ *
+ * // Compare-and-swap with a known versionId.
+ * client.put("k", value, Set.of(PutOption.IfVersionIdEquals(currentVersionId)));
+ *
+ * // Co-locate records under the same partition and add a secondary index.
+ * client.put("k", value, Set.of(
+ *         PutOption.PartitionKey("tenant-1"),
+ *         PutOption.SecondaryIndex("by-name", "alice")));
+ *
+ * // Read using a comparison instead of equality (find the floor key).
+ * GetResult floor = client.get("k", Set.of(GetOption.ComparisonFloor));
+ *
+ * // Read by following a secondary index.
+ * GetResult byName = client.get("alice", Set.of(GetOption.UseIndex("by-name")));
+ * }</pre>
+ *
+ * <h2>Common options</h2>
+ *
+ * <ul>
+ *   <li><b>PartitionKey</b> — available on every operation. Routes the call to the shard determined
+ *       by {@code partitionKey} instead of the record key, guaranteeing co-location of records that
+ *       share the same {@code partitionKey}.
+ *   <li><b>UseIndex</b> — available on {@code GetOption}, {@code ListOption} and {@code
+ *       RangeScanOption}; follows a secondary index registered via {@code
+ *       PutOption.SecondaryIndex}.
+ *   <li><b>IfVersionIdEquals / IfRecordDoesNotExist</b> — conditional writes used for optimistic
+ *       concurrency control.
+ * </ul>
+ */
 package io.oxia.client.api.options;

--- a/client-api/src/main/java/io/oxia/client/api/package-info.java
+++ b/client-api/src/main/java/io/oxia/client/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,96 @@
 /**
  * The public API for interacting with Oxia.
  *
- * <pre>
- *     SyncOxiaClient client = OxiaClientBuilder.create("localhost:6648")
+ * <h2>Getting started</h2>
+ *
+ * Every client is created through {@link io.oxia.client.api.OxiaClientBuilder}. The builder lets
+ * you produce either a {@link io.oxia.client.api.SyncOxiaClient blocking} or {@link
+ * io.oxia.client.api.AsyncOxiaClient non-blocking} client; both speak to the same Oxia cluster and
+ * expose the same operations. Pick whichever fits your code style — if in doubt, start with the
+ * synchronous one.
+ *
+ * <h3>Synchronous client</h3>
+ *
+ * <pre>{@code
+ * try (SyncOxiaClient client = OxiaClientBuilder.create("localhost:6648")
  *         .namespace("my-namespace")
- *         .syncClient();
+ *         .syncClient()) {
  *
- *     PutResult res = client.put("my-key", "my-value".getBytes());
+ *     PutResult put = client.put("my-key", "my-value".getBytes(StandardCharsets.UTF_8));
  *
- *     GetResult res = client.get("my-key");
- * </pre>
+ *     GetResult got = client.get("my-key");
+ *     if (got != null) {
+ *         String value = new String(got.value(), StandardCharsets.UTF_8);
+ *     }
+ *
+ *     boolean wasPresent = client.delete("my-key");
+ * }
+ * }</pre>
+ *
+ * <h3>Asynchronous client</h3>
+ *
+ * <pre>{@code
+ * AsyncOxiaClient client = OxiaClientBuilder.create("localhost:6648")
+ *         .namespace("my-namespace")
+ *         .asyncClient()
+ *         .join();
+ *
+ * client.put("my-key", "my-value".getBytes(StandardCharsets.UTF_8))
+ *         .thenCompose(put -> client.get("my-key"))
+ *         .thenAccept(got -> System.out.println(new String(got.value(), StandardCharsets.UTF_8)));
+ * }</pre>
+ *
+ * <h3>Conditional puts and optimistic concurrency</h3>
+ *
+ * <p>Operations can be made conditional by passing {@link io.oxia.client.api.options options}.
+ * Conditional writes that fail produce an {@link
+ * io.oxia.client.api.exceptions.UnexpectedVersionIdException}.
+ *
+ * <pre>{@code
+ * // Only insert if the key does not already exist.
+ * client.put("my-key", value, Set.of(PutOption.IfRecordDoesNotExist));
+ *
+ * // Read-modify-write with version check.
+ * GetResult current = client.get("my-key");
+ * client.put("my-key", newValue, Set.of(PutOption.IfVersionIdEquals(current.version().versionId())));
+ * }</pre>
+ *
+ * <h3>Listing and scanning ranges</h3>
+ *
+ * <pre>{@code
+ * List<String> keys = client.list("a", "z");
+ *
+ * try (CloseableIterable<GetResult> scan = client.rangeScan("a", "z")) {
+ *     for (GetResult r : scan) {
+ *         // process r
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h3>Watching for changes</h3>
+ *
+ * <pre>{@code
+ * client.notifications(n -> {
+ *     switch (n) {
+ *         case Notification.KeyCreated c  -> { /* ... *\/ }
+ *         case Notification.KeyModified m -> { /* ... *\/ }
+ *         case Notification.KeyDeleted d  -> { /* ... *\/ }
+ *         case Notification.KeyRangeDelete r -> { /* ... *\/ }
+ *     }
+ * });
+ * }</pre>
+ *
+ * <h2>Package layout</h2>
+ *
+ * <ul>
+ *   <li>{@link io.oxia.client.api} — client interfaces, builder, and result/notification types.
+ *   <li>{@link io.oxia.client.api.options} — operation options ({@code PutOption}, {@code
+ *       GetOption}, ...) passed as a {@link java.util.Set} to each call.
+ *   <li>{@link io.oxia.client.api.exceptions} — checked exceptions raised by client operations.
+ * </ul>
  *
  * @see io.oxia.client.api.OxiaClientBuilder
+ * @see io.oxia.client.api.SyncOxiaClient
+ * @see io.oxia.client.api.AsyncOxiaClient
  */
 package io.oxia.client.api;


### PR DESCRIPTION
## Summary

Expand the Javadoc on the public `client-api` module so users landing on the package or on the main interfaces immediately see how to construct a client and run typical operations.

- **Top-level `package-info`**: full quickstart covering sync/async clients, conditional puts, range scans, and notifications.
- **`OxiaClientBuilder`, `SyncOxiaClient`, `AsyncOxiaClient`**: type-level usage examples and notes on the error/threading model.
- **`options/package-info`**: explain the `Set<*Option>` pattern with combined examples for partition keys, conditional writes, and secondary indexes.
- **`exceptions/package-info`**: enumerate the `OxiaException` subtypes.
- **`Notification`, `RangeScanConsumer`**: add usage examples and clarify the callback contract.
- **`Version`, `GetResult`, `PutResult`**: describe field semantics; fix a copy-paste typo in `PutResult` ("result of a client get request").

No behavior changes — this PR is documentation-only.

## Test plan

- [x] `./gradlew :client-api:javadoc` — clean, no warnings.
- [x] `./gradlew :client-api:spotlessCheck` — passes.
- [x] `./gradlew :client-api:compileJava` and `:client:compileJava` — both build.