### PR TITLE
fix: apply deadlines to unary rpcs

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -156,6 +156,8 @@ final class GrpcRpcProvider implements RpcProvider {
                                 connectionManager
                                         .getConnection(getLeader(request.getShard(), hint))
                                         .stub()
+                                        .withDeadlineAfter(
+                                                clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS)
                                         .createSession(request, ManagedObservers.toCompletableFuture(future));
                             } catch (Throwable error) {
                                 future.completeExceptionally(OxiaStatusException.toException(error));
@@ -199,6 +201,8 @@ final class GrpcRpcProvider implements RpcProvider {
                                 connectionManager
                                         .getConnection(getLeader(request.getShard(), hint))
                                         .stub()
+                                        .withDeadlineAfter(
+                                                clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS)
                                         .closeSession(request, ManagedObservers.toCompletableFuture(future));
                             } catch (Throwable error) {
                                 future.completeExceptionally(OxiaStatusException.toException(error));
@@ -213,6 +217,7 @@ final class GrpcRpcProvider implements RpcProvider {
             connectionManager
                     .getConnection(shardLeaderProvider.apply(request.getShard()))
                     .stub()
+                    .withDeadlineAfter(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS)
                     .read(request, new ManagedStreamObserver<>(observer));
         } catch (Throwable error) {
             observer.onError(OxiaStatusException.toException(error));

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -20,6 +20,7 @@ import static org.awaitility.Awaitility.await;
 
 import com.google.protobuf.Any;
 import com.google.rpc.ErrorInfo;
+import io.grpc.Context;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.Status;
@@ -39,6 +40,8 @@ import io.oxia.proto.KeepAliveResponse;
 import io.oxia.proto.NotificationBatch;
 import io.oxia.proto.NotificationsRequest;
 import io.oxia.proto.OxiaClientGrpc;
+import io.oxia.proto.ReadRequest;
+import io.oxia.proto.ReadResponse;
 import io.oxia.proto.SessionHeartbeat;
 import java.time.Duration;
 import java.util.concurrent.Executors;
@@ -272,6 +275,79 @@ class GrpcRpcProviderTest {
             executor.shutdownNow();
             staleLeaderServer.shutdownNow();
             leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void unaryRequestsUseRequestTimeoutDeadline() throws Exception {
+        var createSessionHasDeadline = new AtomicReference<Boolean>();
+        var closeSessionHasDeadline = new AtomicReference<Boolean>();
+        var readHasDeadline = new AtomicReference<Boolean>();
+        var service =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void createSession(
+                            CreateSessionRequest request,
+                            StreamObserver<CreateSessionResponse> responseObserver) {
+                        createSessionHasDeadline.set(Context.current().getDeadline() != null);
+                        responseObserver.onNext(new CreateSessionResponse().setSessionId(1));
+                        responseObserver.onCompleted();
+                    }
+
+                    @Override
+                    public void closeSession(
+                            CloseSessionRequest request, StreamObserver<CloseSessionResponse> responseObserver) {
+                        closeSessionHasDeadline.set(Context.current().getDeadline() != null);
+                        responseObserver.onNext(new CloseSessionResponse());
+                        responseObserver.onCompleted();
+                    }
+
+                    @Override
+                    public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+                        readHasDeadline.set(Context.current().getDeadline() != null);
+                        responseObserver.onNext(new ReadResponse());
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server server = ServerBuilder.forPort(0).directExecutor().addService(service).build().start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofSeconds(5)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.createSession(new CreateSessionRequest().setShard(1)).get(5, TimeUnit.SECONDS);
+            provider.closeSession(new CloseSessionRequest().setShard(1)).get(5, TimeUnit.SECONDS);
+
+            var readResponse = new AtomicReference<ReadResponse>();
+            provider.read(
+                    new ReadRequest().setShard(1),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(ReadResponse value) {
+                            readResponse.set(value);
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {}
+
+                        @Override
+                        public void onCompleted() {}
+                    });
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(readResponse.get()).isNotNull();
+                                assertThat(createSessionHasDeadline.get()).isTrue();
+                                assertThat(closeSessionHasDeadline.get()).isTrue();
+                                assertThat(readHasDeadline.get()).isTrue();
+                            });
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
         }
     }
 


### PR DESCRIPTION
## Motivation
- Client-side `CompletableFuture` timeouts do not propagate cancellation to the underlying gRPC call.
- Unary RPC attempts should carry the configured request timeout as a gRPC deadline so the channel and server can stop work when the request expires.

## Modifications
- Add `withDeadlineAfter(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS)` to `createSession`, `closeSession`, and `read` RPC calls.
- Keep the existing explicit keep-alive deadline unchanged.
- Leave streaming RPCs unchanged to avoid cancelling valid long-lived streams.
- Add provider-level coverage that create session, close session, and read requests arrive with a server-visible gRPC deadline.

## Testing
- `./gradlew --no-parallel :client:spotlessJavaCheck :client:test --tests io.oxia.client.grpc.GrpcRpcProviderTest`
