### PR TITLE
fix: retry per-shard write streams

### DIFF
--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -98,7 +98,7 @@ final class WriteBatch extends BatchBase implements Batch {
         try {
             final ManagedWriteStream writeStream = rpcProvider.getWriteStream(getShardId());
             writeStream
-                    .sendWithRecovery(toProto())
+                    .send(toProto())
                     .thenAccept(
                             response -> {
                                 factory.writeRequestLatencyHistogram.recordSuccess(

--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -18,6 +18,7 @@ package io.oxia.client.batch;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.oxia.client.grpc.ManagedWriteStream;
 import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.session.SessionManager;
 import io.oxia.proto.WriteRequest;
@@ -95,8 +96,9 @@ final class WriteBatch extends BatchBase implements Batch {
     public void send() {
         startSendTimeNanos = System.nanoTime();
         try {
-            rpcProvider
-                    .write(toProto())
+            final ManagedWriteStream writeStream = rpcProvider.getWriteStream(getShardId());
+            writeStream
+                    .sendWithRecovery(toProto())
                     .thenAccept(
                             response -> {
                                 factory.writeRequestLatencyHistogram.recordSuccess(

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -242,7 +242,12 @@ final class GrpcRpcProvider implements RpcProvider {
         return writeStreams.computeIfAbsent(
                 shardId,
                 (__) ->
-                        new ManagedWriteStream(shardId, connectionManager, shardLeaderProvider, asyncExecutor));
+                        new ManagedWriteStream(
+                                clientConfig.namespace(),
+                                shardId,
+                                connectionManager,
+                                shardLeaderProvider,
+                                asyncExecutor));
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -15,6 +15,7 @@
  */
 package io.oxia.client.grpc;
 
+import com.google.common.collect.Maps;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import dev.failsafe.Timeout;
@@ -41,11 +42,9 @@ import io.oxia.proto.ReadResponse;
 import io.oxia.proto.SessionHeartbeat;
 import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
-import io.oxia.proto.WriteRequest;
-import io.oxia.proto.WriteResponse;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -59,7 +58,7 @@ final class GrpcRpcProvider implements RpcProvider {
     private final ConnectionManager connectionManager;
     private final ScheduledExecutorService asyncExecutor;
     private final LongFunction<String> shardLeaderProvider;
-    private final ManagedWriteStream managedWriteStream;
+    private final Map<Long, ManagedWriteStream> writeStreams;
 
     GrpcRpcProvider(
             @NonNull ClientConfig clientConfig,
@@ -69,10 +68,7 @@ final class GrpcRpcProvider implements RpcProvider {
         this.asyncExecutor = asyncExecutor;
         this.connectionManager = new ConnectionManager(clientConfig, asyncExecutor);
         this.shardLeaderProvider = shardLeaderProvider;
-        this.managedWriteStream =
-                new ManagedWriteStream(
-                        clientConfig.namespace(),
-                        shardId -> connectionManager.getConnection(shardLeaderProvider.apply(shardId)).stub());
+        this.writeStreams = Maps.newConcurrentMap();
     }
 
     @Override
@@ -242,17 +238,11 @@ final class GrpcRpcProvider implements RpcProvider {
     }
 
     @Override
-    public CompletableFuture<WriteResponse> write(@NonNull WriteRequest request) {
-        try {
-            return managedWriteStream
-                    .write(request)
-                    .exceptionally(
-                            error -> {
-                                throw new CompletionException(OxiaStatusException.toException(error));
-                            });
-        } catch (Throwable error) {
-            return CompletableFuture.failedFuture(OxiaStatusException.toException(error));
-        }
+    public ManagedWriteStream getWriteStream(long shardId) {
+        return writeStreams.computeIfAbsent(
+                shardId,
+                (__) ->
+                        new ManagedWriteStream(shardId, connectionManager, shardLeaderProvider, asyncExecutor));
     }
 
     @Override
@@ -356,7 +346,8 @@ final class GrpcRpcProvider implements RpcProvider {
     @Override
     public void close() throws Exception {
         try {
-            managedWriteStream.close();
+            writeStreams.values().forEach(ManagedWriteStream::close);
+            writeStreams.clear();
         } finally {
             connectionManager.close();
         }

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -20,6 +20,8 @@ import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import dev.failsafe.Timeout;
 import io.github.merlimat.slog.Logger;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.grpc.observer.CancelableStreamObserver;
@@ -42,6 +44,9 @@ import io.oxia.proto.ReadResponse;
 import io.oxia.proto.SessionHeartbeat;
 import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
+import io.oxia.proto.WriteRequest;
+import io.oxia.proto.WriteResponse;
+
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -49,10 +54,15 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongFunction;
+
 import lombok.NonNull;
 
 final class GrpcRpcProvider implements RpcProvider {
     private static final Logger log = Logger.get(GrpcRpcProvider.class);
+    private static final Metadata.Key<String> NAMESPACE_KEY =
+            Metadata.Key.of("namespace", Metadata.ASCII_STRING_MARSHALLER);
+    private static final Metadata.Key<String> SHARD_ID_KEY =
+            Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
 
     private final ClientConfig clientConfig;
     private final ConnectionManager connectionManager;
@@ -241,13 +251,31 @@ final class GrpcRpcProvider implements RpcProvider {
     public ManagedWriteStream getWriteStream(long shardId) {
         return writeStreams.computeIfAbsent(
                 shardId,
-                (__) ->
-                        new ManagedWriteStream(
-                                clientConfig.namespace(),
-                                shardId,
-                                connectionManager,
-                                shardLeaderProvider,
-                                asyncExecutor));
+                (__) -> new ManagedWriteStream(shardId, this, asyncExecutor));
+    }
+
+    public StreamObserver<WriteRequest> writeStream(long shardId, StreamObserver<WriteResponse> responseObserver) {
+        final var guardedObserver = ManagedObservers.toGuardedStreamObserver(responseObserver);
+        final var hint = new AtomicReference<OxiaStatusException>();
+        return Failsafe.with(getRetryPolicy("write stream", hint))
+                .get(() -> {
+                            final var future = new CompletableFuture<Void>();
+                            final var barrierObserver =
+                                    ManagedObservers.toBarrierStreamObserver(guardedObserver, future);
+                            final var headers = new Metadata();
+                            headers.put(NAMESPACE_KEY, clientConfig.namespace());
+                            headers.put(SHARD_ID_KEY, Long.toString(shardId));
+                            final var requestObserver =
+                                    connectionManager
+                                            .getConnection(getLeader(shardId, hint))
+                                            .stub()
+                                            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers))
+                                            .writeStream(barrierObserver);
+                            // we don't need to wait for the stream to be ready, only need to check if it fail fast
+                            future.complete(null);
+                            future.join();
+                            return requestObserver;
+                        });
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -251,6 +251,7 @@ final class GrpcRpcProvider implements RpcProvider {
                 shardId, (__) -> new ManagedWriteStream(shardId, this, asyncExecutor));
     }
 
+    @Override
     public StreamObserver<WriteRequest> writeStream(
             long shardId,
             OxiaStatusException leaderHint,

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -46,7 +46,6 @@ import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
-
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -54,7 +53,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongFunction;
-
 import lombok.NonNull;
 
 final class GrpcRpcProvider implements RpcProvider {
@@ -250,15 +248,18 @@ final class GrpcRpcProvider implements RpcProvider {
     @Override
     public ManagedWriteStream getWriteStream(long shardId) {
         return writeStreams.computeIfAbsent(
-                shardId,
-                (__) -> new ManagedWriteStream(shardId, this, asyncExecutor));
+                shardId, (__) -> new ManagedWriteStream(shardId, this, asyncExecutor));
     }
 
-    public StreamObserver<WriteRequest> writeStream(long shardId, StreamObserver<WriteResponse> responseObserver) {
+    public StreamObserver<WriteRequest> writeStream(
+            long shardId,
+            OxiaStatusException leaderHint,
+            StreamObserver<WriteResponse> responseObserver) {
         final var guardedObserver = ManagedObservers.toGuardedStreamObserver(responseObserver);
-        final var hint = new AtomicReference<OxiaStatusException>();
+        final var hint = new AtomicReference<>(leaderHint);
         return Failsafe.with(getRetryPolicy("write stream", hint))
-                .get(() -> {
+                .get(
+                        () -> {
                             final var future = new CompletableFuture<Void>();
                             final var barrierObserver =
                                     ManagedObservers.toBarrierStreamObserver(guardedObserver, future);
@@ -271,7 +272,8 @@ final class GrpcRpcProvider implements RpcProvider {
                                             .stub()
                                             .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers))
                                             .writeStream(barrierObserver);
-                            // we don't need to wait for the stream to be ready, only need to check if it fail fast
+                            // we don't need to wait for the stream to be ready, only need to check if it fail
+                            // fast
                             future.complete(null);
                             future.join();
                             return requestObserver;

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -15,22 +15,32 @@
  */
 package io.oxia.client.grpc;
 
+import static io.oxia.client.constants.Constants.MAXIMUM_FRAME_SIZE;
+
 import io.github.merlimat.slog.Logger;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongFunction;
 
 public final class ManagedWriteStream implements AutoCloseable, StreamObserver<WriteResponse> {
+    private static final Metadata.Key<String> NAMESPACE_KEY =
+            Metadata.Key.of("namespace", Metadata.ASCII_STRING_MARSHALLER);
+    private static final Metadata.Key<String> SHARD_ID_KEY =
+            Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
 
     private final Logger log;
 
     record InflightWrite(WriteRequest request, CompletableFuture<WriteResponse> future) {}
 
+    private final String namespace;
     private final long shardId;
     private final LongFunction<String> shardLeaderProvider;
     private final ConnectionManager connectionManager;
@@ -43,10 +53,12 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
     private StreamObserver<WriteRequest> subStreamObserver;
 
     public ManagedWriteStream(
+            String namespace,
             long shardId,
             ConnectionManager connectionManager,
             LongFunction<String> shardLeaderProvider,
             ScheduledExecutorService asyncExecutor) {
+        this.namespace = namespace;
         this.shardId = shardId;
         this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
         this.inflightWrites = new ConcurrentLinkedQueue<>();
@@ -75,6 +87,14 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
             if (closed) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
             }
+            if (request.getSerializedSize() > MAXIMUM_FRAME_SIZE) {
+                return CompletableFuture.failedFuture(
+                        new OxiaStatusException(
+                                OxiaStatusCode.UNKNOWN,
+                                Map.of(),
+                                "Write request exceeds maximum frame size",
+                                new IllegalArgumentException("Write request exceeds maximum frame size")));
+            }
             if (subStreamObserver == null) {
                 initWithRecovery(null);
             }
@@ -96,13 +116,20 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                 leaderHint == null
                         ? shardLeaderProvider.apply(shardId)
                         : leaderHint.getLeaderHint(shardId).orElseGet(() -> shardLeaderProvider.apply(shardId));
-        subStreamObserver = connectionManager.getConnection(leader).stub().writeStream(this);
+        final var headers = new Metadata();
+        headers.put(NAMESPACE_KEY, namespace);
+        headers.put(SHARD_ID_KEY, Long.toString(shardId));
+        subStreamObserver =
+                connectionManager
+                        .getConnection(leader)
+                        .stub()
+                        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers))
+                        .writeStream(this);
         log.info()
                 .attr("leader", leader)
                 .attr("pendingWrites", inflightWrites.size())
                 .log("Opened write stream");
 
-        log.debug().attr("pendingWrites", inflightWrites.size()).log("Replaying inflight writes");
         final var streamObserverRef = subStreamObserver;
         for (InflightWrite inflightWrite : inflightWrites) {
             streamObserverRef.onNext(inflightWrite.request);
@@ -137,6 +164,9 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                     .log("Write stream failed with retryable error; scheduling recovery");
         }
         resetSubObserver();
+        if (inflightWrites.isEmpty()) {
+            return;
+        }
         scheduleRetry((OxiaStatusException) OxiaStatusException.toException(t), 0); // retry immediately
     }
 
@@ -146,6 +176,9 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                 .attr("pendingWrites", inflightWrites.size())
                 .log("Write stream completed; scheduling recovery");
         resetSubObserver();
+        if (inflightWrites.isEmpty()) {
+            return;
+        }
         scheduleRetry(null, 0); // retry immediately
     }
 

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -15,15 +15,11 @@
  */
 package io.oxia.client.grpc;
 
-import static io.oxia.client.constants.Constants.MAXIMUM_FRAME_SIZE;
-
 import io.github.merlimat.slog.Logger;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
-
-import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
@@ -31,8 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public final class ManagedWriteStream implements AutoCloseable, StreamObserver<WriteResponse> {
     private final Logger log;
 
-    record InflightWrite(WriteRequest request, CompletableFuture<WriteResponse> future) {
-    }
+    record InflightWrite(WriteRequest request, CompletableFuture<WriteResponse> future) {}
 
     private final long shardId;
     private final RpcProvider rpcProvider;
@@ -45,9 +40,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
     private StreamObserver<WriteRequest> subStreamObserver;
 
     public ManagedWriteStream(
-            long shardId,
-            RpcProvider rpcProvider,
-            ScheduledExecutorService asyncExecutor) {
+            long shardId, RpcProvider rpcProvider, ScheduledExecutorService asyncExecutor) {
         this.shardId = shardId;
         this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
         this.inflightWrites = new ConcurrentLinkedQueue<>();
@@ -66,17 +59,16 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
             if (closed) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
             }
-            if (subStreamObserver == null) {
-                initWithRecovery();
-            }
             inflightWrites.add(inflightWrite);
-            log.debug().attr("pendingWrites", inflightWrites.size()).log("Sending write request");
-            subStreamObserver.onNext(request);
+            if (subStreamObserver == null) {
+                initWithRecovery(null);
+            } else {
+                log.debug().attr("pendingWrites", inflightWrites.size()).log("Sending write request");
+                subStreamObserver.onNext(request);
+            }
             return future;
         } catch (Throwable ex) {
-            inflightWrites.remove(inflightWrite);
-            future.completeExceptionally(ex);
-            scheduleRetry(0);
+            scheduleRetry(null, 0);
             return future;
         } finally {
             lock.unlock();
@@ -94,26 +86,30 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
 
     @Override
     public void onError(Throwable t) {
-        if (!OxiaStatusException.isRetryable(t)) {
+        final var translated = OxiaStatusException.toException(t);
+        final OxiaStatusException leaderHint;
+        if (!OxiaStatusException.isRetryable(translated)) {
             final InflightWrite inflight = inflightWrites.poll();
             if (inflight != null) {
                 log.warn()
                         .attr("pendingWrites", inflightWrites.size())
-                        .exceptionMessage(t)
+                        .exceptionMessage(translated)
                         .log("Write stream failed with non-retryable error; failing head write");
-                inflight.future.completeExceptionally(OxiaStatusException.toException(t));
+                inflight.future.completeExceptionally(translated);
             }
+            leaderHint = null;
         } else {
             log.warn()
                     .attr("pendingWrites", inflightWrites.size())
-                    .exceptionMessage(t)
+                    .exceptionMessage(translated)
                     .log("Write stream failed with retryable error; scheduling recovery");
+            leaderHint = translated instanceof OxiaStatusException oxiaError ? oxiaError : null;
         }
         resetSubObserver();
         if (inflightWrites.isEmpty()) {
             return;
         }
-        scheduleRetry( 0); // retry immediately
+        scheduleRetry(leaderHint, 0); // retry immediately
     }
 
     @Override
@@ -125,10 +121,10 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         if (inflightWrites.isEmpty()) {
             return;
         }
-        scheduleRetry(0); // retry immediately
+        scheduleRetry(null, 0); // retry immediately
     }
 
-    private void scheduleRetry(long backoffMills) {
+    private void scheduleRetry(OxiaStatusException leaderHint, long backoffMills) {
         log.info()
                 .attr("retryDelayMillis", backoffMills)
                 .attr("pendingWrites", inflightWrites.size())
@@ -144,10 +140,10 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                         if (subStreamObserver != null) {
                             return;
                         }
-                        initWithRecovery();
+                        initWithRecovery(leaderHint);
                     } catch (Throwable ex) {
                         log.error().exceptionMessage(ex).log("Failed to recover write stream");
-                        scheduleRetry(backoff.nextDelayMillis());
+                        scheduleRetry(null, backoff.nextDelayMillis());
                     } finally {
                         lock.unlock();
                     }
@@ -155,7 +151,6 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                 backoffMills,
                 TimeUnit.MILLISECONDS);
     }
-
 
     private void resetSubObserver() {
         lock.lock();
@@ -166,9 +161,8 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         }
     }
 
-
-    private void initWithRecovery() {
-        subStreamObserver = rpcProvider.writeStream(shardId, this);
+    private void initWithRecovery(OxiaStatusException leaderHint) {
+        subStreamObserver = rpcProvider.writeStream(shardId, leaderHint, this);
         log.info().attr("pendingWrites", inflightWrites.size()).log("Opened write stream");
         for (InflightWrite inflightWrite : inflightWrites) {
             subStreamObserver.onNext(inflightWrite.request);

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -94,8 +94,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                     subStreamObserver.onNext(inflightWrite.request);
                 }
             } catch (Throwable ex) {
-                log.warn().exceptionMessage(ex)
-                        .log("Failed to send write request, retrying");
+                log.warn().exceptionMessage(ex).log("Failed to send write request, retrying");
                 subStreamObserver = null;
                 // we are using null here to avoid the new request exception discard old.
                 scheduleRetry(null, 0);

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -75,7 +75,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         if (inflightWrites.isEmpty()) {
             return;
         }
-        scheduleRetry(new CancellationException(), 0); // retry immediately
+        scheduleRetry(null, 0); // retry immediately
     }
 
     public CompletableFuture<WriteResponse> send(WriteRequest request) {
@@ -90,8 +90,9 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
             try {
                 if (subStreamObserver == null) {
                     initWithRecovery(null);
+                } else {
+                    subStreamObserver.onNext(inflightWrite.request);
                 }
-                subStreamObserver.onNext(inflightWrite.request);
             } catch (Throwable ex) {
                 log.warn().exceptionMessage(ex)
                         .log("Failed to send write request, retrying");

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -18,32 +18,24 @@ package io.oxia.client.grpc;
 import static io.oxia.client.constants.Constants.MAXIMUM_FRAME_SIZE;
 
 import io.github.merlimat.slog.Logger;
-import io.grpc.Metadata;
-import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
+
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.LongFunction;
 
 public final class ManagedWriteStream implements AutoCloseable, StreamObserver<WriteResponse> {
-    private static final Metadata.Key<String> NAMESPACE_KEY =
-            Metadata.Key.of("namespace", Metadata.ASCII_STRING_MARSHALLER);
-    private static final Metadata.Key<String> SHARD_ID_KEY =
-            Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
-
     private final Logger log;
 
-    record InflightWrite(WriteRequest request, CompletableFuture<WriteResponse> future) {}
+    record InflightWrite(WriteRequest request, CompletableFuture<WriteResponse> future) {
+    }
 
-    private final String namespace;
     private final long shardId;
-    private final LongFunction<String> shardLeaderProvider;
-    private final ConnectionManager connectionManager;
+    private final RpcProvider rpcProvider;
     private final ScheduledExecutorService asyncExecutor;
     private final Backoff backoff;
 
@@ -53,30 +45,17 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
     private StreamObserver<WriteRequest> subStreamObserver;
 
     public ManagedWriteStream(
-            String namespace,
             long shardId,
-            ConnectionManager connectionManager,
-            LongFunction<String> shardLeaderProvider,
+            RpcProvider rpcProvider,
             ScheduledExecutorService asyncExecutor) {
-        this.namespace = namespace;
         this.shardId = shardId;
         this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
         this.inflightWrites = new ConcurrentLinkedQueue<>();
-        this.shardLeaderProvider = shardLeaderProvider;
-        this.connectionManager = connectionManager;
+        this.rpcProvider = rpcProvider;
         this.lock = new ReentrantLock();
         this.asyncExecutor = asyncExecutor;
         this.backoff = new Backoff();
         this.closed = false;
-    }
-
-    private void resetSubObserver() {
-        lock.lock();
-        try {
-            subStreamObserver = null;
-        } finally {
-            lock.unlock();
-        }
     }
 
     public CompletableFuture<WriteResponse> sendWithRecovery(WriteRequest request) {
@@ -87,16 +66,8 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
             if (closed) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
             }
-            if (request.getSerializedSize() > MAXIMUM_FRAME_SIZE) {
-                return CompletableFuture.failedFuture(
-                        new OxiaStatusException(
-                                OxiaStatusCode.UNKNOWN,
-                                Map.of(),
-                                "Write request exceeds maximum frame size",
-                                new IllegalArgumentException("Write request exceeds maximum frame size")));
-            }
             if (subStreamObserver == null) {
-                initWithRecovery(null);
+                initWithRecovery();
             }
             inflightWrites.add(inflightWrite);
             log.debug().attr("pendingWrites", inflightWrites.size()).log("Sending write request");
@@ -105,36 +76,11 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         } catch (Throwable ex) {
             inflightWrites.remove(inflightWrite);
             future.completeExceptionally(ex);
+            scheduleRetry(0);
             return future;
         } finally {
             lock.unlock();
         }
-    }
-
-    private void initWithRecovery(OxiaStatusException leaderHint) {
-        final var leader =
-                leaderHint == null
-                        ? shardLeaderProvider.apply(shardId)
-                        : leaderHint.getLeaderHint(shardId).orElseGet(() -> shardLeaderProvider.apply(shardId));
-        final var headers = new Metadata();
-        headers.put(NAMESPACE_KEY, namespace);
-        headers.put(SHARD_ID_KEY, Long.toString(shardId));
-        subStreamObserver =
-                connectionManager
-                        .getConnection(leader)
-                        .stub()
-                        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers))
-                        .writeStream(this);
-        log.info()
-                .attr("leader", leader)
-                .attr("pendingWrites", inflightWrites.size())
-                .log("Opened write stream");
-
-        final var streamObserverRef = subStreamObserver;
-        for (InflightWrite inflightWrite : inflightWrites) {
-            streamObserverRef.onNext(inflightWrite.request);
-        }
-        backoff.reset();
     }
 
     @Override
@@ -167,7 +113,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         if (inflightWrites.isEmpty()) {
             return;
         }
-        scheduleRetry((OxiaStatusException) OxiaStatusException.toException(t), 0); // retry immediately
+        scheduleRetry( 0); // retry immediately
     }
 
     @Override
@@ -179,10 +125,10 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         if (inflightWrites.isEmpty()) {
             return;
         }
-        scheduleRetry(null, 0); // retry immediately
+        scheduleRetry(0); // retry immediately
     }
 
-    private void scheduleRetry(OxiaStatusException leaderHint, long backoffMills) {
+    private void scheduleRetry(long backoffMills) {
         log.info()
                 .attr("retryDelayMillis", backoffMills)
                 .attr("pendingWrites", inflightWrites.size())
@@ -198,16 +144,36 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                         if (subStreamObserver != null) {
                             return;
                         }
-                        initWithRecovery(leaderHint);
+                        initWithRecovery();
                     } catch (Throwable ex) {
                         log.error().exceptionMessage(ex).log("Failed to recover write stream");
-                        scheduleRetry(null, backoff.nextDelayMillis());
+                        scheduleRetry(backoff.nextDelayMillis());
                     } finally {
                         lock.unlock();
                     }
                 },
                 backoffMills,
                 TimeUnit.MILLISECONDS);
+    }
+
+
+    private void resetSubObserver() {
+        lock.lock();
+        try {
+            subStreamObserver = null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+
+    private void initWithRecovery() {
+        subStreamObserver = rpcProvider.writeStream(shardId, this);
+        log.info().attr("pendingWrites", inflightWrites.size()).log("Opened write stream");
+        for (InflightWrite inflightWrite : inflightWrites) {
+            subStreamObserver.onNext(inflightWrite.request);
+        }
+        backoff.reset();
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -16,164 +16,190 @@
 package io.oxia.client.grpc;
 
 import io.github.merlimat.slog.Logger;
-import io.grpc.Metadata;
-import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
-import io.oxia.proto.OxiaClientGrpc;
+import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Queue;
+import java.util.concurrent.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongFunction;
 
-final class ManagedWriteStream implements AutoCloseable {
-    private static final Metadata.Key<String> NAMESPACE_KEY =
-            Metadata.Key.of("namespace", Metadata.ASCII_STRING_MARSHALLER);
-    private static final Metadata.Key<String> SHARD_ID_KEY =
-            Metadata.Key.of("shard-id", Metadata.ASCII_STRING_MARSHALLER);
+public final class ManagedWriteStream implements AutoCloseable, StreamObserver<WriteResponse> {
 
-    private final Map<Long, ShardWriteStream> streams = new ConcurrentHashMap<>();
-    private final String namespace;
-    private final LongFunction<OxiaClientGrpc.OxiaClientStub> stubProvider;
+    private final Logger log;
 
-    ManagedWriteStream(String namespace, LongFunction<OxiaClientGrpc.OxiaClientStub> stubProvider) {
-        this.namespace = namespace;
-        this.stubProvider = stubProvider;
+    record InflightWrite(WriteRequest request, CompletableFuture<WriteResponse> future) {}
+
+    private final long shardId;
+    private final LongFunction<String> shardLeaderProvider;
+    private final ConnectionManager connectionManager;
+    private final ScheduledExecutorService asyncExecutor;
+    private final Backoff backoff;
+
+    private final ReentrantLock lock;
+    private boolean closed;
+    private final Queue<InflightWrite> inflightWrites;
+    private StreamObserver<WriteRequest> subStreamObserver;
+
+    public ManagedWriteStream(
+            long shardId,
+            ConnectionManager connectionManager,
+            LongFunction<String> shardLeaderProvider,
+            ScheduledExecutorService asyncExecutor) {
+        this.shardId = shardId;
+        this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
+        this.inflightWrites = new ConcurrentLinkedQueue<>();
+        this.shardLeaderProvider = shardLeaderProvider;
+        this.connectionManager = connectionManager;
+        this.lock = new ReentrantLock();
+        this.asyncExecutor = asyncExecutor;
+        this.backoff = new Backoff();
+        this.closed = false;
     }
 
-    CompletableFuture<WriteResponse> write(WriteRequest request) {
-        return stream(request.getShard()).send(request);
-    }
-
-    private ShardWriteStream stream(long shardId) {
-        ShardWriteStream stream = null;
-        for (int i = 0; i < 2; i++) {
-            stream = streams.get(shardId);
-            if (stream == null) {
-                stream = streams.computeIfAbsent(shardId, this::newStream);
-            }
-            if (stream.isValid()) {
-                break;
-            }
-            streams.remove(shardId, stream);
+    private void resetSubObserver() {
+        lock.lock();
+        try {
+            subStreamObserver = null;
+        } finally {
+            lock.unlock();
         }
-        return stream;
     }
 
-    private ShardWriteStream newStream(long shardId) {
-        Metadata headers = new Metadata();
-        headers.put(NAMESPACE_KEY, namespace);
-        headers.put(SHARD_ID_KEY, Long.toString(shardId));
-        return new ShardWriteStream(
-                stubProvider
-                        .apply(shardId)
-                        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers)),
-                shardId);
+    public CompletableFuture<WriteResponse> sendWithRecovery(WriteRequest request) {
+        lock.lock();
+        final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
+        final InflightWrite inflightWrite = new InflightWrite(request, future);
+        try {
+            if (closed) {
+                return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
+            }
+            if (subStreamObserver == null) {
+                initWithRecovery(null);
+            }
+            inflightWrites.add(inflightWrite);
+            log.debug().attr("pendingWrites", inflightWrites.size()).log("Sending write request");
+            subStreamObserver.onNext(request);
+            return future;
+        } catch (Throwable ex) {
+            inflightWrites.remove(inflightWrite);
+            future.completeExceptionally(ex);
+            return future;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void initWithRecovery(OxiaStatusException leaderHint) {
+        final var leader =
+                leaderHint == null
+                        ? shardLeaderProvider.apply(shardId)
+                        : leaderHint.getLeaderHint(shardId).orElseGet(() -> shardLeaderProvider.apply(shardId));
+        subStreamObserver = connectionManager.getConnection(leader).stub().writeStream(this);
+        log.info()
+                .attr("leader", leader)
+                .attr("pendingWrites", inflightWrites.size())
+                .log("Opened write stream");
+
+        log.debug().attr("pendingWrites", inflightWrites.size()).log("Replaying inflight writes");
+        final var streamObserverRef = subStreamObserver;
+        for (InflightWrite inflightWrite : inflightWrites) {
+            streamObserverRef.onNext(inflightWrite.request);
+        }
+        backoff.reset();
+    }
+
+    @Override
+    public void onNext(WriteResponse value) {
+        final InflightWrite inflight = inflightWrites.poll();
+        if (inflight != null) {
+            log.debug().attr("pendingWrites", inflightWrites.size()).log("Received write response");
+            inflight.future.complete(value);
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        if (!OxiaStatusException.isRetryable(t)) {
+            final InflightWrite inflight = inflightWrites.poll();
+            if (inflight != null) {
+                log.warn()
+                        .attr("pendingWrites", inflightWrites.size())
+                        .exceptionMessage(t)
+                        .log("Write stream failed with non-retryable error; failing head write");
+                inflight.future.completeExceptionally(OxiaStatusException.toException(t));
+            }
+        } else {
+            log.warn()
+                    .attr("pendingWrites", inflightWrites.size())
+                    .exceptionMessage(t)
+                    .log("Write stream failed with retryable error; scheduling recovery");
+        }
+        resetSubObserver();
+        scheduleRetry((OxiaStatusException) OxiaStatusException.toException(t), 0); // retry immediately
+    }
+
+    @Override
+    public void onCompleted() {
+        log.info()
+                .attr("pendingWrites", inflightWrites.size())
+                .log("Write stream completed; scheduling recovery");
+        resetSubObserver();
+        scheduleRetry(null, 0); // retry immediately
+    }
+
+    private void scheduleRetry(OxiaStatusException leaderHint, long backoffMills) {
+        log.info()
+                .attr("retryDelayMillis", backoffMills)
+                .attr("pendingWrites", inflightWrites.size())
+                .log("Scheduling write stream recovery");
+        asyncExecutor.schedule(
+                () -> {
+                    lock.lock();
+                    try {
+                        if (closed) {
+                            log.info("Skipping write stream recovery after close");
+                            return;
+                        }
+                        if (subStreamObserver != null) {
+                            return;
+                        }
+                        initWithRecovery(leaderHint);
+                    } catch (Throwable ex) {
+                        log.error().exceptionMessage(ex).log("Failed to recover write stream");
+                        scheduleRetry(null, backoff.nextDelayMillis());
+                    } finally {
+                        lock.unlock();
+                    }
+                },
+                backoffMills,
+                TimeUnit.MILLISECONDS);
     }
 
     @Override
     public void close() {
-        streams.values().forEach(ShardWriteStream::close);
-        streams.clear();
-    }
-
-    private static final class ShardWriteStream implements StreamObserver<WriteResponse> {
-        private final Logger log;
-        private final StreamObserver<WriteRequest> requestStream;
-        private final Deque<CompletableFuture<WriteResponse>> pendingWrites = new ArrayDeque<>();
-
-        private volatile boolean completed;
-        private volatile Throwable completedException;
-
-        ShardWriteStream(OxiaClientGrpc.OxiaClientStub stub, long shardId) {
-            this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
-            this.requestStream = stub.writeStream(this);
-        }
-
-        boolean isValid() {
-            return !completed;
-        }
-
-        @Override
-        public void onNext(WriteResponse value) {
-            synchronized (this) {
-                final var future = pendingWrites.poll();
-                if (future != null) {
-                    future.complete(value);
-                }
+        lock.lock();
+        try {
+            closed = true;
+            if (subStreamObserver != null) {
+                subStreamObserver.onCompleted();
+                subStreamObserver = null;
             }
-        }
-
-        @Override
-        public void onError(Throwable error) {
-            synchronized (this) {
-                completedException = error;
-                completed = true;
-                if (!pendingWrites.isEmpty()) {
-                    log.warn()
-                            .attr("pendingWrites", pendingWrites.size())
-                            .exceptionMessage(completedException)
-                            .log(
-                                    "Receive error when writing data to server through the stream, prepare to fail pending requests");
-                }
-                pendingWrites.forEach(f -> f.completeExceptionally(completedException));
-                pendingWrites.clear();
-            }
-        }
-
-        @Override
-        public void onCompleted() {
-            synchronized (this) {
-                completed = true;
-                if (!pendingWrites.isEmpty()) {
-                    log.info()
-                            .attr("pendingWrites", pendingWrites.size())
-                            .log(
-                                    "Receive stream close signal when writing data to server through the stream, prepare to cancel pending requests");
-                }
-                pendingWrites.forEach(f -> f.completeExceptionally(new CancellationException()));
-                pendingWrites.clear();
-            }
-        }
-
-        CompletableFuture<WriteResponse> send(WriteRequest request) {
-            if (completed) {
-                return CompletableFuture.failedFuture(
-                        Optional.ofNullable(completedException).orElseGet(CancellationException::new));
-            }
-            synchronized (this) {
-                if (completed) {
-                    return CompletableFuture.failedFuture(
-                            Optional.ofNullable(completedException).orElseGet(CancellationException::new));
-                }
-                final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
-                pendingWrites.add(future);
-                try {
-                    log.debug().attr("request", request).log("Sending request");
-                    requestStream.onNext(request);
-                } catch (Exception e) {
-                    pendingWrites.remove(future);
-                    future.completeExceptionally(e);
-                }
-                return future;
-            }
-        }
-
-        void close() {
-            synchronized (this) {
-                if (completed) {
-                    return;
-                }
-                completed = true;
-                pendingWrites.forEach(f -> f.completeExceptionally(new CancellationException()));
-                pendingWrites.clear();
-            }
-            requestStream.onCompleted();
+            log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
+            inflightWrites.forEach(
+                    inflight -> {
+                        inflight.future.completeExceptionally(new CancellationException("Stream is closed"));
+                    });
+            inflightWrites.clear();
+        } catch (Throwable ex) {
+            inflightWrites.forEach(
+                    inflight -> {
+                        inflight.future.completeExceptionally(ex);
+                    });
+            inflightWrites.clear();
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -51,30 +51,6 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         this.closed = false;
     }
 
-    public CompletableFuture<WriteResponse> sendWithRecovery(WriteRequest request) {
-        lock.lock();
-        final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
-        final InflightWrite inflightWrite = new InflightWrite(request, future);
-        try {
-            if (closed) {
-                return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
-            }
-            inflightWrites.add(inflightWrite);
-            if (subStreamObserver == null) {
-                initWithRecovery(null);
-            } else {
-                log.debug().attr("pendingWrites", inflightWrites.size()).log("Sending write request");
-                subStreamObserver.onNext(request);
-            }
-            return future;
-        } catch (Throwable ex) {
-            scheduleRetry(null, 0);
-            return future;
-        } finally {
-            lock.unlock();
-        }
-    }
-
     @Override
     public void onNext(WriteResponse value) {
         final InflightWrite inflight = inflightWrites.poll();
@@ -86,49 +62,68 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
 
     @Override
     public void onError(Throwable t) {
-        final var translated = OxiaStatusException.toException(t);
-        final OxiaStatusException leaderHint;
-        if (!OxiaStatusException.isRetryable(translated)) {
-            final InflightWrite inflight = inflightWrites.poll();
-            if (inflight != null) {
-                log.warn()
-                        .attr("pendingWrites", inflightWrites.size())
-                        .exceptionMessage(translated)
-                        .log("Write stream failed with non-retryable error; failing head write");
-                inflight.future.completeExceptionally(translated);
-            }
-            leaderHint = null;
-        } else {
-            log.warn()
-                    .attr("pendingWrites", inflightWrites.size())
-                    .exceptionMessage(translated)
-                    .log("Write stream failed with retryable error; scheduling recovery");
-            leaderHint = translated instanceof OxiaStatusException oxiaError ? oxiaError : null;
-        }
         resetSubObserver();
         if (inflightWrites.isEmpty()) {
             return;
         }
-        scheduleRetry(leaderHint, 0); // retry immediately
+        scheduleRetry(t, 0); // retry immediately
     }
 
     @Override
     public void onCompleted() {
-        log.info()
-                .attr("pendingWrites", inflightWrites.size())
-                .log("Write stream completed; scheduling recovery");
         resetSubObserver();
         if (inflightWrites.isEmpty()) {
             return;
         }
-        scheduleRetry(null, 0); // retry immediately
+        scheduleRetry(new CancellationException(), 0); // retry immediately
     }
 
-    private void scheduleRetry(OxiaStatusException leaderHint, long backoffMills) {
+    public CompletableFuture<WriteResponse> send(WriteRequest request) {
+        lock.lock();
+        final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
+        final InflightWrite inflightWrite = new InflightWrite(request, future);
+        try {
+            if (closed) {
+                return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
+            }
+            inflightWrites.add(inflightWrite);
+            try {
+                if (subStreamObserver == null) {
+                    initWithRecovery(null);
+                }
+                subStreamObserver.onNext(inflightWrite.request);
+            } catch (Throwable ex) {
+                log.warn().exceptionMessage(ex)
+                        .log("Failed to send write request, retrying");
+                subStreamObserver = null;
+                // we are using null here to avoid the new request exception discard old.
+                scheduleRetry(null, 0);
+            }
+            return future;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void scheduleRetry(Throwable error, long backoffMills) {
+        OxiaStatusException leaderHint = null;
+        if (error != null) {
+            final var translated = OxiaStatusException.toException(error);
+            if (OxiaStatusException.isRetryable(translated)) {
+                leaderHint = translated instanceof OxiaStatusException oxiaError ? oxiaError : null;
+            } else {
+                final InflightWrite inflight = inflightWrites.poll();
+                if (inflight != null) {
+                    inflight.future.completeExceptionally(translated);
+                }
+            }
+        }
         log.info()
+                .exceptionMessage(error)
                 .attr("retryDelayMillis", backoffMills)
                 .attr("pendingWrites", inflightWrites.size())
                 .log("Scheduling write stream recovery");
+        final OxiaStatusException fLeaderHint = leaderHint;
         asyncExecutor.schedule(
                 () -> {
                     lock.lock();
@@ -140,10 +135,10 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                         if (subStreamObserver != null) {
                             return;
                         }
-                        initWithRecovery(leaderHint);
+                        initWithRecovery(fLeaderHint);
                     } catch (Throwable ex) {
                         log.error().exceptionMessage(ex).log("Failed to recover write stream");
-                        scheduleRetry(null, backoff.nextDelayMillis());
+                        scheduleRetry(ex, backoff.nextDelayMillis());
                     } finally {
                         lock.unlock();
                     }

--- a/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
@@ -36,8 +36,6 @@ import io.oxia.proto.ReadResponse;
 import io.oxia.proto.SessionHeartbeat;
 import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
-import io.oxia.proto.WriteRequest;
-import io.oxia.proto.WriteResponse;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -67,7 +65,7 @@ public interface RpcProvider extends AutoCloseable {
 
     void read(@NonNull ReadRequest request, @NonNull StreamObserver<ReadResponse> observer);
 
-    CompletableFuture<WriteResponse> write(@NonNull WriteRequest request);
+    ManagedWriteStream getWriteStream(long shardId);
 
     void list(@NonNull ListRequest request, @NonNull CancelableStreamObserver<ListResponse> observer);
 

--- a/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
@@ -18,24 +18,8 @@ package io.oxia.client.grpc;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.grpc.observer.CancelableStreamObserver;
-import io.oxia.proto.CloseSessionRequest;
-import io.oxia.proto.CloseSessionResponse;
-import io.oxia.proto.CreateSessionRequest;
-import io.oxia.proto.CreateSessionResponse;
-import io.oxia.proto.GetSequenceUpdatesRequest;
-import io.oxia.proto.GetSequenceUpdatesResponse;
-import io.oxia.proto.KeepAliveResponse;
-import io.oxia.proto.ListRequest;
-import io.oxia.proto.ListResponse;
-import io.oxia.proto.NotificationBatch;
-import io.oxia.proto.NotificationsRequest;
-import io.oxia.proto.RangeScanRequest;
-import io.oxia.proto.RangeScanResponse;
-import io.oxia.proto.ReadRequest;
-import io.oxia.proto.ReadResponse;
-import io.oxia.proto.SessionHeartbeat;
-import io.oxia.proto.ShardAssignments;
-import io.oxia.proto.ShardAssignmentsRequest;
+import io.oxia.proto.*;
+
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -64,6 +48,8 @@ public interface RpcProvider extends AutoCloseable {
     CompletableFuture<CloseSessionResponse> closeSession(@NonNull CloseSessionRequest request);
 
     void read(@NonNull ReadRequest request, @NonNull StreamObserver<ReadResponse> observer);
+
+    StreamObserver<WriteRequest> writeStream(long shardId, StreamObserver<WriteResponse> responseObserver);
 
     ManagedWriteStream getWriteStream(long shardId);
 

--- a/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
@@ -19,7 +19,6 @@ import io.grpc.stub.StreamObserver;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.grpc.observer.CancelableStreamObserver;
 import io.oxia.proto.*;
-
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -49,7 +48,8 @@ public interface RpcProvider extends AutoCloseable {
 
     void read(@NonNull ReadRequest request, @NonNull StreamObserver<ReadResponse> observer);
 
-    StreamObserver<WriteRequest> writeStream(long shardId, StreamObserver<WriteResponse> responseObserver);
+    StreamObserver<WriteRequest> writeStream(
+            long shardId, OxiaStatusException leaderHint, StreamObserver<WriteResponse> responseObserver);
 
     ManagedWriteStream getWriteStream(long shardId);
 

--- a/client/src/main/java/io/oxia/client/grpc/observer/BarrierStreamObserver.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/BarrierStreamObserver.java
@@ -32,7 +32,9 @@ public final class BarrierStreamObserver<T> implements StreamObserver<T> {
 
     @Override
     public void onNext(@NonNull T response) {
-        barrierFuture.complete(null);
+        if (!barrierFuture.isDone()) {
+            barrierFuture.complete(null);
+        }
         streamObserver.onNext(response);
     }
 
@@ -48,7 +50,9 @@ public final class BarrierStreamObserver<T> implements StreamObserver<T> {
 
     @Override
     public void onCompleted() {
-        barrierFuture.complete(null);
+        if (!barrierFuture.isDone()) {
+            barrierFuture.complete(null);
+        }
         streamObserver.onCompleted();
     }
 }

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -302,7 +302,7 @@ class BatchTest {
             resp.addPut().setStatus(OK).setVersion();
             resp.addDelete().setStatus(KEY_NOT_FOUND);
             resp.addDeleteRange().setStatus(OK);
-            when(writeStream.sendWithRecovery(any(WriteRequest.class)))
+            when(writeStream.send(any(WriteRequest.class)))
                     .thenReturn(CompletableFuture.completedFuture(resp));
 
             batch.add(put);
@@ -323,7 +323,7 @@ class BatchTest {
         @Test
         public void sendFail() {
             var batchError = Status.UNAVAILABLE.asRuntimeException();
-            when(writeStream.sendWithRecovery(any(WriteRequest.class)))
+            when(writeStream.send(any(WriteRequest.class)))
                     .thenReturn(CompletableFuture.failedFuture(batchError));
 
             batch.add(put);

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -36,6 +36,7 @@ import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
@@ -49,6 +50,7 @@ import io.oxia.client.batch.Operation.ReadOperation.GetOperation;
 import io.oxia.client.batch.Operation.WriteOperation.DeleteOperation;
 import io.oxia.client.batch.Operation.WriteOperation.DeleteRangeOperation;
 import io.oxia.client.batch.Operation.WriteOperation.PutOperation;
+import io.oxia.client.grpc.ManagedWriteStream;
 import io.oxia.client.grpc.OxiaStatusException;
 import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.metrics.InstrumentProvider;
@@ -119,12 +121,6 @@ class BatchTest {
                             new OxiaClientImplBase() {
 
                                 @Override
-                                public void write(
-                                        WriteRequest request, StreamObserver<WriteResponse> responseObserver) {
-                                    writeResponses.forEach(c -> c.accept(responseObserver));
-                                }
-
-                                @Override
                                 public void read(
                                         ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
                                     readResponses.forEach(c -> c.accept(responseObserver));
@@ -133,12 +129,10 @@ class BatchTest {
 
     private Server server;
     private ManagedChannel channel;
-    private final List<Consumer<StreamObserver<WriteResponse>>> writeResponses = new ArrayList<>();
     private final List<Consumer<StreamObserver<ReadResponse>>> readResponses = new ArrayList<>();
 
     @BeforeEach
     public void setUp() throws Exception {
-        writeResponses.clear();
         readResponses.clear();
         String serverName = InProcessServerBuilder.generateName();
         InProcessServerBuilder serverBuilder =
@@ -149,30 +143,6 @@ class BatchTest {
         server = serverBuilder.build().start();
         channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
         clientByShardId = mock(RpcProvider.class);
-        lenient()
-                .when(clientByShardId.write(any(WriteRequest.class)))
-                .thenAnswer(
-                        invocation -> {
-                            var future = new CompletableFuture<WriteResponse>();
-                            stub()
-                                    .write(
-                                            invocation.getArgument(0),
-                                            new StreamObserver<>() {
-                                                @Override
-                                                public void onNext(WriteResponse response) {
-                                                    future.complete(response);
-                                                }
-
-                                                @Override
-                                                public void onError(Throwable error) {
-                                                    future.completeExceptionally(OxiaStatusException.toException(error));
-                                                }
-
-                                                @Override
-                                                public void onCompleted() {}
-                                            });
-                            return future;
-                        });
         lenient()
                 .doAnswer(
                         invocation -> {
@@ -234,6 +204,7 @@ class BatchTest {
     @DisplayName("Tests of write batch")
     class WriteBatchTests {
         WriteBatch batch;
+        ManagedWriteStream writeStream;
         CompletableFuture<PutResult> putCallable = new CompletableFuture<>();
         CompletableFuture<PutResult> putEphemeralCallable = new CompletableFuture<>();
         CompletableFuture<Boolean> deleteCallable = new CompletableFuture<>();
@@ -270,6 +241,8 @@ class BatchTest {
 
         @BeforeEach
         void setup() {
+            writeStream = mock(ManagedWriteStream.class);
+            lenient().when(clientByShardId.getWriteStream(shardId)).thenReturn(writeStream);
 
             var factory =
                     new WriteBatchFactory(
@@ -324,16 +297,13 @@ class BatchTest {
 
         @Test
         public void sendOk() {
-            writeResponses.add(
-                    o -> {
-                        var resp = new WriteResponse();
-                        resp.addPut().setStatus(UNEXPECTED_VERSION_ID);
-                        resp.addPut().setStatus(OK).setVersion();
-                        resp.addDelete().setStatus(KEY_NOT_FOUND);
-                        resp.addDeleteRange().setStatus(OK);
-                        o.onNext(resp);
-                    });
-            writeResponses.add(StreamObserver::onCompleted);
+            var resp = new WriteResponse();
+            resp.addPut().setStatus(UNEXPECTED_VERSION_ID);
+            resp.addPut().setStatus(OK).setVersion();
+            resp.addDelete().setStatus(KEY_NOT_FOUND);
+            resp.addDeleteRange().setStatus(OK);
+            when(writeStream.sendWithRecovery(any(WriteRequest.class)))
+                    .thenReturn(CompletableFuture.completedFuture(resp));
 
             batch.add(put);
             batch.add(putEphemeral);
@@ -342,12 +312,7 @@ class BatchTest {
 
             batch.send();
 
-            Awaitility.await()
-                    .untilAsserted(
-                            () -> {
-                                assertThat(putCallable).isCompletedExceptionally();
-                            });
-
+            Awaitility.await().untilAsserted(() -> assertThat(putCallable).isCompletedExceptionally());
             assertThat(putEphemeralCallable).isCompleted();
             assertThatThrownBy(putCallable::get)
                     .hasCauseExactlyInstanceOf(UnexpectedVersionIdException.class);
@@ -358,7 +323,8 @@ class BatchTest {
         @Test
         public void sendFail() {
             var batchError = Status.UNAVAILABLE.asRuntimeException();
-            writeResponses.add(o -> o.onError(batchError));
+            when(writeStream.sendWithRecovery(any(WriteRequest.class)))
+                    .thenReturn(CompletableFuture.failedFuture(batchError));
 
             batch.add(put);
             batch.add(putEphemeral);
@@ -367,25 +333,21 @@ class BatchTest {
 
             batch.send();
 
-            Awaitility.await()
-                    .untilAsserted(
-                            () -> {
-                                assertThat(putCallable).isCompletedExceptionally();
-                            });
-
-            assertThatThrownBy(putCallable::get).hasCauseInstanceOf(OxiaStatusException.class);
+            Awaitility.await().untilAsserted(() -> assertThat(putCallable).isCompletedExceptionally());
+            assertThatThrownBy(putCallable::get).hasCauseInstanceOf(StatusRuntimeException.class);
             assertThat(putEphemeralCallable).isCompletedExceptionally();
-            assertThatThrownBy(putEphemeralCallable::get).hasCauseInstanceOf(OxiaStatusException.class);
+            assertThatThrownBy(putEphemeralCallable::get)
+                    .hasCauseInstanceOf(StatusRuntimeException.class);
             assertThat(deleteCallable).isCompletedExceptionally();
-            assertThatThrownBy(deleteCallable::get).hasCauseInstanceOf(OxiaStatusException.class);
+            assertThatThrownBy(deleteCallable::get).hasCauseInstanceOf(StatusRuntimeException.class);
             assertThat(deleteRangeCallable).isCompletedExceptionally();
-            assertThatThrownBy(deleteRangeCallable::get).hasCauseInstanceOf(OxiaStatusException.class);
+            assertThatThrownBy(deleteRangeCallable::get).hasCauseInstanceOf(StatusRuntimeException.class);
         }
 
         @Test
         public void sendFailNoClient() {
             var rpcProvider = mock(RpcProvider.class);
-            when(rpcProvider.write(any(WriteRequest.class))).thenThrow(new NoShardAvailableException(1));
+            when(rpcProvider.getWriteStream(shardId)).thenThrow(new NoShardAvailableException(shardId));
 
             batch =
                     new WriteBatch(
@@ -404,11 +366,7 @@ class BatchTest {
 
             batch.send();
 
-            Awaitility.await()
-                    .untilAsserted(
-                            () -> {
-                                assertThat(putCallable).isCompletedExceptionally();
-                            });
+            Awaitility.await().untilAsserted(() -> assertThat(putCallable).isCompletedExceptionally());
             assertThatThrownBy(putCallable::get)
                     .satisfies(
                             e -> {
@@ -417,7 +375,7 @@ class BatchTest {
                                         .isEqualTo(shardId);
                             });
             assertThat(deleteCallable).isCompletedExceptionally();
-            assertThatThrownBy(putCallable::get)
+            assertThatThrownBy(deleteCallable::get)
                     .satisfies(
                             e -> {
                                 assertThat(e).hasCauseExactlyInstanceOf(NoShardAvailableException.class);
@@ -425,7 +383,7 @@ class BatchTest {
                                         .isEqualTo(shardId);
                             });
             assertThat(deleteRangeCallable).isCompletedExceptionally();
-            assertThatThrownBy(putCallable::get)
+            assertThatThrownBy(deleteRangeCallable::get)
                     .satisfies(
                             e -> {
                                 assertThat(e).hasCauseExactlyInstanceOf(NoShardAvailableException.class);

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import com.google.protobuf.Any;
+import com.google.rpc.ErrorInfo;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.protobuf.StatusProto;
+import io.grpc.stub.StreamObserver;
+import io.oxia.client.OxiaClientBuilderImpl;
+import io.oxia.client.api.OxiaClientBuilder;
+import io.oxia.proto.OxiaClientGrpc;
+import io.oxia.proto.WriteRequest;
+import io.oxia.proto.WriteResponse;
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ManagedWriteStreamTest {
+
+    @Test
+    void completesWritesInResponseOrder() throws Exception {
+        var requests = new ConcurrentLinkedQueue<WriteRequest>();
+        Server server = writeServer(respondingWriteService(requests));
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config = clientConfig(address);
+
+        try (var stream =
+                new ManagedWriteStream(
+                        1, new ConnectionManager(config, executor), shard -> address, executor)) {
+            var first = writeRequest(1);
+            var second = writeRequest(2);
+
+            var firstFuture = stream.sendWithRecovery(first);
+            var secondFuture = stream.sendWithRecovery(second);
+
+            firstFuture.get(5, TimeUnit.SECONDS);
+            secondFuture.get(5, TimeUnit.SECONDS);
+
+            await().untilAsserted(() -> assertThat(keys(requests)).containsExactly("key-1", "key-2"));
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void closeCancelsPendingWritesAndRejectsNewWrites() throws Exception {
+        Server server =
+                writeServer(
+                        new OxiaClientGrpc.OxiaClientImplBase() {
+                            @Override
+                            public StreamObserver<WriteRequest> writeStream(
+                                    StreamObserver<WriteResponse> responseObserver) {
+                                return new StreamObserver<>() {
+                                    @Override
+                                    public void onNext(WriteRequest value) {}
+
+                                    @Override
+                                    public void onError(Throwable t) {}
+
+                                    @Override
+                                    public void onCompleted() {}
+                                };
+                            }
+                        });
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config = clientConfig(address);
+
+        try (var stream =
+                new ManagedWriteStream(
+                        1, new ConnectionManager(config, executor), shard -> address, executor)) {
+            CompletableFuture<WriteResponse> pending = stream.sendWithRecovery(writeRequest(1));
+
+            stream.close();
+
+            assertThat(pending).isCompletedExceptionally();
+            assertThatThrownBy(pending::get)
+                    .isInstanceOf(java.util.concurrent.CancellationException.class);
+            assertThat(stream.sendWithRecovery(writeRequest(2))).isCompletedExceptionally();
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void replaysInflightWritesAfterRetryableError() throws Exception {
+        var leaderRequests = new ConcurrentLinkedQueue<WriteRequest>();
+        Server leaderServer = writeServer(respondingWriteService(leaderRequests));
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+
+        var staleRequests = new ConcurrentLinkedQueue<WriteRequest>();
+        var staleRequestCount = new AtomicInteger();
+        Server staleServer =
+                writeServer(
+                        new OxiaClientGrpc.OxiaClientImplBase() {
+                            @Override
+                            public StreamObserver<WriteRequest> writeStream(
+                                    StreamObserver<WriteResponse> responseObserver) {
+                                return new StreamObserver<>() {
+                                    @Override
+                                    public void onNext(WriteRequest value) {
+                                        staleRequests.add(value);
+                                        if (staleRequestCount.incrementAndGet() == 2) {
+                                            responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable t) {}
+
+                                    @Override
+                                    public void onCompleted() {}
+                                };
+                            }
+                        });
+        var staleAddress = "localhost:" + staleServer.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config = clientConfig(staleAddress);
+
+        try (var stream =
+                new ManagedWriteStream(
+                        1, new ConnectionManager(config, executor), shard -> staleAddress, executor)) {
+            var firstFuture = stream.sendWithRecovery(writeRequest(1));
+            var secondFuture = stream.sendWithRecovery(writeRequest(2));
+
+            firstFuture.get(5, TimeUnit.SECONDS);
+            secondFuture.get(5, TimeUnit.SECONDS);
+
+            await()
+                    .untilAsserted(() -> assertThat(keys(staleRequests)).containsExactly("key-1", "key-2"));
+            await()
+                    .untilAsserted(() -> assertThat(keys(leaderRequests)).containsExactly("key-1", "key-2"));
+        } finally {
+            executor.shutdownNow();
+            staleServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    private static OxiaClientGrpc.OxiaClientImplBase respondingWriteService(
+            Queue<WriteRequest> requests) {
+        return new OxiaClientGrpc.OxiaClientImplBase() {
+            @Override
+            public StreamObserver<WriteRequest> writeStream(
+                    StreamObserver<WriteResponse> responseObserver) {
+                return new StreamObserver<>() {
+                    @Override
+                    public void onNext(WriteRequest value) {
+                        requests.add(value);
+                        responseObserver.onNext(new WriteResponse());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {}
+
+                    @Override
+                    public void onCompleted() {
+                        responseObserver.onCompleted();
+                    }
+                };
+            }
+        };
+    }
+
+    private static Server writeServer(OxiaClientGrpc.OxiaClientImplBase service) throws Exception {
+        return ServerBuilder.forPort(0).directExecutor().addService(service).build().start();
+    }
+
+    private static WriteRequest writeRequest(int id) {
+        var request = new WriteRequest();
+        request.setShard(1);
+        request.addPut().setKey("key-" + id);
+        return request;
+    }
+
+    private static java.util.List<String> keys(Queue<WriteRequest> requests) {
+        return requests.stream().map(request -> request.getPutAt(0).getKey()).toList();
+    }
+
+    private static io.oxia.client.ClientConfig clientConfig(String address) {
+        return ((OxiaClientBuilderImpl)
+                        OxiaClientBuilder.create(address)
+                                .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                .getClientConfig();
+    }
+
+    private static Throwable retryableErrorWithLeaderHint(String leaderAddress) {
+        var grpcStatus =
+                com.google.rpc.Status.newBuilder()
+                        .setCode(Status.Code.ABORTED.value())
+                        .setMessage("oxia: node is not leader")
+                        .addDetails(
+                                Any.pack(
+                                        ErrorInfo.newBuilder()
+                                                .setDomain("oxia.io")
+                                                .setReason("NODE_IS_NOT_LEADER")
+                                                .putMetadata("shard", "1")
+                                                .putMetadata("leader", leaderAddress)
+                                                .build()))
+                        .build();
+        return StatusProto.toStatusRuntimeException(grpcStatus);
+    }
+}

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -55,8 +55,8 @@ class ManagedWriteStreamTest {
             var first = writeRequest(1);
             var second = writeRequest(2);
 
-            var firstFuture = stream.sendWithRecovery(first);
-            var secondFuture = stream.sendWithRecovery(second);
+            var firstFuture = stream.send(first);
+            var secondFuture = stream.send(second);
 
             firstFuture.get(5, TimeUnit.SECONDS);
             secondFuture.get(5, TimeUnit.SECONDS);
@@ -94,14 +94,14 @@ class ManagedWriteStreamTest {
 
         try (var provider = new GrpcRpcProvider(config, executor, shard -> address);
                 var stream = new ManagedWriteStream(1, provider, executor)) {
-            CompletableFuture<WriteResponse> pending = stream.sendWithRecovery(writeRequest(1));
+            CompletableFuture<WriteResponse> pending = stream.send(writeRequest(1));
 
             stream.close();
 
             assertThat(pending).isCompletedExceptionally();
             assertThatThrownBy(pending::get)
                     .isInstanceOf(java.util.concurrent.CancellationException.class);
-            assertThat(stream.sendWithRecovery(writeRequest(2))).isCompletedExceptionally();
+            assertThat(stream.send(writeRequest(2))).isCompletedExceptionally();
         } finally {
             executor.shutdownNow();
             server.shutdownNow();
@@ -145,8 +145,8 @@ class ManagedWriteStreamTest {
 
         try (var provider = new GrpcRpcProvider(config, executor, shard -> staleAddress);
                 var stream = new ManagedWriteStream(1, provider, executor)) {
-            var firstFuture = stream.sendWithRecovery(writeRequest(1));
-            var secondFuture = stream.sendWithRecovery(writeRequest(2));
+            var firstFuture = stream.send(writeRequest(1));
+            var secondFuture = stream.send(writeRequest(2));
 
             firstFuture.get(5, TimeUnit.SECONDS);
             secondFuture.get(5, TimeUnit.SECONDS);

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -50,9 +50,8 @@ class ManagedWriteStreamTest {
         var executor = Executors.newSingleThreadScheduledExecutor();
         var config = clientConfig(address);
 
-        try (var stream =
-                new ManagedWriteStream(
-                        "default", 1, new ConnectionManager(config, executor), shard -> address, executor)) {
+        try (var provider = new GrpcRpcProvider(config, executor, shard -> address);
+                var stream = new ManagedWriteStream(1, provider, executor)) {
             var first = writeRequest(1);
             var second = writeRequest(2);
 
@@ -93,9 +92,8 @@ class ManagedWriteStreamTest {
         var executor = Executors.newSingleThreadScheduledExecutor();
         var config = clientConfig(address);
 
-        try (var stream =
-                new ManagedWriteStream(
-                        "default", 1, new ConnectionManager(config, executor), shard -> address, executor)) {
+        try (var provider = new GrpcRpcProvider(config, executor, shard -> address);
+                var stream = new ManagedWriteStream(1, provider, executor)) {
             CompletableFuture<WriteResponse> pending = stream.sendWithRecovery(writeRequest(1));
 
             stream.close();
@@ -112,11 +110,9 @@ class ManagedWriteStreamTest {
 
     @Test
     void replaysInflightWritesAfterRetryableError() throws Exception {
-        var leaderRequests = new ConcurrentLinkedQueue<WriteRequest>();
-        Server leaderServer = writeServer(respondingWriteService(leaderRequests));
-        var leaderAddress = "localhost:" + leaderServer.getPort();
-
         var staleRequests = new ConcurrentLinkedQueue<WriteRequest>();
+        var recoveredRequests = new ConcurrentLinkedQueue<WriteRequest>();
+        var streamOpenCount = new AtomicInteger();
         var staleRequestCount = new AtomicInteger();
         Server staleServer =
                 writeServer(
@@ -124,13 +120,20 @@ class ManagedWriteStreamTest {
                             @Override
                             public StreamObserver<WriteRequest> writeStream(
                                     StreamObserver<WriteResponse> responseObserver) {
+                                var streamAttempt = streamOpenCount.incrementAndGet();
                                 return new StreamObserver<>() {
                                     @Override
                                     public void onNext(WriteRequest value) {
-                                        staleRequests.add(value);
-                                        if (staleRequestCount.incrementAndGet() == 2) {
-                                            responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
+                                        if (streamAttempt == 1) {
+                                            staleRequests.add(value);
+                                            if (staleRequestCount.incrementAndGet() == 2) {
+                                                responseObserver.onError(
+                                                        retryableErrorWithLeaderHint("localhost:0"));
+                                            }
+                                            return;
                                         }
+                                        recoveredRequests.add(value);
+                                        responseObserver.onNext(new WriteResponse());
                                     }
 
                                     @Override
@@ -145,13 +148,8 @@ class ManagedWriteStreamTest {
         var executor = Executors.newSingleThreadScheduledExecutor();
         var config = clientConfig(staleAddress);
 
-        try (var stream =
-                new ManagedWriteStream(
-                        "default",
-                        1,
-                        new ConnectionManager(config, executor),
-                        shard -> staleAddress,
-                        executor)) {
+        try (var provider = new GrpcRpcProvider(config, executor, shard -> staleAddress);
+                var stream = new ManagedWriteStream(1, provider, executor)) {
             var firstFuture = stream.sendWithRecovery(writeRequest(1));
             var secondFuture = stream.sendWithRecovery(writeRequest(2));
 
@@ -161,11 +159,10 @@ class ManagedWriteStreamTest {
             await()
                     .untilAsserted(() -> assertThat(keys(staleRequests)).containsExactly("key-1", "key-2"));
             await()
-                    .untilAsserted(() -> assertThat(keys(leaderRequests)).containsExactly("key-1", "key-2"));
+                    .untilAsserted(() -> assertThat(keys(recoveredRequests)).containsExactly("key-1", "key-2"));
         } finally {
             executor.shutdownNow();
             staleServer.shutdownNow();
-            leaderServer.shutdownNow();
         }
     }
 

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -110,9 +110,11 @@ class ManagedWriteStreamTest {
 
     @Test
     void replaysInflightWritesAfterRetryableError() throws Exception {
+        var leaderRequests = new ConcurrentLinkedQueue<WriteRequest>();
+        Server leaderServer = writeServer(respondingWriteService(leaderRequests));
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+
         var staleRequests = new ConcurrentLinkedQueue<WriteRequest>();
-        var recoveredRequests = new ConcurrentLinkedQueue<WriteRequest>();
-        var streamOpenCount = new AtomicInteger();
         var staleRequestCount = new AtomicInteger();
         Server staleServer =
                 writeServer(
@@ -120,20 +122,13 @@ class ManagedWriteStreamTest {
                             @Override
                             public StreamObserver<WriteRequest> writeStream(
                                     StreamObserver<WriteResponse> responseObserver) {
-                                var streamAttempt = streamOpenCount.incrementAndGet();
                                 return new StreamObserver<>() {
                                     @Override
                                     public void onNext(WriteRequest value) {
-                                        if (streamAttempt == 1) {
-                                            staleRequests.add(value);
-                                            if (staleRequestCount.incrementAndGet() == 2) {
-                                                responseObserver.onError(
-                                                        retryableErrorWithLeaderHint("localhost:0"));
-                                            }
-                                            return;
+                                        staleRequests.add(value);
+                                        if (staleRequestCount.incrementAndGet() == 2) {
+                                            responseObserver.onError(retryableErrorWithLeaderHint(leaderAddress));
                                         }
-                                        recoveredRequests.add(value);
-                                        responseObserver.onNext(new WriteResponse());
                                     }
 
                                     @Override
@@ -159,10 +154,11 @@ class ManagedWriteStreamTest {
             await()
                     .untilAsserted(() -> assertThat(keys(staleRequests)).containsExactly("key-1", "key-2"));
             await()
-                    .untilAsserted(() -> assertThat(keys(recoveredRequests)).containsExactly("key-1", "key-2"));
+                    .untilAsserted(() -> assertThat(keys(leaderRequests)).containsExactly("key-1", "key-2"));
         } finally {
             executor.shutdownNow();
             staleServer.shutdownNow();
+            leaderServer.shutdownNow();
         }
     }
 

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -52,7 +52,7 @@ class ManagedWriteStreamTest {
 
         try (var stream =
                 new ManagedWriteStream(
-                        1, new ConnectionManager(config, executor), shard -> address, executor)) {
+                        "default", 1, new ConnectionManager(config, executor), shard -> address, executor)) {
             var first = writeRequest(1);
             var second = writeRequest(2);
 
@@ -95,7 +95,7 @@ class ManagedWriteStreamTest {
 
         try (var stream =
                 new ManagedWriteStream(
-                        1, new ConnectionManager(config, executor), shard -> address, executor)) {
+                        "default", 1, new ConnectionManager(config, executor), shard -> address, executor)) {
             CompletableFuture<WriteResponse> pending = stream.sendWithRecovery(writeRequest(1));
 
             stream.close();
@@ -147,7 +147,11 @@ class ManagedWriteStreamTest {
 
         try (var stream =
                 new ManagedWriteStream(
-                        1, new ConnectionManager(config, executor), shard -> staleAddress, executor)) {
+                        "default",
+                        1,
+                        new ConnectionManager(config, executor),
+                        shard -> staleAddress,
+                        executor)) {
             var firstFuture = stream.sendWithRecovery(writeRequest(1));
             var secondFuture = stream.sendWithRecovery(writeRequest(2));
 

--- a/client/src/test/java/io/oxia/client/it/ClientReconnectIT.java
+++ b/client/src/test/java/io/oxia/client/it/ClientReconnectIT.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;

--- a/client/src/test/java/io/oxia/client/it/ClientReconnectIT.java
+++ b/client/src/test/java/io/oxia/client/it/ClientReconnectIT.java
@@ -23,7 +23,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;


### PR DESCRIPTION
## Motivation
- Preserve write availability when a bidirectional write stream is interrupted.
- Reuse one managed write stream per shard while still honoring retryable leader hints from the server.

## Modifications
- Move per-shard write stream ownership into `GrpcRpcProvider`.
- Open write streams with namespace and shard metadata through the retryable RPC path.
- Queue in-flight writes, replay them after retryable stream errors or completion, and cancel pending writes on close.
- Update barrier stream handling so startup failures can be detected without duplicate terminal forwarding.
- Add focused `ManagedWriteStream` coverage and update write batch tests for the new stream path.

## Testing
- `./gradlew :client:spotlessJavaCheck`
- `./gradlew :client:test --tests io.oxia.client.grpc.ManagedWriteStreamTest --tests io.oxia.client.batch.BatchTest`
- `./gradlew :client:test --tests io.oxia.client.it.OxiaClientIT.testMaximumSize`
- `./gradlew :client:test`
