### PR TITLE
fix: retry grpc unavailable errors

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/Connection.java
+++ b/client/src/main/java/io/oxia/client/grpc/Connection.java
@@ -188,7 +188,7 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
                 }
                 return;
             }
-            log.warn().exception(error).log("Connection health check failed");
+            log.warn().exceptionMessage(error).log("Connection health check failed");
             if (healthCheckFailureCallback != null) {
                 healthCheckFailureCallback.onFailure(this);
             }

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -83,7 +83,7 @@ final class GrpcRpcProvider implements RpcProvider {
             @NonNull StreamObserver<ShardAssignments> observer) {
         final var guardedObserver = ManagedObservers.toGuardedStreamObserver(observer);
         try {
-            Failsafe.with(getRetryPolicy(null))
+            Failsafe.with(getRetryPolicy("get shard assignments", null))
                     .with(asyncExecutor)
                     .getStageAsync(
                             () -> {
@@ -127,7 +127,7 @@ final class GrpcRpcProvider implements RpcProvider {
     public CompletableFuture<CreateSessionResponse> createSession(
             @NonNull CreateSessionRequest request) {
         final var hint = new AtomicReference<OxiaStatusException>();
-        return Failsafe.with(getRetryPolicy(hint))
+        return Failsafe.with(getRetryPolicy("create session", hint))
                 .with(asyncExecutor)
                 .getStageAsync(
                         () -> {
@@ -148,7 +148,7 @@ final class GrpcRpcProvider implements RpcProvider {
     public CompletableFuture<KeepAliveResponse> keepAlive(
             @NonNull SessionHeartbeat heartbeat, @NonNull Duration timeout) {
         final var hint = new AtomicReference<OxiaStatusException>();
-        return Failsafe.with(Timeout.of(timeout), getRetryPolicy(hint))
+        return Failsafe.with(Timeout.of(timeout), getRetryPolicy("keep alive", hint))
                 .with(asyncExecutor)
                 .getStageAsync(
                         () -> {
@@ -170,7 +170,7 @@ final class GrpcRpcProvider implements RpcProvider {
     public CompletableFuture<CloseSessionResponse> closeSession(
             @NonNull CloseSessionRequest request) {
         final var hint = new AtomicReference<OxiaStatusException>();
-        return Failsafe.with(getRetryPolicy(hint))
+        return Failsafe.with(getRetryPolicy("close session", hint))
                 .with(asyncExecutor)
                 .getStageAsync(
                         () -> {
@@ -271,7 +271,8 @@ final class GrpcRpcProvider implements RpcProvider {
                 : retryHint.getLeaderHint(shardId).orElseGet(() -> shardLeaderProvider.apply(shardId));
     }
 
-    private <T> RetryPolicy<T> getRetryPolicy(AtomicReference<OxiaStatusException> hint) {
+    private <T> RetryPolicy<T> getRetryPolicy(
+            @NonNull String operation, AtomicReference<OxiaStatusException> hint) {
         return RetryPolicy.<T>builder()
                 .handleIf(
                         error -> {
@@ -288,7 +289,9 @@ final class GrpcRpcProvider implements RpcProvider {
                                 log.warn()
                                         .exceptionMessage(OxiaStatusException.toException(event.getLastException()))
                                         .log(
-                                                "Retrying RPC operation after "
+                                                "Retrying "
+                                                        + operation
+                                                        + " after "
                                                         + event.getDelay()
                                                         + ". attempt="
                                                         + (event.getAttemptCount() + 1)))

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
@@ -87,6 +87,8 @@ public class OxiaStatusException extends RuntimeException {
             com.google.rpc.Status grpcStatus, Throwable cause) {
         OxiaStatusCode statusCode = UNKNOWN;
         Map<String, String> metadata = Map.of();
+
+        // parse from the error info
         for (var detail : grpcStatus.getDetailsList()) {
             if (!detail.is(ErrorInfo.class)) {
                 continue;
@@ -102,6 +104,16 @@ public class OxiaStatusException extends RuntimeException {
             } catch (InvalidProtocolBufferException ignored) {
             }
         }
+        // parse from the grpc standard code
+        if (statusCode == UNKNOWN) {
+            statusCode =
+                    switch (io.grpc.Status.fromCodeValue(grpcStatus.getCode()).getCode()) {
+                        case UNAVAILABLE -> OxiaStatusCode.RESOURCE_UNAVAILABLE;
+                        case ABORTED -> OxiaStatusCode.ABORTED;
+                        default -> UNKNOWN;
+                    };
+        }
+        // parse by the error messages
         if (statusCode == UNKNOWN) {
             statusCode =
                     switch (grpcStatus.getMessage()) {

--- a/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
@@ -158,6 +158,41 @@ class OxiaStatusExceptionTest {
     }
 
     @Test
+    void mapsGrpcUnavailableToRetryableResourceUnavailable() {
+        var error =
+                OxiaStatusException.toException(
+                        Status.UNAVAILABLE.withDescription("connection unavailable").asRuntimeException());
+
+        assertThat(error).isInstanceOf(OxiaStatusException.class);
+        assertThat(((OxiaStatusException) error).getStatusCode())
+                .isEqualTo(OxiaStatusCode.RESOURCE_UNAVAILABLE);
+        assertThat(OxiaStatusException.isRetryable(error)).isTrue();
+    }
+
+    @Test
+    void mapsGrpcAbortedToRetryableAborted() {
+        var error =
+                OxiaStatusException.toException(
+                        Status.ABORTED.withDescription("operation aborted").asRuntimeException());
+
+        assertThat(error).isInstanceOf(OxiaStatusException.class);
+        assertThat(((OxiaStatusException) error).getStatusCode()).isEqualTo(OxiaStatusCode.ABORTED);
+        assertThat(OxiaStatusException.isRetryable(error)).isTrue();
+    }
+
+    @Test
+    void doesNotTreatGrpcDeadlineExceededAsRetryable() {
+        var error = Status.DEADLINE_EXCEEDED.withDescription("deadline exceeded").asRuntimeException();
+
+        var translated = OxiaStatusException.toException(error);
+
+        assertThat(translated).isInstanceOf(OxiaStatusException.class);
+        assertThat(((OxiaStatusException) translated).getStatusCode())
+                .isEqualTo(OxiaStatusCode.UNKNOWN);
+        assertThat(OxiaStatusException.isRetryable(error)).isFalse();
+    }
+
+    @Test
     void returnsNonGrpcError() {
         var error = new IllegalStateException("failed");
 


### PR DESCRIPTION
## Motivation
- Plain gRPC transport failures such as `UNAVAILABLE` were not mapped to retryable Oxia status errors, so retry handling could miss transient network failures.
- Retry warnings did not identify which RPC operation was retrying, making keep-alive/session retry logs harder to diagnose.
- Connection health check failures should log the exception message without noisy stack traces for expected health-check failures.

## Modifications
- Map gRPC `UNAVAILABLE` to `OxiaStatusCode.RESOURCE_UNAVAILABLE` and gRPC `ABORTED` to `OxiaStatusCode.ABORTED` when no Oxia `ErrorInfo` detail is present.
- Keep `DEADLINE_EXCEEDED` as `UNKNOWN` so it does not become retryable by default.
- Include the RPC operation name in retry scheduled logs for shard assignments, session creation, keep-alive, and session close.
- Log connection health check failures with `exceptionMessage(error)` instead of `exception(error)`.

## Testing
- `./gradlew :client:spotlessJavaCheck :client:test --tests io.oxia.client.grpc.OxiaStatusExceptionTest --tests io.oxia.client.grpc.GrpcRpcProviderTest`
- `./gradlew :client:spotlessJavaCheck :client:compileJava`
