### PR TITLE
chore: log grpc connection lifecycle

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/Connection.java
+++ b/client/src/main/java/io/oxia/client/grpc/Connection.java
@@ -39,13 +39,16 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import lombok.NonNull;
 
 class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
     private static final String TLS_SCHEMA = "tls://";
     private static final Logger log = Logger.get(Connection.class);
+    private static final AtomicLong NEXT_CONNECTION_ID = new AtomicLong();
 
+    private final long connectionId;
     private final ManagedChannel channel;
     private final @NonNull OxiaClientGrpc.OxiaClientStub asyncStub;
     private final @NonNull HealthGrpc.HealthStub healthStub;
@@ -59,6 +62,7 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
             @NonNull ClientConfig clientConfig,
             @NonNull ScheduledExecutorService executor,
             @NonNull HealthCheckFailureCallback healthCheckFailureCallback) {
+        this.connectionId = NEXT_CONNECTION_ID.incrementAndGet();
         this.channel =
                 Grpc.newChannelBuilder(
                                 getAddress(address), getChannelCredential(address, clientConfig.enableTls()))
@@ -124,6 +128,10 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
         return asyncStub;
     }
 
+    long connectionId() {
+        return connectionId;
+    }
+
     static String getAddress(String address) {
         if (address.startsWith(TLS_SCHEMA)) {
             return address.substring(TLS_SCHEMA.length());
@@ -166,7 +174,10 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
             if (closed.get()) {
                 return;
             }
-            log.warn().attr("status", response.getStatus()).log("Connection health check failed");
+            log.warn()
+                    .attr("connectionId", connectionId)
+                    .attr("status", response.getStatus())
+                    .log("Connection health check failed");
             if (healthCheckFailureCallback != null) {
                 healthCheckFailureCallback.onFailure(this);
             }
@@ -188,7 +199,10 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
                 }
                 return;
             }
-            log.warn().exceptionMessage(error).log("Connection health check failed");
+            log.warn()
+                    .attr("connectionId", connectionId)
+                    .exceptionMessage(error)
+                    .log("Connection health check failed");
             if (healthCheckFailureCallback != null) {
                 healthCheckFailureCallback.onFailure(this);
             }

--- a/client/src/main/java/io/oxia/client/grpc/Connection.java
+++ b/client/src/main/java/io/oxia/client/grpc/Connection.java
@@ -148,7 +148,7 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
             return;
         }
         if (healthCheckTask != null) {
-            healthCheckTask.cancel(true);
+            healthCheckTask.cancel(false);
         }
         channel.shutdown();
         try {

--- a/client/src/main/java/io/oxia/client/grpc/Connection.java
+++ b/client/src/main/java/io/oxia/client/grpc/Connection.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
+import lombok.Getter;
 import lombok.NonNull;
 
 class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
@@ -48,7 +49,7 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
     private static final Logger log = Logger.get(Connection.class);
     private static final AtomicLong NEXT_CONNECTION_ID = new AtomicLong();
 
-    private final long connectionId;
+    @Getter private final long connectionId;
     private final ManagedChannel channel;
     private final @NonNull OxiaClientGrpc.OxiaClientStub asyncStub;
     private final @NonNull HealthGrpc.HealthStub healthStub;
@@ -126,10 +127,6 @@ class Connection implements AutoCloseable, StreamObserver<HealthCheckResponse> {
     @NonNull
     OxiaClientGrpc.OxiaClientStub stub() {
         return asyncStub;
-    }
-
-    long connectionId() {
-        return connectionId;
     }
 
     static String getAddress(String address) {

--- a/client/src/main/java/io/oxia/client/grpc/ConnectionManager.java
+++ b/client/src/main/java/io/oxia/client/grpc/ConnectionManager.java
@@ -56,7 +56,7 @@ class ConnectionManager implements AutoCloseable {
                     log.info()
                             .attr("address", key.address)
                             .attr("connectionKey", key.random)
-                            .attr("connectionId", connection.connectionId())
+                            .attr("connectionId", connection.getConnectionId())
                             .log("Creating managed GRPC connection");
                     return connection;
                 });
@@ -76,7 +76,7 @@ class ConnectionManager implements AutoCloseable {
         log.info()
                 .attr("address", key.address)
                 .attr("connectionKey", key.random)
-                .attr("connectionId", connection.connectionId())
+                .attr("connectionId", connection.getConnectionId())
                 .log("Removing unhealthy GRPC connection");
         try {
             connection.close();

--- a/client/src/main/java/io/oxia/client/grpc/ConnectionManager.java
+++ b/client/src/main/java/io/oxia/client/grpc/ConnectionManager.java
@@ -46,12 +46,20 @@ class ConnectionManager implements AutoCloseable {
         }
         return connections.computeIfAbsent(
                 new Key(address, modKey),
-                key ->
-                        new Connection(
-                                key.address,
-                                clientConfig,
-                                executor,
-                                connection -> removeConnection(key, connection)));
+                key -> {
+                    final var connection =
+                            new Connection(
+                                    key.address,
+                                    clientConfig,
+                                    executor,
+                                    connectionToRemove -> removeConnection(key, connectionToRemove));
+                    log.info()
+                            .attr("address", key.address)
+                            .attr("connectionKey", key.random)
+                            .attr("connectionId", connection.connectionId())
+                            .log("Creating managed GRPC connection");
+                    return connection;
+                });
     }
 
     @Override
@@ -65,6 +73,11 @@ class ConnectionManager implements AutoCloseable {
         if (!connections.remove(key, connection)) {
             return;
         }
+        log.info()
+                .attr("address", key.address)
+                .attr("connectionKey", key.random)
+                .attr("connectionId", connection.connectionId())
+                .log("Removing unhealthy GRPC connection");
         try {
             connection.close();
         } catch (Exception e) {


### PR DESCRIPTION
## Motivation
- Connection health-check logs do not currently identify whether retries are reusing the same managed connection or creating new connections for the same address/key.
- This makes it difficult to diagnose shard-assignment retries that report `Channel shutdownNow invoked` after health-check failures.

## Modifications
- Add a monotonically increasing connection id to each gRPC `Connection`.
- Log managed connection creation and unhealthy removal with address, connection key, and connection id.
- Include the connection id on health-check failure logs.

## Testing
- `./gradlew :client:spotlessJavaApply :client:test --tests io.oxia.client.grpc.ConnectionHealthTest --tests io.oxia.client.grpc.ConnectionTest`
- `git diff --check`
