### PR TITLE
feat: retry unary RPC calls

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(project(":client-api"))
 
     implementation(libs.caffeine)
+    implementation(libs.failsafe)
     implementation(libs.netty.buffer)
     implementation(libs.grpc.netty.shaded)
     implementation(libs.grpc.protobuf)

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -72,21 +72,23 @@ import lombok.NonNull;
 class AsyncOxiaClientImpl implements AsyncOxiaClient {
 
     static @NonNull CompletableFuture<AsyncOxiaClient> newInstance(@NonNull ClientConfig config) {
-        ScheduledExecutorService executor =
-                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("oxia-client"));
+        final ScheduledExecutorService asyncExecutor =
+                Executors.newScheduledThreadPool(
+                        Runtime.getRuntime().availableProcessors(),
+                        new DefaultThreadFactory("oxia-client-async"));
         var instrumentProvider = new InstrumentProvider(config.openTelemetry(), config.namespace());
         var shardManagerRef = new AtomicReference<ShardManager>();
         var rpcProvider =
-                RpcProvider.create(config, executor, shardId -> shardManagerRef.get().leader(shardId));
+                RpcProvider.create(config, asyncExecutor, shardId -> shardManagerRef.get().leader(shardId));
         var shardManager =
-                new ShardManager(executor, rpcProvider, instrumentProvider, config.namespace());
+                new ShardManager(asyncExecutor, rpcProvider, instrumentProvider, config.namespace());
         shardManagerRef.set(shardManager);
         var notificationManager =
-                new NotificationManager(executor, rpcProvider, shardManager, instrumentProvider);
+                new NotificationManager(asyncExecutor, rpcProvider, shardManager, instrumentProvider);
         shardManager.addCallback(notificationManager);
         var readBatchManager =
                 BatchManager.newReadBatchManager(config, rpcProvider, instrumentProvider);
-        var sessionManager = new SessionManager(executor, config, rpcProvider, instrumentProvider);
+        var sessionManager = new SessionManager(asyncExecutor, config, rpcProvider, instrumentProvider);
         shardManager.addCallback(sessionManager);
         var writeBatchManager =
                 BatchManager.newWriteBatchManager(config, rpcProvider, sessionManager, instrumentProvider);
@@ -94,7 +96,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         var client =
                 new AsyncOxiaClientImpl(
                         config.clientIdentifier(),
-                        executor,
+                        asyncExecutor,
                         instrumentProvider,
                         rpcProvider,
                         shardManager,

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -56,17 +56,17 @@ final class GrpcRpcProvider implements RpcProvider {
 
     private final ClientConfig clientConfig;
     private final ConnectionManager connectionManager;
-    private final ScheduledExecutorService executor;
+    private final ScheduledExecutorService asyncExecutor;
     private final LongFunction<String> shardLeaderProvider;
     private final ManagedWriteStream managedWriteStream;
 
     GrpcRpcProvider(
             @NonNull ClientConfig clientConfig,
-            @NonNull ScheduledExecutorService executor,
+            @NonNull ScheduledExecutorService asyncExecutor,
             @NonNull LongFunction<String> shardLeaderProvider) {
         this.clientConfig = clientConfig;
-        this.executor = executor;
-        this.connectionManager = new ConnectionManager(clientConfig, executor);
+        this.asyncExecutor = asyncExecutor;
+        this.connectionManager = new ConnectionManager(clientConfig, asyncExecutor);
         this.shardLeaderProvider = shardLeaderProvider;
         this.managedWriteStream =
                 new ManagedWriteStream(
@@ -106,7 +106,7 @@ final class GrpcRpcProvider implements RpcProvider {
             @NonNull CreateSessionRequest request) {
         final var hint = new AtomicReference<OxiaStatusException>();
         return Failsafe.with(getRetryPolicy(hint))
-                .with(executor)
+                .with(asyncExecutor)
                 .getStageAsync(
                         () -> {
                             final var future = new CompletableFuture<CreateSessionResponse>();
@@ -126,7 +126,7 @@ final class GrpcRpcProvider implements RpcProvider {
     public CompletableFuture<KeepAliveResponse> keepAlive(@NonNull SessionHeartbeat heartbeat) {
         final var hint = new AtomicReference<OxiaStatusException>();
         return Failsafe.with(getRetryPolicy(hint))
-                .with(executor)
+                .with(asyncExecutor)
                 .getStageAsync(
                         () -> {
                             final var future = new CompletableFuture<KeepAliveResponse>();
@@ -147,7 +147,7 @@ final class GrpcRpcProvider implements RpcProvider {
             @NonNull CloseSessionRequest request) {
         final var hint = new AtomicReference<OxiaStatusException>();
         return Failsafe.with(getRetryPolicy(hint))
-                .with(executor)
+                .with(asyncExecutor)
                 .getStageAsync(
                         () -> {
                             final var future = new CompletableFuture<CloseSessionResponse>();
@@ -227,7 +227,7 @@ final class GrpcRpcProvider implements RpcProvider {
                     .getSequenceUpdates(request, new ManagedClientResponseObserver<>(observer));
         } catch (Throwable error) {
             final var translated = OxiaStatusException.toException(error);
-            executor.execute(() -> observer.onError(translated));
+            asyncExecutor.execute(() -> observer.onError(translated));
         }
     }
 

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -15,10 +15,14 @@
  */
 package io.oxia.client.grpc;
 
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import io.github.merlimat.slog.Logger;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.grpc.observer.CancelableStreamObserver;
 import io.oxia.client.grpc.observer.ManagedClientResponseObserver;
+import io.oxia.client.grpc.observer.ManagedObservers;
 import io.oxia.client.grpc.observer.ManagedStreamObserver;
 import io.oxia.proto.CloseSessionRequest;
 import io.oxia.proto.CloseSessionResponse;
@@ -43,10 +47,13 @@ import io.oxia.proto.WriteResponse;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongFunction;
 import lombok.NonNull;
 
 final class GrpcRpcProvider implements RpcProvider {
+    private static final Logger log = Logger.get(GrpcRpcProvider.class);
+
     private final ClientConfig clientConfig;
     private final ConnectionManager connectionManager;
     private final ScheduledExecutorService executor;
@@ -97,82 +104,63 @@ final class GrpcRpcProvider implements RpcProvider {
     @Override
     public CompletableFuture<CreateSessionResponse> createSession(
             @NonNull CreateSessionRequest request) {
-        final CompletableFuture<CreateSessionResponse> future = new CompletableFuture<>();
-        try {
-            connectionManager
-                    .getConnection(shardLeaderProvider.apply(request.getShard()))
-                    .stub()
-                    .createSession(
-                            request,
-                            new StreamObserver<>() {
-                                private CreateSessionResponse response;
-
-                                @Override
-                                public void onNext(@NonNull CreateSessionResponse response) {
-                                    this.response = response;
-                                }
-
-                                @Override
-                                public void onError(@NonNull Throwable error) {
-                                    future.completeExceptionally(OxiaStatusException.toException(error));
-                                }
-
-                                @Override
-                                public void onCompleted() {
-                                    future.complete(response);
-                                }
-                            });
-        } catch (Throwable error) {
-            future.completeExceptionally(OxiaStatusException.toException(error));
-        }
-        return future;
+        final var hint = new AtomicReference<OxiaStatusException>();
+        return Failsafe.with(getRetryPolicy(hint))
+                .with(executor)
+                .getStageAsync(
+                        () -> {
+                            final var future = new CompletableFuture<CreateSessionResponse>();
+                            try {
+                                connectionManager
+                                        .getConnection(getLeader(request.getShard(), hint))
+                                        .stub()
+                                        .createSession(request, ManagedObservers.toCompletableFuture(future));
+                            } catch (Throwable error) {
+                                future.completeExceptionally(OxiaStatusException.toException(error));
+                            }
+                            return future;
+                        });
     }
 
     @Override
-    public void keepAlive(
-            @NonNull SessionHeartbeat heartbeat, @NonNull StreamObserver<KeepAliveResponse> observer) {
-        try {
-            connectionManager
-                    .getConnection(shardLeaderProvider.apply(heartbeat.getShard()))
-                    .stub()
-                    .keepAlive(heartbeat, new ManagedStreamObserver<>(observer));
-        } catch (Throwable error) {
-            observer.onError(OxiaStatusException.toException(error));
-        }
+    public CompletableFuture<KeepAliveResponse> keepAlive(@NonNull SessionHeartbeat heartbeat) {
+        final var hint = new AtomicReference<OxiaStatusException>();
+        return Failsafe.with(getRetryPolicy(hint))
+                .with(executor)
+                .getStageAsync(
+                        () -> {
+                            final var future = new CompletableFuture<KeepAliveResponse>();
+                            try {
+                                connectionManager
+                                        .getConnection(getLeader(heartbeat.getShard(), hint))
+                                        .stub()
+                                        .keepAlive(heartbeat, ManagedObservers.toCompletableFuture(future));
+                            } catch (Throwable error) {
+                                future.completeExceptionally(OxiaStatusException.toException(error));
+                            }
+                            return future;
+                        });
     }
 
     @Override
     public CompletableFuture<CloseSessionResponse> closeSession(
             @NonNull CloseSessionRequest request) {
-        final CompletableFuture<CloseSessionResponse> future = new CompletableFuture<>();
-        try {
-            connectionManager
-                    .getConnection(shardLeaderProvider.apply(request.getShard()))
-                    .stub()
-                    .closeSession(
-                            request,
-                            new StreamObserver<>() {
-                                private CloseSessionResponse response;
-
-                                @Override
-                                public void onNext(@NonNull CloseSessionResponse response) {
-                                    this.response = response;
-                                }
-
-                                @Override
-                                public void onError(@NonNull Throwable error) {
-                                    future.completeExceptionally(OxiaStatusException.toException(error));
-                                }
-
-                                @Override
-                                public void onCompleted() {
-                                    future.complete(response);
-                                }
-                            });
-        } catch (Throwable error) {
-            future.completeExceptionally(OxiaStatusException.toException(error));
-        }
-        return future;
+        final var hint = new AtomicReference<OxiaStatusException>();
+        return Failsafe.with(getRetryPolicy(hint))
+                .with(executor)
+                .getStageAsync(
+                        () -> {
+                            final var future = new CompletableFuture<CloseSessionResponse>();
+                            try {
+                                connectionManager
+                                        .getConnection(getLeader(request.getShard(), hint))
+                                        .stub()
+                                        .closeSession(request, ManagedObservers.toCompletableFuture(future));
+                            } catch (Throwable error) {
+                                future.completeExceptionally(OxiaStatusException.toException(error));
+                            }
+                            return future;
+                        });
     }
 
     @Override
@@ -250,5 +238,37 @@ final class GrpcRpcProvider implements RpcProvider {
         } finally {
             connectionManager.close();
         }
+    }
+
+    private String getLeader(long shardId, @NonNull AtomicReference<OxiaStatusException> hint) {
+        final var retryHint = hint.get();
+        return retryHint == null
+                ? shardLeaderProvider.apply(shardId)
+                : retryHint.getLeaderHint(shardId).orElseGet(() -> shardLeaderProvider.apply(shardId));
+    }
+
+    private <T> RetryPolicy<T> getRetryPolicy(@NonNull AtomicReference<OxiaStatusException> hint) {
+        return RetryPolicy.<T>builder()
+                .handleIf(
+                        error -> {
+                            final var translated = OxiaStatusException.toException(error);
+                            if (translated instanceof OxiaStatusException oxiaError) {
+                                hint.set(oxiaError);
+                            }
+                            return OxiaStatusException.isRetryable(translated);
+                        })
+                .withBackoff(
+                        clientConfig.connectionBackoffMinDelay(), clientConfig.connectionBackoffMaxDelay())
+                .onRetryScheduled(
+                        event ->
+                                log.warn()
+                                        .exceptionMessage(OxiaStatusException.toException(event.getLastException()))
+                                        .log(
+                                                "Retrying RPC operation after "
+                                                        + event.getDelay()
+                                                        + ". attempt="
+                                                        + (event.getAttemptCount() + 1)))
+                .withMaxAttempts(-1)
+                .build();
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
@@ -22,6 +22,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.ErrorInfo;
 import io.grpc.protobuf.StatusProto;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import lombok.Getter;
@@ -57,6 +58,13 @@ public class OxiaStatusException extends RuntimeException {
                     true;
             default -> false;
         };
+    }
+
+    public @NonNull Optional<String> getLeaderHint(long shardId) {
+        if (!Long.toString(shardId).equals(metadata.get("shard"))) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(metadata.get("leader")).filter(leader -> !leader.isEmpty());
     }
 
     public static @NonNull Throwable toException(@NonNull Throwable error) {

--- a/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
@@ -46,9 +46,9 @@ import lombok.NonNull;
 public interface RpcProvider extends AutoCloseable {
     static RpcProvider create(
             @NonNull ClientConfig clientConfig,
-            @NonNull ScheduledExecutorService executor,
+            @NonNull ScheduledExecutorService asyncExecutor,
             @NonNull LongFunction<String> shardLeaderProvider) {
-        return new GrpcRpcProvider(clientConfig, executor, shardLeaderProvider);
+        return new GrpcRpcProvider(clientConfig, asyncExecutor, shardLeaderProvider);
     }
 
     void getShardAssignments(

--- a/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
@@ -59,8 +59,7 @@ public interface RpcProvider extends AutoCloseable {
 
     CompletableFuture<CreateSessionResponse> createSession(@NonNull CreateSessionRequest request);
 
-    void keepAlive(
-            @NonNull SessionHeartbeat heartbeat, @NonNull StreamObserver<KeepAliveResponse> observer);
+    CompletableFuture<KeepAliveResponse> keepAlive(@NonNull SessionHeartbeat heartbeat);
 
     CompletableFuture<CloseSessionResponse> closeSession(@NonNull CloseSessionRequest request);
 

--- a/client/src/main/java/io/oxia/client/grpc/observer/ManagedObservers.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/ManagedObservers.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc.observer;
+
+import io.grpc.stub.StreamObserver;
+import io.oxia.client.grpc.OxiaStatusException;
+import java.util.concurrent.CompletableFuture;
+import lombok.NonNull;
+
+public final class ManagedObservers {
+    private ManagedObservers() {}
+
+    public static <T> StreamObserver<T> toCompletableFuture(@NonNull CompletableFuture<T> future) {
+        return new StreamObserver<>() {
+            private T response;
+
+            @Override
+            public void onNext(@NonNull T response) {
+                this.response = response;
+            }
+
+            @Override
+            public void onError(@NonNull Throwable error) {
+                future.completeExceptionally(OxiaStatusException.toException(error));
+            }
+
+            @Override
+            public void onCompleted() {
+                future.complete(response);
+            }
+        };
+    }
+}

--- a/client/src/main/java/io/oxia/client/session/Session.java
+++ b/client/src/main/java/io/oxia/client/session/Session.java
@@ -21,15 +21,14 @@ import static lombok.AccessLevel.PUBLIC;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import io.github.merlimat.slog.Logger;
-import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.common.Attributes;
 import io.oxia.client.ClientConfig;
+import io.oxia.client.grpc.OxiaStatusException;
 import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.metrics.Counter;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.client.metrics.Unit;
 import io.oxia.proto.CloseSessionRequest;
-import io.oxia.proto.KeepAliveResponse;
 import io.oxia.proto.SessionHeartbeat;
 import java.time.Duration;
 import java.time.Instant;
@@ -40,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.NonNull;
 
-public class Session implements StreamObserver<KeepAliveResponse> {
+public class Session {
 
     private final @NonNull Logger log;
 
@@ -55,20 +54,12 @@ public class Session implements StreamObserver<KeepAliveResponse> {
     @Getter(PUBLIC)
     private final long sessionId;
 
-    private final String clientIdentifier;
-
     private final @NonNull SessionHeartbeat heartbeat;
-
     private final @NonNull SessionNotificationListener listener;
-
-    private volatile boolean closed;
-
-    private Counter sessionsOpened;
-    private Counter sessionsExpired;
-    private Counter sessionsClosed;
-
+    private final Counter sessionsOpened;
+    private final Counter sessionsExpired;
+    private final Counter sessionsClosed;
     private final ScheduledFuture<?> heartbeatFuture;
-
     private volatile Instant lastSuccessfullResponse;
 
     Session(
@@ -86,7 +77,6 @@ public class Session implements StreamObserver<KeepAliveResponse> {
                         Math.max(config.sessionTimeout().toMillis() / 10, Duration.ofSeconds(2).toMillis()));
         this.shardId = shardId;
         this.sessionId = sessionId;
-        this.clientIdentifier = config.clientIdentifier();
         this.heartbeat = new SessionHeartbeat();
         this.heartbeat.setShard(shardId).setSessionId(sessionId);
         this.listener = listener;
@@ -124,52 +114,41 @@ public class Session implements StreamObserver<KeepAliveResponse> {
         this.lastSuccessfullResponse = Instant.now();
         this.heartbeatFuture =
                 executor.scheduleAtFixedRate(
-                        () -> {
-                            // we should catch exception to avoid the schedule future complete
-                            try {
-                                sendKeepAlive();
-                            } catch (Throwable ex) {
-                                log.warn()
-                                        .exception(Throwables.getRootCause(ex))
-                                        .log("receive error when send keep-alive request");
-                            }
-                        },
+                        this::sendKeepAlive,
                         heartbeatInterval.toMillis(),
                         heartbeatInterval.toMillis(),
                         TimeUnit.MILLISECONDS);
     }
 
     private void sendKeepAlive() {
-        Duration diff = Duration.between(lastSuccessfullResponse, Instant.now());
+        try {
+            Duration diff = Duration.between(lastSuccessfullResponse, Instant.now());
+            if (diff.toMillis() > sessionTimeout.toMillis()) {
+                sessionsExpired.increment();
+                log.warn("Session expired");
+                close();
+                return;
+            }
 
-        if (diff.toMillis() > sessionTimeout.toMillis()) {
-            handleSessionExpired();
-            return;
+            rpcProvider
+                    .keepAlive(heartbeat)
+                    .thenRun(
+                            () -> {
+                                lastSuccessfullResponse = Instant.now();
+                                log.debug("Received keep-alive response");
+                            })
+                    .exceptionally(
+                            error -> {
+                                log.warn()
+                                        .exceptionMessage(OxiaStatusException.toException(error))
+                                        .log("Error during session keep-alive");
+                                return null;
+                            });
+        } catch (Throwable ex) {
+            log.warn()
+                    .exception(Throwables.getRootCause(ex))
+                    .log("receive error when send keep-alive request");
         }
-
-        rpcProvider.keepAlive(heartbeat, this);
-    }
-
-    @Override
-    public void onNext(KeepAliveResponse value) {
-        lastSuccessfullResponse = Instant.now();
-        log.debug("Received keep-alive response");
-    }
-
-    @Override
-    public void onError(Throwable t) {
-        log.warn().exceptionMessage(t).log("Error during session keep-alive");
-    }
-
-    @Override
-    public void onCompleted() {
-        // Nothing to do
-    }
-
-    private void handleSessionExpired() {
-        sessionsExpired.increment();
-        log.warn("Session expired");
-        close();
     }
 
     public CompletableFuture<Void> close() {

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -18,18 +18,190 @@ package io.oxia.client.grpc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import com.google.protobuf.Any;
+import com.google.rpc.ErrorInfo;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.protobuf.StatusProto;
+import io.grpc.stub.StreamObserver;
 import io.oxia.client.OxiaClientBuilderImpl;
 import io.oxia.client.api.OxiaClientBuilder;
 import io.oxia.client.grpc.observer.CancelableStreamObserver;
 import io.oxia.client.shard.NoShardAvailableException;
+import io.oxia.proto.CloseSessionRequest;
+import io.oxia.proto.CloseSessionResponse;
+import io.oxia.proto.CreateSessionRequest;
+import io.oxia.proto.CreateSessionResponse;
 import io.oxia.proto.GetSequenceUpdatesRequest;
 import io.oxia.proto.GetSequenceUpdatesResponse;
+import io.oxia.proto.KeepAliveResponse;
+import io.oxia.proto.OxiaClientGrpc;
+import io.oxia.proto.SessionHeartbeat;
+import java.time.Duration;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
 import org.junit.jupiter.api.Test;
 
 class GrpcRpcProviderTest {
+    @Test
+    void keepAliveRetriesWithLeaderHint() throws Exception {
+        var leaderServerRequests = new AtomicReference<SessionHeartbeat>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void keepAlive(
+                            SessionHeartbeat request, StreamObserver<KeepAliveResponse> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(new KeepAliveResponse());
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var firstServerRequests = new AtomicReference<SessionHeartbeat>();
+        var staleLeaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void keepAlive(
+                            SessionHeartbeat request, StreamObserver<KeepAliveResponse> responseObserver) {
+                        firstServerRequests.set(request);
+                        responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                    }
+                };
+        Server staleLeaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(staleLeaderService).build().start();
+        var staleLeaderAddress = "localhost:" + staleLeaderServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(staleLeaderAddress)
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> staleLeaderAddress)) {
+            var request = new SessionHeartbeat();
+            request.setShard(1);
+
+            provider.keepAlive(request).get(5, TimeUnit.SECONDS);
+
+            assertThat(firstServerRequests.get()).isNotNull();
+            assertThat(leaderServerRequests.get()).isNotNull();
+        } finally {
+            executor.shutdownNow();
+            staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void closeSessionRetriesWithLeaderHint() throws Exception {
+        var leaderServerRequests = new AtomicReference<CloseSessionRequest>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void closeSession(
+                            CloseSessionRequest request, StreamObserver<CloseSessionResponse> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(new CloseSessionResponse());
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var firstServerRequests = new AtomicReference<CloseSessionRequest>();
+        var staleLeaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void closeSession(
+                            CloseSessionRequest request, StreamObserver<CloseSessionResponse> responseObserver) {
+                        firstServerRequests.set(request);
+                        responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                    }
+                };
+        Server staleLeaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(staleLeaderService).build().start();
+        var staleLeaderAddress = "localhost:" + staleLeaderServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(staleLeaderAddress)
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> staleLeaderAddress)) {
+            var request = new CloseSessionRequest();
+            request.setShard(1);
+
+            provider.closeSession(request).get(5, TimeUnit.SECONDS);
+
+            assertThat(firstServerRequests.get()).isNotNull();
+            assertThat(leaderServerRequests.get()).isNotNull();
+        } finally {
+            executor.shutdownNow();
+            staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void createSessionRetriesWithLeaderHint() throws Exception {
+        var leaderServerRequests = new AtomicReference<CreateSessionRequest>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void createSession(
+                            CreateSessionRequest request,
+                            io.grpc.stub.StreamObserver<CreateSessionResponse> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(new CreateSessionResponse().setSessionId(1));
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var firstServerRequests = new AtomicReference<CreateSessionRequest>();
+        var staleLeaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void createSession(
+                            CreateSessionRequest request,
+                            io.grpc.stub.StreamObserver<CreateSessionResponse> responseObserver) {
+                        firstServerRequests.set(request);
+                        responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                    }
+                };
+        Server staleLeaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(staleLeaderService).build().start();
+        var staleLeaderAddress = "localhost:" + staleLeaderServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(staleLeaderAddress)
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> staleLeaderAddress)) {
+            var request = new CreateSessionRequest();
+            request.setShard(1);
+
+            var response = provider.createSession(request).get(5, TimeUnit.SECONDS);
+
+            assertThat(response.getSessionId()).isEqualTo(1);
+            assertThat(firstServerRequests.get()).isNotNull();
+            assertThat(leaderServerRequests.get()).isNotNull();
+        } finally {
+            executor.shutdownNow();
+            staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
     @Test
     void getSequenceUpdatesReportsLookupFailure() throws Exception {
         var executor = Executors.newSingleThreadScheduledExecutor();
@@ -68,5 +240,22 @@ class GrpcRpcProviderTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    private static Throwable retryableErrorWithLeaderHint(String leaderAddress) {
+        var grpcStatus =
+                com.google.rpc.Status.newBuilder()
+                        .setCode(Status.Code.ABORTED.value())
+                        .setMessage("oxia: node is not leader")
+                        .addDetails(
+                                Any.pack(
+                                        ErrorInfo.newBuilder()
+                                                .setDomain("oxia.io")
+                                                .setReason("NODE_IS_NOT_LEADER")
+                                                .putMetadata("shard", "1")
+                                                .putMetadata("leader", leaderAddress)
+                                                .build()))
+                        .build();
+        return StatusProto.toStatusRuntimeException(grpcStatus);
     }
 }

--- a/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
@@ -39,6 +39,8 @@ class OxiaStatusExceptionTest {
         assertThat(oxiaError.getMetadata())
                 .containsEntry("shard", "1")
                 .containsEntry("leader", "server-1");
+        assertThat(oxiaError.getLeaderHint(1)).contains("server-1");
+        assertThat(oxiaError.getLeaderHint(2)).isEmpty();
         assertThat(oxiaError).hasMessage("oxia: namespace not found");
         assertThat(OxiaStatusException.isNamespaceNotFound(error)).isTrue();
         assertThat(oxiaError.isRetryable()).isFalse();

--- a/client/src/test/java/io/oxia/client/grpc/RpcProviderIT.java
+++ b/client/src/test/java/io/oxia/client/grpc/RpcProviderIT.java
@@ -17,6 +17,7 @@ package io.oxia.client.grpc;
 
 import io.oxia.client.OxiaClientBuilderImpl;
 import io.oxia.client.api.OxiaClientBuilder;
+import io.oxia.client.it.OxiaImages;
 import io.oxia.testcontainers.OxiaContainer;
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -32,7 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class RpcProviderIT {
     @Container
     private static final OxiaContainer oxia =
-            new OxiaContainer(OxiaContainer.DEFAULT_IMAGE_NAME, 4, true)
+            new OxiaContainer(OxiaImages.OXIA, 4, true)
                     .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(RpcProviderIT.class)));
 
     @Test

--- a/client/src/test/java/io/oxia/client/it/ClientReconnectIT.java
+++ b/client/src/test/java/io/oxia/client/it/ClientReconnectIT.java
@@ -34,7 +34,7 @@ class ClientReconnectIT {
 
     @Container
     private static final OxiaContainer oxia =
-            new OxiaContainer(OxiaContainer.DEFAULT_IMAGE_NAME, 4, true)
+            new OxiaContainer(OxiaImages.OXIA, 4, true)
                     .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(ClientReconnectIT.class)));
 
     @Test

--- a/client/src/test/java/io/oxia/client/it/NotificationIt.java
+++ b/client/src/test/java/io/oxia/client/it/NotificationIt.java
@@ -45,7 +45,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class NotificationIt {
     @Container
     private static final OxiaContainer oxia =
-            new OxiaContainer(OxiaContainer.DEFAULT_IMAGE_NAME)
+            new OxiaContainer(OxiaImages.OXIA)
                     .withImagePullPolicy(PullPolicy.alwaysPull())
                     .withShards(10)
                     .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(NotificationIt.class)));

--- a/client/src/test/java/io/oxia/client/it/OxiaClientFailFastIT.java
+++ b/client/src/test/java/io/oxia/client/it/OxiaClientFailFastIT.java
@@ -32,7 +32,7 @@ class OxiaClientFailFastIT {
 
     @Container
     private static final OxiaContainer oxia =
-            new OxiaContainer(OxiaContainer.DEFAULT_IMAGE_NAME)
+            new OxiaContainer(OxiaImages.OXIA)
                     .withShards(4)
                     .withLogConsumer(
                             new Slf4jLogConsumer(LoggerFactory.getLogger(OxiaClientFailFastIT.class)));

--- a/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
+++ b/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
@@ -84,7 +84,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class OxiaClientIT {
     @Container
     private static final OxiaContainer oxia =
-            new OxiaContainer(OxiaContainer.DEFAULT_IMAGE_NAME)
+            new OxiaContainer(OxiaImages.OXIA)
                     .withShards(10)
                     .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(OxiaClientIT.class)));
 

--- a/client/src/test/java/io/oxia/client/it/OxiaImages.java
+++ b/client/src/test/java/io/oxia/client/it/OxiaImages.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.it;
+
+import org.testcontainers.utility.DockerImageName;
+
+public final class OxiaImages {
+    public static final DockerImageName OXIA = DockerImageName.parse("oxia/oxia:0.16.3");
+
+    private OxiaImages() {}
+}

--- a/client/src/test/java/io/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionTest.java
@@ -28,6 +28,7 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.grpc.RpcProvider;
+import io.oxia.client.grpc.observer.ManagedObservers;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.proto.CloseSessionRequest;
 import io.oxia.proto.CloseSessionResponse;
@@ -96,13 +97,14 @@ class SessionTest {
 
         rpcProvider = mock(RpcProvider.class);
         lenient()
-                .doAnswer(
+                .when(rpcProvider.keepAlive(any(SessionHeartbeat.class)))
+                .thenAnswer(
                         invocation -> {
-                            async.keepAlive(invocation.getArgument(0), invocation.getArgument(1));
-                            return null;
-                        })
-                .when(rpcProvider)
-                .keepAlive(any(SessionHeartbeat.class), any(StreamObserver.class));
+                            var future = new CompletableFuture<KeepAliveResponse>();
+                            async.keepAlive(
+                                    invocation.getArgument(0), ManagedObservers.toCompletableFuture(future));
+                            return future;
+                        });
         lenient()
                 .when(rpcProvider.closeSession(any(CloseSessionRequest.class)))
                 .thenAnswer(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ byte-buddy = "1.15.10"
 commons-compress = "1.26.0"
 commons-lang3 = "3.19.0"
 caffeine = "3.1.4"
+failsafe = "3.3.2"
 protobuf-java = "4.34.0"
 proto-google-common-protos = "2.59.2"
 jackson = "2.21.1"
@@ -67,6 +68,7 @@ netty-buffer = { module = "io.netty:netty-buffer", version.ref = "netty" }
 
 # Client dependencies
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
+failsafe = { module = "dev.failsafe:failsafe", version.ref = "failsafe" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation" }
 zero-allocation-hashing = { module = "net.openhft:zero-allocation-hashing", version.ref = "zero-allocation-hashing" }
 


### PR DESCRIPTION
## Motivation
- Retry transient Oxia RPC errors for unary session operations.
- Use leader hints from Oxia status metadata to route retries to the correct leader when available.

## Modifications
- Add Failsafe-based retry for createSession, keepAlive, and closeSession.
- Change keepAlive to return a CompletableFuture and update session handling accordingly.
- Add ManagedObservers.toCompletableFuture for unary callback bridging.
- Add leader-hint extraction on OxiaStatusException and retry logging.
- Add tests for retrying createSession, keepAlive, and closeSession with leader hints.

## Testing
- ./gradlew :client:spotlessApply :client:compileJava :client:compileTestJava :client:test --tests io.oxia.client.session.SessionTest --tests io.oxia.client.grpc.GrpcRpcProviderTest --tests io.oxia.client.grpc.OxiaStatusExceptionTest
- ./gradlew :client:test --tests io.oxia.client.it.OxiaClientIT.testMaximumSize
- ./gradlew :client:spotlessCheck :client:test

Note: The first full :client:test run had a one-off failure in OxiaClientIT.testMaximumSize; that test passed when rerun, and the full suite passed on the next run.