### PR TITLE
fix: close reconnect test client

### DIFF
--- a/client/src/test/java/io/oxia/client/it/ClientReconnectIT.java
+++ b/client/src/test/java/io/oxia/client/it/ClientReconnectIT.java
@@ -38,65 +38,66 @@ class ClientReconnectIT {
                     .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(ClientReconnectIT.class)));
 
     @Test
-    void testReconnection() {
-        AsyncOxiaClient client =
-                OxiaClientBuilder.create(oxia.getServiceAddress()).asyncClient().join();
+    void testReconnection() throws Exception {
         String key = "1";
         byte[] value = "1".getBytes(StandardCharsets.UTF_8);
 
-        long startTime = System.currentTimeMillis();
-        long elapse = 3000L;
-        while (true) {
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
-
-            try {
-                client.put(key, value).get(1, TimeUnit.SECONDS);
-            } catch (Throwable ex) {
-                Assertions.fail("unexpected behaviour", ex);
-            }
-
-            try {
-                GetResult getResult = client.get("1").get(1, TimeUnit.SECONDS);
-                Assertions.assertArrayEquals(getResult.value(), value);
-            } catch (Throwable ex) {
-                Assertions.fail("unexpected behaviour", ex);
-            }
-
-            if (System.currentTimeMillis() - startTime >= elapse) {
-                oxia.stop();
-
+        try (AsyncOxiaClient client =
+                OxiaClientBuilder.create(oxia.getServiceAddress()).asyncClient().join()) {
+            long startTime = System.currentTimeMillis();
+            long elapse = 3000L;
+            while (true) {
                 try {
-                    Thread.sleep(3000);
+                    Thread.sleep(500);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new RuntimeException(e);
                 }
 
-                oxia.start();
+                try {
+                    client.put(key, value).get(1, TimeUnit.SECONDS);
+                } catch (Throwable ex) {
+                    Assertions.fail("unexpected behaviour", ex);
+                }
 
-                Awaitility.await()
-                        .atMost(15, TimeUnit.SECONDS)
-                        .untilAsserted(
-                                () -> {
-                                    try {
-                                        client.put(key, value).get(1, TimeUnit.SECONDS);
-                                    } catch (Throwable ex) {
-                                        Assertions.fail("unexpected behaviour", ex);
-                                    }
+                try {
+                    GetResult getResult = client.get("1").get(1, TimeUnit.SECONDS);
+                    Assertions.assertArrayEquals(getResult.value(), value);
+                } catch (Throwable ex) {
+                    Assertions.fail("unexpected behaviour", ex);
+                }
 
-                                    try {
-                                        GetResult getResult = client.get("1").get(1, TimeUnit.SECONDS);
-                                        Assertions.assertArrayEquals(getResult.value(), value);
-                                    } catch (Throwable ex) {
-                                        Assertions.fail("unexpected behaviour", ex);
-                                    }
-                                });
-                break;
+                if (System.currentTimeMillis() - startTime >= elapse) {
+                    oxia.stop();
+
+                    try {
+                        Thread.sleep(3000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+
+                    oxia.start();
+
+                    Awaitility.await()
+                            .atMost(15, TimeUnit.SECONDS)
+                            .untilAsserted(
+                                    () -> {
+                                        try {
+                                            client.put(key, value).get(1, TimeUnit.SECONDS);
+                                        } catch (Throwable ex) {
+                                            Assertions.fail("unexpected behaviour", ex);
+                                        }
+
+                                        try {
+                                            GetResult getResult = client.get("1").get(1, TimeUnit.SECONDS);
+                                            Assertions.assertArrayEquals(getResult.value(), value);
+                                        } catch (Throwable ex) {
+                                            Assertions.fail("unexpected behaviour", ex);
+                                        }
+                                    });
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Motivation
- `ClientReconnectIT` created an async client without closing it.
- After the reconnect scenario stopped/restarted the fixed-port container, the leaked client could keep retrying shard assignment in background threads and make CI appear stuck.

## Modifications
- Wrap the reconnect test client in try-with-resources so it closes when the test exits.
- Allow the test method to throw `Exception` for the AutoCloseable close path.

## Testing
- `./gradlew :client:spotlessJavaApply :client:test --tests io.oxia.client.it.ClientReconnectIT`