### PR TITLE
fix: log health check exception messages

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/Connection.java
+++ b/client/src/main/java/io/oxia/client/grpc/Connection.java
@@ -188,7 +188,7 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
                 }
                 return;
             }
-            log.warn().exception(error).log("Connection health check failed");
+            log.warn().exceptionMessage(error).log("Connection health check failed");
             if (healthCheckFailureCallback != null) {
                 healthCheckFailureCallback.onFailure(this);
             }


### PR DESCRIPTION
## Motivation
- Connection health check failures currently log the full exception object, which can produce noisy stack traces for expected health-check failures.
- The existing structured logger supports logging just the exception message when the stack trace is not needed.

## Modifications
- Log connection health check failures with `exceptionMessage(error)` instead of `exception(error)`.

## Testing
- `./gradlew :client:spotlessJavaCheck :client:compileJava`
