### PR TITLE
fix: rebuild write requests on retry

### DIFF
--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -98,7 +98,7 @@ final class WriteBatch extends BatchBase implements Batch {
         try {
             final ManagedWriteStream writeStream = rpcProvider.getWriteStream(getShardId());
             writeStream
-                    .send(toProto())
+                    .send(this::toProto)
                     .thenAccept(
                             response -> {
                                 factory.writeRequestLatencyHistogram.recordSuccess(

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -23,11 +23,13 @@ import io.oxia.proto.WriteResponse;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 public final class ManagedWriteStream implements AutoCloseable, StreamObserver<WriteResponse> {
     private final Logger log;
 
-    record InflightWrite(WriteRequest request, CompletableFuture<WriteResponse> future) {}
+    record InflightWrite(
+            Supplier<WriteRequest> requestSupplier, CompletableFuture<WriteResponse> future) {}
 
     private final long shardId;
     private final RpcProvider rpcProvider;
@@ -78,10 +80,10 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         scheduleRetry(null, 0); // retry immediately
     }
 
-    public CompletableFuture<WriteResponse> send(WriteRequest request) {
+    public CompletableFuture<WriteResponse> send(Supplier<WriteRequest> requestSupplier) {
         lock.lock();
         final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
-        final InflightWrite inflightWrite = new InflightWrite(request, future);
+        final InflightWrite inflightWrite = new InflightWrite(requestSupplier, future);
         try {
             if (closed) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
@@ -91,7 +93,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                 if (subStreamObserver == null) {
                     initWithRecovery(null);
                 } else {
-                    subStreamObserver.onNext(inflightWrite.request);
+                    subStreamObserver.onNext(inflightWrite.requestSupplier.get());
                 }
             } catch (Throwable ex) {
                 log.warn().exceptionMessage(ex).log("Failed to send write request, retrying");
@@ -160,7 +162,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         subStreamObserver = rpcProvider.writeStream(shardId, leaderHint, this);
         log.info().attr("pendingWrites", inflightWrites.size()).log("Opened write stream");
         for (InflightWrite inflightWrite : inflightWrites) {
-            subStreamObserver.onNext(inflightWrite.request);
+            subStreamObserver.onNext(inflightWrite.requestSupplier.get());
         }
         backoff.reset();
     }

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -63,7 +63,6 @@ import io.oxia.proto.KeyComparisonType;
 import io.oxia.proto.OxiaClientGrpc;
 import io.oxia.proto.ReadRequest;
 import io.oxia.proto.ReadResponse;
-import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -302,8 +301,7 @@ class BatchTest {
             resp.addPut().setStatus(OK).setVersion();
             resp.addDelete().setStatus(KEY_NOT_FOUND);
             resp.addDeleteRange().setStatus(OK);
-            when(writeStream.send(any(WriteRequest.class)))
-                    .thenReturn(CompletableFuture.completedFuture(resp));
+            when(writeStream.send(any())).thenReturn(CompletableFuture.completedFuture(resp));
 
             batch.add(put);
             batch.add(putEphemeral);
@@ -323,8 +321,7 @@ class BatchTest {
         @Test
         public void sendFail() {
             var batchError = Status.UNAVAILABLE.asRuntimeException();
-            when(writeStream.send(any(WriteRequest.class)))
-                    .thenReturn(CompletableFuture.failedFuture(batchError));
+            when(writeStream.send(any())).thenReturn(CompletableFuture.failedFuture(batchError));
 
             batch.add(put);
             batch.add(putEphemeral);

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -31,6 +31,7 @@ import io.oxia.client.api.OxiaClientBuilder;
 import io.oxia.proto.OxiaClientGrpc;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -55,8 +56,8 @@ class ManagedWriteStreamTest {
             var first = writeRequest(1);
             var second = writeRequest(2);
 
-            var firstFuture = stream.send(first);
-            var secondFuture = stream.send(second);
+            var firstFuture = stream.send(() -> first);
+            var secondFuture = stream.send(() -> second);
 
             firstFuture.get(5, TimeUnit.SECONDS);
             secondFuture.get(5, TimeUnit.SECONDS);
@@ -94,14 +95,14 @@ class ManagedWriteStreamTest {
 
         try (var provider = new GrpcRpcProvider(config, executor, shard -> address);
                 var stream = new ManagedWriteStream(1, provider, executor)) {
-            CompletableFuture<WriteResponse> pending = stream.send(writeRequest(1));
+            CompletableFuture<WriteResponse> pending = stream.send(() -> writeRequest(1));
 
             stream.close();
 
             assertThat(pending).isCompletedExceptionally();
             assertThatThrownBy(pending::get)
                     .isInstanceOf(java.util.concurrent.CancellationException.class);
-            assertThat(stream.send(writeRequest(2))).isCompletedExceptionally();
+            assertThat(stream.send(() -> writeRequest(2))).isCompletedExceptionally();
         } finally {
             executor.shutdownNow();
             server.shutdownNow();
@@ -145,8 +146,8 @@ class ManagedWriteStreamTest {
 
         try (var provider = new GrpcRpcProvider(config, executor, shard -> staleAddress);
                 var stream = new ManagedWriteStream(1, provider, executor)) {
-            var firstFuture = stream.send(writeRequest(1));
-            var secondFuture = stream.send(writeRequest(2));
+            var firstFuture = stream.send(() -> writeRequest(1));
+            var secondFuture = stream.send(() -> writeRequest(2));
 
             firstFuture.get(5, TimeUnit.SECONDS);
             secondFuture.get(5, TimeUnit.SECONDS);
@@ -155,6 +156,9 @@ class ManagedWriteStreamTest {
                     .untilAsserted(() -> assertThat(keys(staleRequests)).containsExactly("key-1", "key-2"));
             await()
                     .untilAsserted(() -> assertThat(keys(leaderRequests)).containsExactly("key-1", "key-2"));
+            await()
+                    .untilAsserted(
+                            () -> assertThat(values(leaderRequests)).containsExactly("value-1", "value-2"));
         } finally {
             executor.shutdownNow();
             staleServer.shutdownNow();
@@ -194,12 +198,18 @@ class ManagedWriteStreamTest {
     private static WriteRequest writeRequest(int id) {
         var request = new WriteRequest();
         request.setShard(1);
-        request.addPut().setKey("key-" + id);
+        request.addPut().setKey("key-" + id).setValue(("value-" + id).getBytes(StandardCharsets.UTF_8));
         return request;
     }
 
     private static java.util.List<String> keys(Queue<WriteRequest> requests) {
         return requests.stream().map(request -> request.getPutAt(0).getKey()).toList();
+    }
+
+    private static java.util.List<String> values(Queue<WriteRequest> requests) {
+        return requests.stream()
+                .map(request -> new String(request.getPutAt(0).getValue(), StandardCharsets.UTF_8))
+                .toList();
     }
 
     private static io.oxia.client.ClientConfig clientConfig(String address) {


### PR DESCRIPTION
## Motivation
- Retried write stream requests could replay the same mutable LightProto `WriteRequest` after its `bytes` payload buffer had already been serialized.
- This could cause `put` retries to send an empty value.

## Modifications
- Change `ManagedWriteStream.send` to retain a `Supplier<WriteRequest>` and request a fresh write request on each send/replay.
- Have `WriteBatch` pass `this::toProto` so retries rebuild the batch request from the original operations.
- Extend write stream retry coverage to assert replayed put values remain intact.

## Testing
- `./gradlew :client:spotlessJavaApply`
- `./gradlew :client:test --tests io.oxia.client.grpc.ManagedWriteStreamTest --tests io.oxia.client.batch.BatchTest`
- `git diff --check`
