### PR TITLE
fix: retry notification stream startup

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -113,13 +113,33 @@ final class GrpcRpcProvider implements RpcProvider {
     @Override
     public void getNotifications(
             @NonNull NotificationsRequest request, @NonNull StreamObserver<NotificationBatch> observer) {
+        final var guardedObserver = ManagedObservers.toGuardedStreamObserver(observer);
+        final var hint = new AtomicReference<OxiaStatusException>();
         try {
-            connectionManager
-                    .getConnection(shardLeaderProvider.apply(request.getShard()))
-                    .stub()
-                    .getNotifications(request, new ManagedStreamObserver<>(observer));
+            Failsafe.with(getRetryPolicy("get notifications", hint))
+                    .with(asyncExecutor)
+                    .getStageAsync(
+                            () -> {
+                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierObserver =
+                                        ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
+                                try {
+                                    connectionManager
+                                            .getConnection(getLeader(request.getShard(), hint))
+                                            .stub()
+                                            .getNotifications(request, barrierObserver);
+                                } catch (Throwable error) {
+                                    barrierFuture.completeExceptionally(OxiaStatusException.toException(error));
+                                }
+                                return barrierFuture;
+                            })
+                    .exceptionally(
+                            error -> {
+                                guardedObserver.onError(OxiaStatusException.toException(error));
+                                return null;
+                            });
         } catch (Throwable error) {
-            observer.onError(OxiaStatusException.toException(error));
+            guardedObserver.onError(OxiaStatusException.toException(error));
         }
     }
 

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -36,6 +36,8 @@ import io.oxia.proto.CreateSessionResponse;
 import io.oxia.proto.GetSequenceUpdatesRequest;
 import io.oxia.proto.GetSequenceUpdatesResponse;
 import io.oxia.proto.KeepAliveResponse;
+import io.oxia.proto.NotificationBatch;
+import io.oxia.proto.NotificationsRequest;
 import io.oxia.proto.OxiaClientGrpc;
 import io.oxia.proto.SessionHeartbeat;
 import java.time.Duration;
@@ -195,6 +197,77 @@ class GrpcRpcProviderTest {
             assertThat(response.getSessionId()).isEqualTo(1);
             assertThat(firstServerRequests.get()).isNotNull();
             assertThat(leaderServerRequests.get()).isNotNull();
+        } finally {
+            executor.shutdownNow();
+            staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void getNotificationsRetriesWithLeaderHint() throws Exception {
+        var leaderServerRequests = new AtomicReference<NotificationsRequest>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void getNotifications(
+                            NotificationsRequest request, StreamObserver<NotificationBatch> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(new NotificationBatch().setOffset(1));
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var firstServerRequests = new AtomicReference<NotificationsRequest>();
+        var staleLeaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void getNotifications(
+                            NotificationsRequest request, StreamObserver<NotificationBatch> responseObserver) {
+                        firstServerRequests.set(request);
+                        responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                    }
+                };
+        Server staleLeaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(staleLeaderService).build().start();
+        var staleLeaderAddress = "localhost:" + staleLeaderServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(staleLeaderAddress)
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> staleLeaderAddress)) {
+            var request = new NotificationsRequest();
+            request.setShard(1);
+            var notification = new AtomicReference<NotificationBatch>();
+
+            provider.getNotifications(
+                    request,
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(NotificationBatch value) {
+                            notification.set(value);
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {}
+
+                        @Override
+                        public void onCompleted() {}
+                    });
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(notification.get()).isNotNull();
+                                assertThat(notification.get().getOffset()).isEqualTo(1);
+                                assertThat(firstServerRequests.get()).isNotNull();
+                                assertThat(leaderServerRequests.get()).isNotNull();
+                            });
         } finally {
             executor.shutdownNow();
             staleLeaderServer.shutdownNow();


### PR DESCRIPTION
## Motivation
- Notification streams should recover from retryable startup failures the same way shard assignment streams do.
- A stale shard leader can reject the initial notification stream before the first batch is delivered, and the client should retry with the leader hint instead of surfacing the error immediately.

## Modifications
- Wrap `getNotifications` in the same guarded observer, barrier observer, and Failsafe retry flow used by `getShardAssignments`.
- Use retry leader hints when reconnecting notification streams before the stream is established.
- Add provider-level coverage for retrying `getNotifications` from a stale leader to the hinted leader.

## Testing
- `./gradlew --no-parallel :client:spotlessJavaCheck :client:test --tests io.oxia.client.grpc.GrpcRpcProviderTest --tests io.oxia.client.notify.ShardNotificationReceiverTest --tests io.oxia.client.grpc.OxiaStatusExceptionTest`
