### PR TITLE
fix: evict unhealthy gRPC stubs

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -24,9 +24,11 @@ dependencies {
     implementation(libs.caffeine)
     implementation(libs.netty.buffer)
     implementation(libs.grpc.netty.shaded)
+    implementation(libs.grpc.services)
     implementation(libs.grpc.stub)
     implementation(libs.opentelemetry.api)
     implementation(libs.jakarta.annotation.api)
+    implementation(libs.protobuf.java)
     implementation(libs.zero.allocation.hashing)
 
     testImplementation(libs.grpc.inprocess)

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStub.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStub.java
@@ -18,21 +18,29 @@ package io.oxia.client.grpc;
 import static io.oxia.client.constants.Constants.MAXIMUM_FRAME_SIZE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import io.github.merlimat.slog.Logger;
 import io.grpc.CallCredentials;
 import io.grpc.ChannelCredentials;
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
+import io.grpc.Status;
 import io.grpc.TlsChannelCredentials;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthGrpc;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.api.Authentication;
 import io.oxia.proto.CloseSessionRequest;
 import io.oxia.proto.CloseSessionResponse;
 import io.oxia.proto.OxiaClientGrpc;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 
@@ -40,6 +48,15 @@ public class OxiaStub implements AutoCloseable {
     public static String TLS_SCHEMA = "tls://";
     private final ManagedChannel channel;
     private final @NonNull OxiaClientGrpc.OxiaClientStub asyncStub;
+    private final HealthGrpc.HealthBlockingStub healthStub;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final AtomicBoolean disconnected = new AtomicBoolean(false);
+    private final AtomicBoolean healthCheckStarted = new AtomicBoolean(false);
+    private final @Nullable Consumer<OxiaStub> connectionFailureCallback;
+    private volatile @Nullable Thread healthCheckThread;
+    private final @Nullable Duration healthCheckInterval;
+    private final @Nullable Duration healthCheckTimeout;
+    private final Logger log;
 
     static String getAddress(String address) {
         if (address.startsWith(TLS_SCHEMA)) {
@@ -55,6 +72,13 @@ public class OxiaStub implements AutoCloseable {
     }
 
     public OxiaStub(String address, ClientConfig clientConfig) {
+        this(address, clientConfig, null);
+    }
+
+    OxiaStub(
+            String address,
+            ClientConfig clientConfig,
+            @Nullable Consumer<OxiaStub> connectionFailureCallback) {
         this(
                 Grpc.newChannelBuilder(
                                 getAddress(address), getChannelCredential(address, clientConfig.enableTls()))
@@ -64,7 +88,11 @@ public class OxiaStub implements AutoCloseable {
                         .disableRetry()
                         .directExecutor()
                         .build(),
-                clientConfig.authentication());
+                clientConfig.authentication(),
+                connectionFailureCallback,
+                clientConfig.connectionKeepAliveTime(),
+                clientConfig.connectionKeepAliveTimeout(),
+                address);
     }
 
     public OxiaStub(ManagedChannel channel) {
@@ -72,33 +100,113 @@ public class OxiaStub implements AutoCloseable {
     }
 
     public OxiaStub(ManagedChannel channel, @Nullable final Authentication authentication) {
+        this(channel, authentication, null, null, null, "managed-channel");
+    }
+
+    private OxiaStub(
+            ManagedChannel channel,
+            @Nullable final Authentication authentication,
+            @Nullable Consumer<OxiaStub> connectionFailureCallback,
+            @Nullable Duration healthCheckInterval,
+            @Nullable Duration healthCheckTimeout,
+            String logAddress) {
         this.channel = channel;
-        if (authentication != null) {
-            this.asyncStub =
-                    OxiaClientGrpc.newStub(channel)
-                            .withMaxInboundMessageSize(MAXIMUM_FRAME_SIZE)
-                            .withMaxOutboundMessageSize(MAXIMUM_FRAME_SIZE)
-                            .withCallCredentials(
-                                    new CallCredentials() {
-                                        @Override
-                                        public void applyRequestMetadata(
-                                                RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
-                                            Metadata credentials = new Metadata();
-                                            authentication
-                                                    .generateCredentials()
-                                                    .forEach(
-                                                            (key, value) ->
-                                                                    credentials.put(
-                                                                            Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER),
-                                                                            value));
-                                            applier.apply(credentials);
-                                        }
-                                    });
-        } else {
-            this.asyncStub =
-                    OxiaClientGrpc.newStub(channel)
-                            .withMaxInboundMessageSize(MAXIMUM_FRAME_SIZE)
-                            .withMaxOutboundMessageSize(MAXIMUM_FRAME_SIZE);
+        this.connectionFailureCallback = connectionFailureCallback;
+        this.healthCheckInterval = healthCheckInterval;
+        this.healthCheckTimeout = healthCheckTimeout;
+        this.log = Logger.get(OxiaStub.class).with().attr("address", logAddress).build();
+
+        final var callCredentials = authentication != null ? getCallCredentials(authentication) : null;
+        OxiaClientGrpc.OxiaClientStub oxiaStub =
+                OxiaClientGrpc.newStub(channel)
+                        .withMaxInboundMessageSize(MAXIMUM_FRAME_SIZE)
+                        .withMaxOutboundMessageSize(MAXIMUM_FRAME_SIZE);
+        HealthGrpc.HealthBlockingStub healthStub = HealthGrpc.newBlockingStub(channel);
+        if (callCredentials != null) {
+            oxiaStub = oxiaStub.withCallCredentials(callCredentials);
+            healthStub = healthStub.withCallCredentials(callCredentials);
+        }
+        this.asyncStub = oxiaStub;
+        this.healthStub = healthStub;
+        this.healthCheckThread = null;
+    }
+
+    private static CallCredentials getCallCredentials(@NonNull Authentication authentication) {
+        return new CallCredentials() {
+            @Override
+            public void applyRequestMetadata(
+                    RequestInfo requestInfo, Executor appExecutor, MetadataApplier applier) {
+                Metadata credentials = new Metadata();
+                authentication
+                        .generateCredentials()
+                        .forEach(
+                                (key, value) ->
+                                        credentials.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value));
+                applier.apply(credentials);
+            }
+        };
+    }
+
+    void startHealthCheck() {
+        if (connectionFailureCallback == null
+                || healthCheckInterval == null
+                || healthCheckTimeout == null
+                || !healthCheckStarted.compareAndSet(false, true)) {
+            return;
+        }
+
+        final var thread = new Thread(this::healthCheckLoop, "oxia-grpc-health-check");
+        thread.setDaemon(true);
+        healthCheckThread = thread;
+        thread.start();
+    }
+
+    private void healthCheckLoop() {
+        while (!closed.get()) {
+            if (!healthCheck()) {
+                return;
+            }
+
+            try {
+                Thread.sleep(healthCheckInterval.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private boolean healthCheck() {
+        try {
+            final var response =
+                    healthStub
+                            .withDeadlineAfter(healthCheckTimeout.toMillis(), MILLISECONDS)
+                            .check(HealthCheckRequest.newBuilder().build());
+            if (response.getStatus() == HealthCheckResponse.ServingStatus.SERVING) {
+                return true;
+            }
+            log.warn()
+                    .attr("status", response.getStatus())
+                    .log("Connection health check returned unhealthy status");
+            notifyConnectionFailure();
+            return false;
+        } catch (Throwable t) {
+            if (closed.get()) {
+                return false;
+            }
+            if (Status.fromThrowable(t).getCode() == Status.Code.UNIMPLEMENTED) {
+                log.debug("Connection health check is unsupported");
+                return false;
+            }
+            log.warn().exceptionMessage(t).log("Connection health check failed");
+            notifyConnectionFailure();
+            return false;
+        }
+    }
+
+    private void notifyConnectionFailure() {
+        if (connectionFailureCallback != null && disconnected.compareAndSet(false, true)) {
+            connectionFailureCallback.accept(this);
         }
     }
 
@@ -137,6 +245,13 @@ public class OxiaStub implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        final var thread = healthCheckThread;
+        if (thread != null && Thread.currentThread() != thread) {
+            thread.interrupt();
+        }
         channel.shutdown();
         try {
             if (!channel.awaitTermination(100, MILLISECONDS)) {
@@ -144,6 +259,14 @@ public class OxiaStub implements AutoCloseable {
             }
         } catch (InterruptedException e) {
             channel.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        if (thread != null && Thread.currentThread() != thread) {
+            try {
+                thread.join(MILLISECONDS.toMillis(100));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStubManager.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStubManager.java
@@ -16,12 +16,15 @@
 package io.oxia.client.grpc;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.oxia.client.ClientConfig;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class OxiaStubManager implements AutoCloseable {
+    private static final Logger LOG = Logger.get(OxiaStubManager.class);
+
     @VisibleForTesting final Map<Key, OxiaStub> stubs = new ConcurrentHashMap<>();
 
     private final int maxConnectionPerNode;
@@ -38,8 +41,50 @@ public class OxiaStubManager implements AutoCloseable {
         if (modKey < 0) {
             modKey += maxConnectionPerNode;
         }
-        return stubs.computeIfAbsent(
-                new Key(address, modKey), key -> new OxiaStub(key.address, clientConfig));
+        final var key = new Key(address, modKey);
+        final var existing = stubs.get(key);
+        if (existing != null) {
+            return existing;
+        }
+
+        final var stub = newStub(key);
+        final var previous = stubs.putIfAbsent(key, stub);
+        if (previous != null) {
+            closeUnusedStub(key, stub);
+            return previous;
+        }
+
+        stub.startHealthCheck();
+        return stub;
+    }
+
+    private OxiaStub newStub(Key key) {
+        return new OxiaStub(key.address, clientConfig, stub -> removeStub(key, stub));
+    }
+
+    private void removeStub(Key key, OxiaStub stub) {
+        if (!stubs.remove(key, stub)) {
+            return;
+        }
+        try {
+            stub.close();
+        } catch (Exception e) {
+            LOG.warn()
+                    .attr("address", key.address())
+                    .exceptionMessage(e)
+                    .log("Failed to close unhealthy GRPC stub");
+        }
+    }
+
+    private void closeUnusedStub(Key key, OxiaStub stub) {
+        try {
+            stub.close();
+        } catch (Exception e) {
+            LOG.warn()
+                    .attr("address", key.address())
+                    .exceptionMessage(e)
+                    .log("Failed to close unused GRPC stub");
+        }
     }
 
     @Override

--- a/client/src/test/java/io/oxia/client/grpc/OxiaStubManagerTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/OxiaStubManagerTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.grpc.Server;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthGrpc;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.oxia.client.ClientConfig;
+import io.oxia.client.OxiaClientBuilderImpl;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class OxiaStubManagerTest {
+
+    @Test
+    void removesStubWhenHealthCheckFails() throws Exception {
+        Server server = newHealthServer(HealthCheckResponse.ServingStatus.NOT_SERVING);
+        String target = target(server);
+
+        try (OxiaStubManager manager =
+                new OxiaStubManager(clientConfig(target, Duration.ofMillis(100)))) {
+            OxiaStub stub = manager.getStub(target);
+
+            await()
+                    .atMost(Duration.ofSeconds(1))
+                    .untilAsserted(() -> assertThat(manager.stubs).doesNotContainValue(stub));
+        } finally {
+            close(server);
+        }
+    }
+
+    @Test
+    void removesStubWhenHealthCheckHangs() throws Exception {
+        Server server =
+                NettyServerBuilder.forPort(0)
+                        .directExecutor()
+                        .addService(new BlockingHealthService())
+                        .build()
+                        .start();
+        String target = target(server);
+
+        try (OxiaStubManager manager =
+                new OxiaStubManager(clientConfig(target, Duration.ofMillis(100)))) {
+            OxiaStub stub = manager.getStub(target);
+
+            await()
+                    .atMost(Duration.ofSeconds(1))
+                    .untilAsserted(() -> assertThat(manager.stubs).doesNotContainValue(stub));
+        } finally {
+            close(server);
+        }
+    }
+
+    @Test
+    void keepsStubWhenHealthCheckSucceeds() throws Exception {
+        Server server = newHealthServer(HealthCheckResponse.ServingStatus.SERVING);
+        String target = target(server);
+
+        try (OxiaStubManager manager =
+                new OxiaStubManager(clientConfig(target, Duration.ofSeconds(1)))) {
+            OxiaStub stub = manager.getStub(target);
+
+            await()
+                    .during(Duration.ofMillis(200))
+                    .atMost(Duration.ofMillis(500))
+                    .untilAsserted(() -> assertThat(manager.stubs).containsValue(stub));
+        } finally {
+            close(server);
+        }
+    }
+
+    @Test
+    void keepsStubWhenHealthCheckIsUnsupported() throws Exception {
+        Server server = NettyServerBuilder.forPort(0).directExecutor().build().start();
+        String target = target(server);
+
+        try (OxiaStubManager manager =
+                new OxiaStubManager(clientConfig(target, Duration.ofSeconds(1)))) {
+            OxiaStub stub = manager.getStub(target);
+
+            await()
+                    .during(Duration.ofMillis(200))
+                    .atMost(Duration.ofMillis(500))
+                    .untilAsserted(() -> assertThat(manager.stubs).containsValue(stub));
+        } finally {
+            close(server);
+        }
+    }
+
+    private static Server newHealthServer(HealthCheckResponse.ServingStatus status) throws Exception {
+        return NettyServerBuilder.forPort(0)
+                .directExecutor()
+                .addService(new StaticHealthService(status))
+                .build()
+                .start();
+    }
+
+    private static ClientConfig clientConfig(String target, Duration healthCheckTimeout) {
+        var builder = new OxiaClientBuilderImpl(target);
+        builder.connectionKeepAliveTime(Duration.ofMillis(10));
+        builder.connectionKeepAliveTimeout(healthCheckTimeout);
+        return builder.getClientConfig();
+    }
+
+    private static String target(Server server) {
+        return "127.0.0.1:" + server.getPort();
+    }
+
+    private static void close(Server server) throws InterruptedException {
+        server.shutdownNow();
+        server.awaitTermination(1, TimeUnit.SECONDS);
+    }
+
+    private static final class StaticHealthService extends HealthGrpc.HealthImplBase {
+        private final HealthCheckResponse.ServingStatus status;
+
+        private StaticHealthService(HealthCheckResponse.ServingStatus status) {
+            this.status = status;
+        }
+
+        @Override
+        public void check(
+                HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {
+            responseObserver.onNext(HealthCheckResponse.newBuilder().setStatus(status).build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    private static final class BlockingHealthService extends HealthGrpc.HealthImplBase {
+        @Override
+        public void check(
+                HealthCheckRequest request, StreamObserver<HealthCheckResponse> responseObserver) {}
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semco
 
 # gRPC
 grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded" }
+grpc-services = { module = "io.grpc:grpc-services" }
 grpc-stub = { module = "io.grpc:grpc-stub" }
 grpc-inprocess = { module = "io.grpc:grpc-inprocess" }
 


### PR DESCRIPTION
## Motivation
- Support the stale proxied gRPC connection handling added in oxia-db/oxia#1130 for the Java client.
- The Java client pooled channels with keepalive enabled, but had no active health probe to evict a stale channel after server-side proxy failure.

## Modifications
- Add gRPC health client support to production-created Oxia stubs.
- Run a lightweight health check loop using the existing keepalive interval and timeout settings.
- Evict and close only the exact failed pooled stub so subsequent calls create a fresh channel.
- Keep compatibility with servers that do not implement the health service.
- Add regression coverage for unhealthy, hung, healthy, and unsupported health-check scenarios.

## Testing
- ./gradlew :client:spotlessApply :client:test --tests io.oxia.client.grpc.OxiaStubManagerTest --tests io.oxia.client.grpc.OxiaStubTest
- ./gradlew :client:check -x test
- git diff --check