### PR TITLE
fix: guard grpc status translation

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -20,6 +20,7 @@ import io.grpc.stub.StreamObserver;
 import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
+import java.time.Duration;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
@@ -122,7 +123,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         }
         log.info()
                 .exceptionMessage(error)
-                .attr("retryDelayMillis", backoffMills)
+                .attr("retryDelay", Duration.ofMillis(backoffMills).toString())
                 .attr("pendingWrites", inflightWrites.size())
                 .log("Scheduling write stream recovery");
         final OxiaStatusException fLeaderHint = leaderHint;


### PR DESCRIPTION
## Motivation
- Prevent malformed rich gRPC status metadata from throwing inside response observer callbacks and leaving callback futures incomplete.
- Make write stream recovery logs easier to read when retry delays are large.

## Modifications
- Wrap the full `OxiaStatusException.toException(...)` translation path and fall back to the outer gRPC status when rich status parsing fails.
- Add a regression test for mismatched outer gRPC status and `grpc-status-details-bin` codes.
- Log write stream recovery delay as `retryDelay=PT...` using `Duration.ofMillis(...)`.

## Testing
- `./gradlew :client:spotlessJavaApply :client:test --tests io.oxia.client.grpc.OxiaStatusExceptionTest --tests io.oxia.client.grpc.ManagedWriteStreamTest`
- `go test ./common/constant` in `oxia-db/oxia` while checking server-side status mapping