### PR TITLE
fix: retry grpc provider shard RPCs

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -22,9 +22,7 @@ import io.github.merlimat.slog.Logger;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.grpc.observer.CancelableStreamObserver;
-import io.oxia.client.grpc.observer.ManagedClientResponseObserver;
 import io.oxia.client.grpc.observer.ManagedObservers;
-import io.oxia.client.grpc.observer.ManagedStreamObserver;
 import io.oxia.proto.CloseSessionRequest;
 import io.oxia.proto.CloseSessionResponse;
 import io.oxia.proto.CreateSessionRequest;
@@ -213,14 +211,33 @@ final class GrpcRpcProvider implements RpcProvider {
 
     @Override
     public void read(@NonNull ReadRequest request, @NonNull StreamObserver<ReadResponse> observer) {
+        final var guardedObserver = ManagedObservers.toGuardedStreamObserver(observer);
+        final var hint = new AtomicReference<OxiaStatusException>();
         try {
-            connectionManager
-                    .getConnection(shardLeaderProvider.apply(request.getShard()))
-                    .stub()
-                    .withDeadlineAfter(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS)
-                    .read(request, new ManagedStreamObserver<>(observer));
+            Failsafe.with(getRetryPolicy("read", hint))
+                    .with(asyncExecutor)
+                    .getStageAsync(
+                            () -> {
+                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierObserver =
+                                        ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
+                                try {
+                                    connectionManager
+                                            .getConnection(getLeader(request.getShard(), hint))
+                                            .stub()
+                                            .read(request, barrierObserver);
+                                } catch (Throwable error) {
+                                    barrierFuture.completeExceptionally(OxiaStatusException.toException(error));
+                                }
+                                return barrierFuture;
+                            })
+                    .exceptionally(
+                            error -> {
+                                guardedObserver.onError(OxiaStatusException.toException(error));
+                                return null;
+                            });
         } catch (Throwable error) {
-            observer.onError(OxiaStatusException.toException(error));
+            guardedObserver.onError(OxiaStatusException.toException(error));
         }
     }
 
@@ -241,11 +258,30 @@ final class GrpcRpcProvider implements RpcProvider {
     @Override
     public void list(
             @NonNull ListRequest request, @NonNull CancelableStreamObserver<ListResponse> observer) {
+        final var hint = new AtomicReference<OxiaStatusException>();
         try {
-            connectionManager
-                    .getConnection(shardLeaderProvider.apply(request.getShard()))
-                    .stub()
-                    .list(request, new ManagedClientResponseObserver<>(observer));
+            Failsafe.with(getRetryPolicy("list", hint))
+                    .with(asyncExecutor)
+                    .getStageAsync(
+                            () -> {
+                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierObserver =
+                                        ManagedObservers.toBarrierClientResponseObserver(observer, barrierFuture);
+                                try {
+                                    connectionManager
+                                            .getConnection(getLeader(request.getShard(), hint))
+                                            .stub()
+                                            .list(request, barrierObserver);
+                                } catch (Throwable error) {
+                                    barrierFuture.completeExceptionally(OxiaStatusException.toException(error));
+                                }
+                                return barrierFuture;
+                            })
+                    .exceptionally(
+                            error -> {
+                                observer.onError(OxiaStatusException.toException(error));
+                                return null;
+                            });
         } catch (Throwable error) {
             observer.onError(OxiaStatusException.toException(error));
         }
@@ -255,11 +291,30 @@ final class GrpcRpcProvider implements RpcProvider {
     public void rangeScan(
             @NonNull RangeScanRequest request,
             @NonNull CancelableStreamObserver<RangeScanResponse> observer) {
+        final var hint = new AtomicReference<OxiaStatusException>();
         try {
-            connectionManager
-                    .getConnection(shardLeaderProvider.apply(request.getShard()))
-                    .stub()
-                    .rangeScan(request, new ManagedClientResponseObserver<>(observer));
+            Failsafe.with(getRetryPolicy("range scan", hint))
+                    .with(asyncExecutor)
+                    .getStageAsync(
+                            () -> {
+                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierObserver =
+                                        ManagedObservers.toBarrierClientResponseObserver(observer, barrierFuture);
+                                try {
+                                    connectionManager
+                                            .getConnection(getLeader(request.getShard(), hint))
+                                            .stub()
+                                            .rangeScan(request, barrierObserver);
+                                } catch (Throwable error) {
+                                    barrierFuture.completeExceptionally(OxiaStatusException.toException(error));
+                                }
+                                return barrierFuture;
+                            })
+                    .exceptionally(
+                            error -> {
+                                observer.onError(OxiaStatusException.toException(error));
+                                return null;
+                            });
         } catch (Throwable error) {
             observer.onError(OxiaStatusException.toException(error));
         }
@@ -269,14 +324,32 @@ final class GrpcRpcProvider implements RpcProvider {
     public void getSequenceUpdates(
             @NonNull GetSequenceUpdatesRequest request,
             @NonNull CancelableStreamObserver<GetSequenceUpdatesResponse> observer) {
+        final var hint = new AtomicReference<OxiaStatusException>();
         try {
-            connectionManager
-                    .getConnection(shardLeaderProvider.apply(request.getShard()))
-                    .stub()
-                    .getSequenceUpdates(request, new ManagedClientResponseObserver<>(observer));
+            Failsafe.with(getRetryPolicy("get sequence updates", hint))
+                    .with(asyncExecutor)
+                    .getStageAsync(
+                            () -> {
+                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierObserver =
+                                        ManagedObservers.toBarrierClientResponseObserver(observer, barrierFuture);
+                                try {
+                                    connectionManager
+                                            .getConnection(getLeader(request.getShard(), hint))
+                                            .stub()
+                                            .getSequenceUpdates(request, barrierObserver);
+                                } catch (Throwable error) {
+                                    barrierFuture.completeExceptionally(OxiaStatusException.toException(error));
+                                }
+                                return barrierFuture;
+                            })
+                    .exceptionally(
+                            error -> {
+                                observer.onError(OxiaStatusException.toException(error));
+                                return null;
+                            });
         } catch (Throwable error) {
-            final var translated = OxiaStatusException.toException(error);
-            asyncExecutor.execute(() -> observer.onError(translated));
+            observer.onError(OxiaStatusException.toException(error));
         }
     }
 

--- a/client/src/main/java/io/oxia/client/grpc/observer/BarrierClientResponseObserver.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/BarrierClientResponseObserver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc.observer;
+
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.oxia.client.grpc.OxiaStatusException;
+import java.util.concurrent.CompletableFuture;
+import lombok.NonNull;
+
+public final class BarrierClientResponseObserver<ReqT, RespT>
+        implements ClientResponseObserver<ReqT, RespT> {
+    private final CancelableStreamObserver<RespT> streamObserver;
+    private final CompletableFuture<Void> barrierFuture;
+
+    BarrierClientResponseObserver(
+            @NonNull CancelableStreamObserver<RespT> streamObserver,
+            @NonNull CompletableFuture<Void> barrierFuture) {
+        this.streamObserver = streamObserver;
+        this.barrierFuture = barrierFuture;
+    }
+
+    @Override
+    public void beforeStart(@NonNull ClientCallStreamObserver<ReqT> requestStream) {
+        streamObserver.setRequestStream(requestStream);
+    }
+
+    @Override
+    public void onNext(@NonNull RespT response) {
+        barrierFuture.complete(null);
+        streamObserver.onNext(response);
+    }
+
+    @Override
+    public void onError(@NonNull Throwable error) {
+        final var translated = OxiaStatusException.toException(error);
+        if (!barrierFuture.isDone()) {
+            barrierFuture.completeExceptionally(translated);
+            return;
+        }
+        streamObserver.onError(translated);
+    }
+
+    @Override
+    public void onCompleted() {
+        barrierFuture.complete(null);
+        streamObserver.onCompleted();
+    }
+}

--- a/client/src/main/java/io/oxia/client/grpc/observer/BarrierStreamObserver.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/BarrierStreamObserver.java
@@ -17,27 +17,38 @@ package io.oxia.client.grpc.observer;
 
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.grpc.OxiaStatusException;
+import java.util.concurrent.CompletableFuture;
 import lombok.NonNull;
 
-public final class ManagedStreamObserver<T> implements StreamObserver<T> {
-    private final StreamObserver<T> observer;
+public final class BarrierStreamObserver<T> implements StreamObserver<T> {
+    private final StreamObserver<T> streamObserver;
+    private final CompletableFuture<Void> barrierFuture;
 
-    public ManagedStreamObserver(@NonNull StreamObserver<T> observer) {
-        this.observer = observer;
+    BarrierStreamObserver(
+            @NonNull StreamObserver<T> streamObserver, @NonNull CompletableFuture<Void> barrierFuture) {
+        this.streamObserver = streamObserver;
+        this.barrierFuture = barrierFuture;
     }
 
     @Override
-    public void onNext(@NonNull T value) {
-        observer.onNext(value);
+    public void onNext(@NonNull T response) {
+        barrierFuture.complete(null);
+        streamObserver.onNext(response);
     }
 
     @Override
     public void onError(@NonNull Throwable error) {
-        observer.onError(OxiaStatusException.toException(error));
+        final var translated = OxiaStatusException.toException(error);
+        if (!barrierFuture.isDone()) {
+            barrierFuture.completeExceptionally(translated);
+            return;
+        }
+        streamObserver.onError(translated);
     }
 
     @Override
     public void onCompleted() {
-        observer.onCompleted();
+        barrierFuture.complete(null);
+        streamObserver.onCompleted();
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/observer/CancelableStreamObserver.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/CancelableStreamObserver.java
@@ -43,8 +43,9 @@ public abstract class CancelableStreamObserver<T> implements StreamObserver<T> {
     }
 
     void setRequestStream(ClientCallStreamObserver<?> requestStream) {
-        if (!this.requestStream.compareAndSet(null, requestStream)) {
-            throw new IllegalStateException("Request stream was already initialized");
+        final var previous = this.requestStream.getAndSet(requestStream);
+        if (previous != null) {
+            previous.cancel(CANCELED, null);
         }
         if (canceled.get() && this.requestStream.compareAndSet(requestStream, null)) {
             requestStream.cancel(CANCELED, null);
@@ -53,23 +54,26 @@ public abstract class CancelableStreamObserver<T> implements StreamObserver<T> {
 
     @Override
     public final void onNext(@NonNull T value) {
-        if (!isCanceled()) {
-            onNextValue(value);
+        if (isCanceled()) {
+            return;
         }
+        onNextValue(value);
     }
 
     @Override
     public final void onError(@NonNull Throwable t) {
-        if (!isCanceled()) {
-            onErrorValue(t);
+        if (isCanceled()) {
+            return;
         }
+        onErrorValue(t);
     }
 
     @Override
     public final void onCompleted() {
-        if (!isCanceled()) {
-            onCompletedValue();
+        if (isCanceled()) {
+            return;
         }
+        onCompletedValue();
     }
 
     protected abstract void onNextValue(@NonNull T value);

--- a/client/src/main/java/io/oxia/client/grpc/observer/GuardedStreamObserver.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/GuardedStreamObserver.java
@@ -15,36 +15,35 @@
  */
 package io.oxia.client.grpc.observer;
 
-import io.grpc.stub.ClientCallStreamObserver;
-import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.StreamObserver;
 import io.oxia.client.grpc.OxiaStatusException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.NonNull;
 
-public final class ManagedClientResponseObserver<ReqT, RespT>
-        implements ClientResponseObserver<ReqT, RespT> {
-    private final CancelableStreamObserver<RespT> observer;
+public final class GuardedStreamObserver<T> implements StreamObserver<T> {
+    private final StreamObserver<T> streamObserver;
+    private final AtomicBoolean terminated = new AtomicBoolean();
 
-    public ManagedClientResponseObserver(@NonNull CancelableStreamObserver<RespT> observer) {
-        this.observer = observer;
+    GuardedStreamObserver(@NonNull StreamObserver<T> streamObserver) {
+        this.streamObserver = streamObserver;
     }
 
     @Override
-    public void beforeStart(@NonNull ClientCallStreamObserver<ReqT> requestStream) {
-        observer.setRequestStream(requestStream);
-    }
-
-    @Override
-    public void onNext(@NonNull RespT value) {
-        observer.onNext(value);
+    public void onNext(@NonNull T response) {
+        streamObserver.onNext(response);
     }
 
     @Override
     public void onError(@NonNull Throwable error) {
-        observer.onError(OxiaStatusException.toException(error));
+        if (terminated.compareAndSet(false, true)) {
+            streamObserver.onError(OxiaStatusException.toException(error));
+        }
     }
 
     @Override
     public void onCompleted() {
-        observer.onCompleted();
+        if (terminated.compareAndSet(false, true)) {
+            streamObserver.onCompleted();
+        }
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/observer/ManagedObservers.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/ManagedObservers.java
@@ -18,7 +18,6 @@ package io.oxia.client.grpc.observer;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.grpc.OxiaStatusException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.NonNull;
 
 public final class ManagedObservers {
@@ -55,64 +54,10 @@ public final class ManagedObservers {
         return new BarrierStreamObserver<>(streamObserver, barrierFuture);
     }
 
-    public static final class GuardedStreamObserver<T> implements StreamObserver<T> {
-        private final StreamObserver<T> streamObserver;
-        private final AtomicBoolean terminated = new AtomicBoolean();
-
-        private GuardedStreamObserver(@NonNull StreamObserver<T> streamObserver) {
-            this.streamObserver = streamObserver;
-        }
-
-        @Override
-        public void onNext(@NonNull T response) {
-            streamObserver.onNext(response);
-        }
-
-        @Override
-        public void onError(@NonNull Throwable error) {
-            if (terminated.compareAndSet(false, true)) {
-                streamObserver.onError(OxiaStatusException.toException(error));
-            }
-        }
-
-        @Override
-        public void onCompleted() {
-            if (terminated.compareAndSet(false, true)) {
-                streamObserver.onCompleted();
-            }
-        }
-    }
-
-    public static final class BarrierStreamObserver<T> implements StreamObserver<T> {
-        private final StreamObserver<T> streamObserver;
-        private final CompletableFuture<Void> barrierFuture;
-
-        private BarrierStreamObserver(
-                @NonNull StreamObserver<T> streamObserver, @NonNull CompletableFuture<Void> barrierFuture) {
-            this.streamObserver = streamObserver;
-            this.barrierFuture = barrierFuture;
-        }
-
-        @Override
-        public void onNext(@NonNull T response) {
-            barrierFuture.complete(null);
-            streamObserver.onNext(response);
-        }
-
-        @Override
-        public void onError(@NonNull Throwable error) {
-            final var translated = OxiaStatusException.toException(error);
-            if (!barrierFuture.isDone()) {
-                barrierFuture.completeExceptionally(translated);
-                return;
-            }
-            streamObserver.onError(translated);
-        }
-
-        @Override
-        public void onCompleted() {
-            barrierFuture.complete(null);
-            streamObserver.onCompleted();
-        }
+    public static <ReqT, RespT>
+            BarrierClientResponseObserver<ReqT, RespT> toBarrierClientResponseObserver(
+                    @NonNull CancelableStreamObserver<RespT> streamObserver,
+                    @NonNull CompletableFuture<Void> barrierFuture) {
+        return new BarrierClientResponseObserver<>(streamObserver, barrierFuture);
     }
 }

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -37,9 +37,13 @@ import io.oxia.proto.CreateSessionResponse;
 import io.oxia.proto.GetSequenceUpdatesRequest;
 import io.oxia.proto.GetSequenceUpdatesResponse;
 import io.oxia.proto.KeepAliveResponse;
+import io.oxia.proto.ListRequest;
+import io.oxia.proto.ListResponse;
 import io.oxia.proto.NotificationBatch;
 import io.oxia.proto.NotificationsRequest;
 import io.oxia.proto.OxiaClientGrpc;
+import io.oxia.proto.RangeScanRequest;
+import io.oxia.proto.RangeScanResponse;
 import io.oxia.proto.ReadRequest;
 import io.oxia.proto.ReadResponse;
 import io.oxia.proto.SessionHeartbeat;
@@ -279,10 +283,238 @@ class GrpcRpcProviderTest {
     }
 
     @Test
-    void unaryRequestsUseRequestTimeoutDeadline() throws Exception {
+    void readRetriesWithLeaderHint() throws Exception {
+        var leaderServerRequests = new AtomicReference<ReadRequest>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(new ReadResponse());
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var firstServerRequests = new AtomicReference<ReadRequest>();
+        var staleLeaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+                        firstServerRequests.set(request);
+                        responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                    }
+                };
+        Server staleLeaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(staleLeaderService).build().start();
+        var staleLeaderAddress = "localhost:" + staleLeaderServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(staleLeaderAddress)
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> staleLeaderAddress)) {
+            var request = new ReadRequest();
+            request.setShard(1);
+            var response = new AtomicReference<ReadResponse>();
+
+            provider.read(request, capturingStreamObserver(response));
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(response.get()).isNotNull();
+                                assertThat(firstServerRequests.get()).isNotNull();
+                                assertThat(leaderServerRequests.get()).isNotNull();
+                            });
+        } finally {
+            executor.shutdownNow();
+            staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void listRetriesWithLeaderHint() throws Exception {
+        var leaderServerRequests = new AtomicReference<ListRequest>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void list(ListRequest request, StreamObserver<ListResponse> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(new ListResponse().addAllKeys(java.util.List.of("key")));
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var firstServerRequests = new AtomicReference<ListRequest>();
+        var staleLeaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void list(ListRequest request, StreamObserver<ListResponse> responseObserver) {
+                        firstServerRequests.set(request);
+                        responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                    }
+                };
+        Server staleLeaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(staleLeaderService).build().start();
+        var staleLeaderAddress = "localhost:" + staleLeaderServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(staleLeaderAddress)
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> staleLeaderAddress)) {
+            var request = new ListRequest();
+            request.setShard(1);
+            var response = new AtomicReference<ListResponse>();
+
+            provider.list(request, capturingCancelableObserver(response));
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(response.get()).isNotNull();
+                                assertThat(response.get().getKeyAt(0)).isEqualTo("key");
+                                assertThat(firstServerRequests.get()).isNotNull();
+                                assertThat(leaderServerRequests.get()).isNotNull();
+                            });
+        } finally {
+            executor.shutdownNow();
+            staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void rangeScanRetriesWithLeaderHint() throws Exception {
+        var leaderServerRequests = new AtomicReference<RangeScanRequest>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void rangeScan(
+                            RangeScanRequest request, StreamObserver<RangeScanResponse> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(new RangeScanResponse());
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var firstServerRequests = new AtomicReference<RangeScanRequest>();
+        var staleLeaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void rangeScan(
+                            RangeScanRequest request, StreamObserver<RangeScanResponse> responseObserver) {
+                        firstServerRequests.set(request);
+                        responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                    }
+                };
+        Server staleLeaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(staleLeaderService).build().start();
+        var staleLeaderAddress = "localhost:" + staleLeaderServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(staleLeaderAddress)
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> staleLeaderAddress)) {
+            var request = new RangeScanRequest();
+            request.setShard(1);
+            var response = new AtomicReference<RangeScanResponse>();
+
+            provider.rangeScan(request, capturingCancelableObserver(response));
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(response.get()).isNotNull();
+                                assertThat(firstServerRequests.get()).isNotNull();
+                                assertThat(leaderServerRequests.get()).isNotNull();
+                            });
+        } finally {
+            executor.shutdownNow();
+            staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void getSequenceUpdatesRetriesWithLeaderHint() throws Exception {
+        var leaderServerRequests = new AtomicReference<GetSequenceUpdatesRequest>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void getSequenceUpdates(
+                            GetSequenceUpdatesRequest request,
+                            StreamObserver<GetSequenceUpdatesResponse> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(
+                                new GetSequenceUpdatesResponse().setHighestSequenceKey("key-1"));
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var firstServerRequests = new AtomicReference<GetSequenceUpdatesRequest>();
+        var staleLeaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void getSequenceUpdates(
+                            GetSequenceUpdatesRequest request,
+                            StreamObserver<GetSequenceUpdatesResponse> responseObserver) {
+                        firstServerRequests.set(request);
+                        responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                    }
+                };
+        Server staleLeaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(staleLeaderService).build().start();
+        var staleLeaderAddress = "localhost:" + staleLeaderServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(staleLeaderAddress)
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> staleLeaderAddress)) {
+            var request = new GetSequenceUpdatesRequest();
+            request.setShard(1).setKey("key");
+            var response = new AtomicReference<GetSequenceUpdatesResponse>();
+
+            provider.getSequenceUpdates(request, capturingCancelableObserver(response));
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(response.get()).isNotNull();
+                                assertThat(response.get().getHighestSequenceKey()).isEqualTo("key-1");
+                                assertThat(firstServerRequests.get()).isNotNull();
+                                assertThat(leaderServerRequests.get()).isNotNull();
+                            });
+        } finally {
+            executor.shutdownNow();
+            staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void sessionRequestsUseRequestTimeoutDeadline() throws Exception {
         var createSessionHasDeadline = new AtomicReference<Boolean>();
         var closeSessionHasDeadline = new AtomicReference<Boolean>();
-        var readHasDeadline = new AtomicReference<Boolean>();
         var service =
                 new OxiaClientGrpc.OxiaClientImplBase() {
                     @Override
@@ -301,13 +533,6 @@ class GrpcRpcProviderTest {
                         responseObserver.onNext(new CloseSessionResponse());
                         responseObserver.onCompleted();
                     }
-
-                    @Override
-                    public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
-                        readHasDeadline.set(Context.current().getDeadline() != null);
-                        responseObserver.onNext(new ReadResponse());
-                        responseObserver.onCompleted();
-                    }
                 };
         Server server = ServerBuilder.forPort(0).directExecutor().addService(service).build().start();
         var address = "localhost:" + server.getPort();
@@ -321,29 +546,11 @@ class GrpcRpcProviderTest {
             provider.createSession(new CreateSessionRequest().setShard(1)).get(5, TimeUnit.SECONDS);
             provider.closeSession(new CloseSessionRequest().setShard(1)).get(5, TimeUnit.SECONDS);
 
-            var readResponse = new AtomicReference<ReadResponse>();
-            provider.read(
-                    new ReadRequest().setShard(1),
-                    new StreamObserver<>() {
-                        @Override
-                        public void onNext(ReadResponse value) {
-                            readResponse.set(value);
-                        }
-
-                        @Override
-                        public void onError(Throwable t) {}
-
-                        @Override
-                        public void onCompleted() {}
-                    });
-
             await()
                     .untilAsserted(
                             () -> {
-                                assertThat(readResponse.get()).isNotNull();
                                 assertThat(createSessionHasDeadline.get()).isTrue();
                                 assertThat(closeSessionHasDeadline.get()).isTrue();
-                                assertThat(readHasDeadline.get()).isTrue();
                             });
         } finally {
             executor.shutdownNow();
@@ -389,6 +596,37 @@ class GrpcRpcProviderTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    private static <T> StreamObserver<T> capturingStreamObserver(AtomicReference<T> response) {
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(T value) {
+                response.set(value);
+            }
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onCompleted() {}
+        };
+    }
+
+    private static <T> CancelableStreamObserver<T> capturingCancelableObserver(
+            AtomicReference<T> response) {
+        return new CancelableStreamObserver<>() {
+            @Override
+            protected void onNextValue(@NonNull T value) {
+                response.set(value);
+            }
+
+            @Override
+            protected void onErrorValue(@NonNull Throwable t) {}
+
+            @Override
+            protected void onCompletedValue() {}
+        };
     }
 
     private static Throwable retryableErrorWithLeaderHint(String leaderAddress) {


### PR DESCRIPTION
## Motivation
- Shard-scoped RPCs in `GrpcRpcProvider` should retry retryable Oxia errors and honor leader hints consistently with the existing session and notification retry logic.
- Streaming RPCs should only retry before the first response is delivered, then surface subsequent stream errors to the caller.

## Modifications
- Added retry handling with leader hints for read, write, list, range scan, and sequence update RPCs.
- Moved cancelable barrier observer handling into `ManagedObservers` and removed the now-unused `ManagedStreamObserver`.
- Updated write stream creation to use the retry-resolved leader address.
- Added regression coverage for retrying each remaining shard RPC against a hinted leader.

## Testing
- `./gradlew spotlessCheck`
- `./gradlew :client:test --tests io.oxia.client.grpc.GrpcRpcProviderTest`
- `./gradlew :client:test` was also run earlier and had one unrelated failure in `OxiaClientIT.testMaximumSize()`: expected `OxiaStatusException`, but the test process hit `OutOfMemoryError: Java heap space` while allocating the maximum-frame payload.