### PR TITLE
fix: retry shard assignment initialization

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -81,13 +81,32 @@ final class GrpcRpcProvider implements RpcProvider {
     public void getShardAssignments(
             @NonNull ShardAssignmentsRequest request,
             @NonNull StreamObserver<ShardAssignments> observer) {
+        final var guardedObserver = ManagedObservers.toGuardedStreamObserver(observer);
         try {
-            connectionManager
-                    .getConnection(clientConfig.serviceAddress())
-                    .stub()
-                    .getShardAssignments(request, new ManagedStreamObserver<>(observer));
+            Failsafe.with(getRetryPolicy(null))
+                    .with(asyncExecutor)
+                    .getStageAsync(
+                            () -> {
+                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierObserver =
+                                        ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
+                                try {
+                                    connectionManager
+                                            .getConnection(clientConfig.serviceAddress())
+                                            .stub()
+                                            .getShardAssignments(request, barrierObserver);
+                                } catch (Throwable error) {
+                                    barrierFuture.completeExceptionally(OxiaStatusException.toException(error));
+                                }
+                                return barrierFuture;
+                            })
+                    .exceptionally(
+                            error -> {
+                                guardedObserver.onError(OxiaStatusException.toException(error));
+                                return null;
+                            });
         } catch (Throwable error) {
-            observer.onError(OxiaStatusException.toException(error));
+            guardedObserver.onError(OxiaStatusException.toException(error));
         }
     }
 
@@ -252,12 +271,12 @@ final class GrpcRpcProvider implements RpcProvider {
                 : retryHint.getLeaderHint(shardId).orElseGet(() -> shardLeaderProvider.apply(shardId));
     }
 
-    private <T> RetryPolicy<T> getRetryPolicy(@NonNull AtomicReference<OxiaStatusException> hint) {
+    private <T> RetryPolicy<T> getRetryPolicy(AtomicReference<OxiaStatusException> hint) {
         return RetryPolicy.<T>builder()
                 .handleIf(
                         error -> {
                             final var translated = OxiaStatusException.toException(error);
-                            if (translated instanceof OxiaStatusException oxiaError) {
+                            if (hint != null && translated instanceof OxiaStatusException oxiaError) {
                                 hint.set(oxiaError);
                             }
                             return OxiaStatusException.isRetryable(translated);

--- a/client/src/main/java/io/oxia/client/grpc/observer/ManagedObservers.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/ManagedObservers.java
@@ -18,6 +18,7 @@ package io.oxia.client.grpc.observer;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.grpc.OxiaStatusException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.NonNull;
 
 public final class ManagedObservers {
@@ -42,5 +43,76 @@ public final class ManagedObservers {
                 future.complete(response);
             }
         };
+    }
+
+    public static <T> GuardedStreamObserver<T> toGuardedStreamObserver(
+            @NonNull StreamObserver<T> streamObserver) {
+        return new GuardedStreamObserver<>(streamObserver);
+    }
+
+    public static <T> BarrierStreamObserver<T> toBarrierStreamObserver(
+            @NonNull StreamObserver<T> streamObserver, @NonNull CompletableFuture<Void> barrierFuture) {
+        return new BarrierStreamObserver<>(streamObserver, barrierFuture);
+    }
+
+    public static final class GuardedStreamObserver<T> implements StreamObserver<T> {
+        private final StreamObserver<T> streamObserver;
+        private final AtomicBoolean terminated = new AtomicBoolean();
+
+        private GuardedStreamObserver(@NonNull StreamObserver<T> streamObserver) {
+            this.streamObserver = streamObserver;
+        }
+
+        @Override
+        public void onNext(@NonNull T response) {
+            streamObserver.onNext(response);
+        }
+
+        @Override
+        public void onError(@NonNull Throwable error) {
+            if (terminated.compareAndSet(false, true)) {
+                streamObserver.onError(OxiaStatusException.toException(error));
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            if (terminated.compareAndSet(false, true)) {
+                streamObserver.onCompleted();
+            }
+        }
+    }
+
+    public static final class BarrierStreamObserver<T> implements StreamObserver<T> {
+        private final StreamObserver<T> streamObserver;
+        private final CompletableFuture<Void> barrierFuture;
+
+        private BarrierStreamObserver(
+                @NonNull StreamObserver<T> streamObserver, @NonNull CompletableFuture<Void> barrierFuture) {
+            this.streamObserver = streamObserver;
+            this.barrierFuture = barrierFuture;
+        }
+
+        @Override
+        public void onNext(@NonNull T response) {
+            barrierFuture.complete(null);
+            streamObserver.onNext(response);
+        }
+
+        @Override
+        public void onError(@NonNull Throwable error) {
+            final var translated = OxiaStatusException.toException(error);
+            if (!barrierFuture.isDone()) {
+                barrierFuture.completeExceptionally(translated);
+                return;
+            }
+            streamObserver.onError(translated);
+        }
+
+        @Override
+        public void onCompleted() {
+            barrierFuture.complete(null);
+            streamObserver.onCompleted();
+        }
     }
 }

--- a/client/src/main/java/io/oxia/client/shard/ShardManager.java
+++ b/client/src/main/java/io/oxia/client/shard/ShardManager.java
@@ -50,32 +50,31 @@ import lombok.NonNull;
 
 public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignments> {
 
-    private static final Logger LOG = Logger.get(ShardManager.class);
     private final Logger log;
-    private final ScheduledExecutorService executor;
+    private final ScheduledExecutorService asyncExecutor;
     private final RpcProvider rpcProvider;
-    private final @NonNull ShardAssignmentsContainer assignments;
-    private final @NonNull CompositeConsumer<ShardAssignmentChanges> callbacks;
+    private final ShardAssignmentsContainer assignments;
+    private final CompositeConsumer<ShardAssignmentChanges> callbacks;
+
+    private final Backoff backoff = new Backoff();
+    private final CompletableFuture<Void> initialAssignmentsFuture;
+
+    private volatile boolean closed;
 
     private final Counter shardAssignmentsEvents;
 
-    private final Backoff backoff = new Backoff();
-    private volatile boolean closed;
-
-    private final CompletableFuture<Void> initialAssignmentsFuture = new CompletableFuture<>();
-
-    @VisibleForTesting
-    ShardManager(
-            @NonNull ScheduledExecutorService executor,
+    public ShardManager(
+            @NonNull ScheduledExecutorService asyncExecutor,
             @NonNull RpcProvider rpcProvider,
-            @NonNull ShardAssignmentsContainer assignments,
-            @NonNull CompositeConsumer<ShardAssignmentChanges> callbacks,
-            @NonNull InstrumentProvider instrumentProvider) {
+            @NonNull InstrumentProvider instrumentProvider,
+            @NonNull String namespace) {
         this.rpcProvider = rpcProvider;
-        this.executor = executor;
-        this.assignments = assignments;
-        this.callbacks = callbacks;
-        this.log = LOG.with().attr("namespace", assignments.getNamespace()).build();
+        this.asyncExecutor = asyncExecutor;
+        this.assignments = new ShardAssignmentsContainer(Xxh332HashRangeShardStrategy, namespace);
+        this.callbacks = new CompositeConsumer<>();
+        this.initialAssignmentsFuture = new CompletableFuture<>();
+        this.log =
+                Logger.get(ShardManager.class).with().attr("namespace", assignments.getNamespace()).build();
 
         this.shardAssignmentsEvents =
                 instrumentProvider.newCounter(
@@ -83,19 +82,6 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
                         Unit.None,
                         "The total count of received shard assignment events",
                         Attributes.empty());
-    }
-
-    public ShardManager(
-            @NonNull ScheduledExecutorService executor,
-            @NonNull RpcProvider rpcProvider,
-            @NonNull InstrumentProvider instrumentProvider,
-            @NonNull String namespace) {
-        this(
-                executor,
-                rpcProvider,
-                new ShardAssignmentsContainer(Xxh332HashRangeShardStrategy, namespace),
-                new CompositeConsumer<>(),
-                instrumentProvider);
     }
 
     @Override
@@ -135,8 +121,8 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
                 return;
             }
         }
-        log.warn().exception(getRootCause(error)).log("Failed receiving shard assignments");
-        executor.schedule(
+        log.warn().exceptionMessage(getRootCause(error)).log("Failed receiving shard assignments");
+        asyncExecutor.schedule(
                 () -> {
                     if (!closed) {
                         log.info("Retry creating stream for shard assignments");
@@ -154,7 +140,7 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
         }
 
         log.warn("Stream closed while receiving shard assignments");
-        executor.schedule(
+        asyncExecutor.schedule(
                 () -> {
                     if (!closed) {
                         log.info("Retry creating stream for shard assignments after stream closed");
@@ -193,18 +179,16 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
     static Map<Long, Shard> recomputeShardHashBoundaries(
             Map<Long, Shard> assignments, Set<Shard> updates) {
         var toDelete = new ArrayList<>();
-        updates.forEach(
-                update ->
-                        update
-                                .findOverlapping(assignments.values())
-                                .forEach(
-                                        existing -> {
-                                            LOG.info()
-                                                    .attr("existing", existing)
-                                                    .attr("update", update)
-                                                    .log("Deleting shard as it overlaps");
-                                            toDelete.add(existing.id());
-                                        }));
+        var log = Logger.get(ShardManager.class);
+        for (var update : updates) {
+            for (var existing : update.findOverlapping(assignments.values())) {
+                log.info()
+                        .attr("existing", existing)
+                        .attr("update", update)
+                        .log("Deleting shard as it overlaps");
+                toDelete.add(existing.id());
+            }
+        }
 
         return unmodifiableMap(
                 Stream.concat(

--- a/client/src/test/java/io/oxia/client/shard/ShardManagerGrpcTest.java
+++ b/client/src/test/java/io/oxia/client/shard/ShardManagerGrpcTest.java
@@ -92,11 +92,11 @@ class ShardManagerGrpcTest {
     ManagedChannel channel;
     @Mock RpcProvider rpcProvider;
 
-    ScheduledExecutorService executor;
+    ScheduledExecutorService asyncExecutor;
 
     @BeforeEach
     void beforeEach() throws Exception {
-        executor = Executors.newSingleThreadScheduledExecutor();
+        asyncExecutor = Executors.newSingleThreadScheduledExecutor();
         requests.set(0);
         responses.clear();
         server =
@@ -123,7 +123,7 @@ class ShardManagerGrpcTest {
     void afterEach() throws Exception {
         channel.shutdownNow();
         server.shutdownNow();
-        executor.shutdownNow();
+        asyncExecutor.shutdownNow();
     }
 
     @Test
@@ -132,7 +132,7 @@ class ShardManagerGrpcTest {
         assignments.putNamespaces(DefaultNamespace).addAssignment().copyFrom(assignment(0, 0, 3));
         assertThat(responses.offer(new AssignmentWrapper(assignments, null, false))).isTrue();
         try (var shardManager =
-                new ShardManager(executor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
+                new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
             assertThat(shardManager.start()).succeedsWithin(Duration.ofSeconds(1));
             assertThat(shardManager.allShardIds()).containsExactlyInAnyOrder(0L);
             assertThat(shardManager.leader(0)).isEqualTo("leader0");
@@ -142,7 +142,7 @@ class ShardManagerGrpcTest {
     @Test
     void neverStarts() {
         try (var shardManager =
-                new ShardManager(executor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
+                new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
             assertThatThrownBy(() -> shardManager.start().get(1, SECONDS))
                     .isInstanceOf(TimeoutException.class);
             assertThat(shardManager.allShardIds()).isEmpty();
@@ -161,7 +161,7 @@ class ShardManagerGrpcTest {
                                         false)))
                 .isTrue();
         try (var shardManager =
-                new ShardManager(executor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
+                new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
             assertThatThrownBy(() -> shardManager.start().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(NamespaceNotFoundException.class);
@@ -181,7 +181,7 @@ class ShardManagerGrpcTest {
                                         false)))
                 .isTrue();
         try (var shardManager =
-                new ShardManager(executor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
+                new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
             assertThatThrownBy(() -> shardManager.start().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(NamespaceNotFoundException.class);
@@ -200,7 +200,7 @@ class ShardManagerGrpcTest {
         assertThat(responses.offer(new AssignmentWrapper(assignments0, null, false))).isTrue();
         assertThat(responses.offer(new AssignmentWrapper(assignments1, null, false))).isTrue();
         try (var shardManager =
-                new ShardManager(executor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
+                new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
             shardManager.start().join();
             await()
                     .untilAsserted(
@@ -221,7 +221,7 @@ class ShardManagerGrpcTest {
         assignments.putNamespaces(DefaultNamespace).addAssignment().copyFrom(assignment(0, 0, 3));
         assertThat(responses.offer(new AssignmentWrapper(assignments, null, false))).isTrue();
         try (var shardManager =
-                new ShardManager(executor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
+                new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
             assertThat(shardManager.start()).succeedsWithin(Duration.ofSeconds(1));
             assertThat(shardManager.allShardIds()).containsExactlyInAnyOrder(0L);
             assertThat(shardManager.leader(0)).isEqualTo("leader0");
@@ -236,7 +236,7 @@ class ShardManagerGrpcTest {
         assignments.putNamespaces(DefaultNamespace).addAssignment().copyFrom(assignment(0, 0, 3));
         assertThat(responses.offer(new AssignmentWrapper(assignments, null, false))).isTrue();
         try (var shardManager =
-                new ShardManager(executor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
+                new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
             assertThat(shardManager.start()).succeedsWithin(Duration.ofSeconds(1));
             assertThat(shardManager.allShardIds()).containsExactlyInAnyOrder(0L);
             assertThat(shardManager.leader(0)).isEqualTo("leader0");

--- a/client/src/test/java/io/oxia/client/shard/ShardManagerTest.java
+++ b/client/src/test/java/io/oxia/client/shard/ShardManagerTest.java
@@ -16,7 +16,6 @@
 package io.oxia.client.shard;
 
 import static io.oxia.client.OxiaClientBuilderImpl.DefaultNamespace;
-import static io.oxia.client.shard.HashRangeShardStrategy.Xxh332HashRangeShardStrategy;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,7 +25,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
 import io.grpc.Status;
-import io.oxia.client.CompositeConsumer;
 import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.proto.ShardAssignment;
@@ -46,7 +44,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -135,30 +132,21 @@ public class ShardManagerTest {
     class ManagerTests {
         private final String namespace = "default";
 
-        @Spy
-        ShardAssignmentsContainer assignments =
-                new ShardAssignmentsContainer(Xxh332HashRangeShardStrategy, DefaultNamespace);
-
         @Mock RpcProvider rpcProvider;
         ShardManager manager;
-        ScheduledExecutorService executor;
+        ScheduledExecutorService asyncExecutor;
 
         @BeforeEach
         void mocking() {
-            executor = Executors.newSingleThreadScheduledExecutor();
+            asyncExecutor = Executors.newSingleThreadScheduledExecutor();
 
             manager =
-                    new ShardManager(
-                            executor,
-                            rpcProvider,
-                            assignments,
-                            new CompositeConsumer<>(),
-                            InstrumentProvider.NOOP);
+                    new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace);
         }
 
         @AfterEach
         void cleanup() {
-            executor.shutdownNow();
+            asyncExecutor.shutdownNow();
         }
 
         @Test
@@ -187,12 +175,7 @@ public class ShardManagerTest {
         void refetchesStubWhenRetryingShardAssignmentStream() {
             var stubCalls = new AtomicInteger();
             manager =
-                    new ShardManager(
-                            executor,
-                            rpcProvider,
-                            assignments,
-                            new CompositeConsumer<>(),
-                            InstrumentProvider.NOOP);
+                    new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace);
 
             var assignment = new ShardAssignment();
             assignment.setShard(0).setLeader("leader0");
@@ -227,8 +210,7 @@ public class ShardManagerTest {
 
         @Test
         void getAll() {
-            manager.allShardIds();
-            verify(assignments).allShardIds();
+            assertThat(manager.allShardIds()).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
## Motivation
- `getShardAssignments` should retry transient initialization failures instead of surfacing them immediately to shard assignment startup.
- The initial shard assignment wait should respect the configured request timeout.

## Modifications
- Wrap `getShardAssignments` initialization with Failsafe retry and timeout.
- Add a managed observer helper that completes a barrier future when the shard assignment stream first progresses.
- Simplify `ShardManager` construction and clean up retry scheduling naming/logging.

## Testing
- `./gradlew spotlessApply`
- `./gradlew :client:check`
