### PR TITLE
fix: handle empty shard leader addresses

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
@@ -15,6 +15,7 @@
  */
 package io.oxia.client.grpc;
 
+import static io.oxia.client.grpc.OxiaStatusCode.RESOURCE_UNAVAILABLE;
 import static io.oxia.client.grpc.OxiaStatusCode.SHARD_NOT_FOUND;
 import static io.oxia.client.grpc.OxiaStatusCode.UNKNOWN;
 
@@ -70,6 +71,14 @@ public class OxiaStatusException extends RuntimeException {
                 SHARD_NOT_FOUND,
                 Map.of("shard", Long.toString(shardId)),
                 "Shard not available : " + shardId,
+                null);
+    }
+
+    public static @NonNull OxiaStatusException leaderNotAvailable(long shardId) {
+        return new OxiaStatusException(
+                RESOURCE_UNAVAILABLE,
+                Map.of("shard", Long.toString(shardId)),
+                "Leader not available for shard : " + shardId,
                 null);
     }
 

--- a/client/src/main/java/io/oxia/client/shard/ShardAssignmentsContainer.java
+++ b/client/src/main/java/io/oxia/client/shard/ShardAssignmentsContainer.java
@@ -54,6 +54,9 @@ public class ShardAssignmentsContainer {
         if (shard == null) {
             throw OxiaStatusException.shardNotFound(shardId);
         }
+        if (shard.leader().isBlank()) {
+            throw OxiaStatusException.leaderNotAvailable(shardId);
+        }
 
         return shard.leader();
     }

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -49,6 +49,7 @@ import io.oxia.proto.SessionHeartbeat;
 import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
 import org.junit.jupiter.api.Test;
@@ -332,6 +333,75 @@ class GrpcRpcProviderTest {
         } finally {
             executor.shutdownNow();
             staleLeaderServer.shutdownNow();
+            leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void readRetriesWhenLeaderIsTemporarilyUnavailable() throws Exception {
+        var leaderServerRequests = new AtomicReference<ReadRequest>();
+        var leaderService =
+                new OxiaClientGrpc.OxiaClientImplBase() {
+                    @Override
+                    public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+                        leaderServerRequests.set(request);
+                        responseObserver.onNext(new ReadResponse());
+                        responseObserver.onCompleted();
+                    }
+                };
+        Server leaderServer =
+                ServerBuilder.forPort(0).directExecutor().addService(leaderService).build().start();
+        var leaderAddress = "localhost:" + leaderServer.getPort();
+        var lookupAttempts = new AtomicInteger();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create("localhost:0")
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider =
+                new GrpcRpcProvider(
+                        config,
+                        executor,
+                        shardId -> {
+                            if (lookupAttempts.getAndIncrement() == 0) {
+                                throw OxiaStatusException.leaderNotAvailable(shardId);
+                            }
+                            return leaderAddress;
+                        })) {
+            var request = new ReadRequest();
+            request.setShard(1);
+            var response = new AtomicReference<ReadResponse>();
+            var error = new AtomicReference<Throwable>();
+
+            provider.read(
+                    request,
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(ReadResponse value) {
+                            response.set(value);
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            error.set(t);
+                        }
+
+                        @Override
+                        public void onCompleted() {}
+                    });
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(error.get()).isNull();
+                                assertThat(response.get()).isNotNull();
+                                assertThat(leaderServerRequests.get()).isNotNull();
+                                assertThat(lookupAttempts.get()).isGreaterThanOrEqualTo(2);
+                            });
+        } finally {
+            executor.shutdownNow();
             leaderServer.shutdownNow();
         }
     }

--- a/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
@@ -217,6 +217,18 @@ class OxiaStatusExceptionTest {
     }
 
     @Test
+    void createsLeaderNotAvailableForEmptyShardLeader() {
+        var translated = OxiaStatusException.leaderNotAvailable(1);
+
+        assertThat(translated.getStatusCode()).isEqualTo(OxiaStatusCode.RESOURCE_UNAVAILABLE);
+        assertThat(translated).hasMessage("Leader not available for shard : 1");
+        assertThat(translated.getMetadata()).containsEntry("shard", "1");
+        assertThat(translated).hasNoCause();
+        assertThat(translated.isRetryable()).isTrue();
+        assertThat(OxiaStatusException.from(new CompletionException(translated))).isSameAs(translated);
+    }
+
+    @Test
     void createsShardNotFoundForMissingKeyShard() {
         var translated = OxiaStatusException.shardNotFound("key");
 

--- a/client/src/test/java/io/oxia/client/shard/ShardManagerTest.java
+++ b/client/src/test/java/io/oxia/client/shard/ShardManagerTest.java
@@ -232,5 +232,35 @@ public class ShardManagerTest {
                                 assertThat(oxiaError.getMetadata()).containsEntry("shard", "1");
                             });
         }
+
+        @Test
+        void leaderUnavailableWhenAssignmentLeaderIsEmpty() {
+            var assignment = new ShardAssignment();
+            assignment.setShard(0).setLeader("");
+            assignment.setInt32HashRange().setMinHashInclusive(0).setMaxHashInclusive(Integer.MAX_VALUE);
+
+            doAnswer(
+                            invocation -> {
+                                var sa = new ShardAssignments();
+                                sa.putNamespaces(namespace).addAssignment().copyFrom(assignment);
+                                manager.onNext(sa);
+                                return null;
+                            })
+                    .when(rpcProvider)
+                    .getShardAssignments(any(ShardAssignmentsRequest.class), eq(manager));
+
+            assertThat(manager.start()).succeedsWithin(Duration.ofSeconds(1));
+            assertThat(manager.allShardIds()).containsExactly(0L);
+            assertThatThrownBy(() -> manager.leader(0))
+                    .isInstanceOf(OxiaStatusException.class)
+                    .satisfies(
+                            error -> {
+                                var oxiaError = (OxiaStatusException) error;
+                                assertThat(oxiaError.getStatusCode())
+                                        .isEqualTo(OxiaStatusCode.RESOURCE_UNAVAILABLE);
+                                assertThat(oxiaError.getMetadata()).containsEntry("shard", "0");
+                                assertThat(oxiaError.isRetryable()).isTrue();
+                            });
+        }
     }
 }


### PR DESCRIPTION
## Motivation
- Shard assignments can temporarily report an empty leader address.
- Passing that empty address into gRPC channel creation surfaces a low-level authority error instead of a retryable Oxia error.

## Modifications
- Add `OxiaStatusException.leaderNotAvailable(shardId)` using retryable `RESOURCE_UNAVAILABLE`.
- Return that exception from shard leader lookup when the assignment leader is blank.
- Add coverage for the exception contract, shard-manager lookup behavior, and RPC retry after a temporary missing leader.

## Testing
- `./gradlew --console=plain :client:spotlessCheck`
- `./gradlew --console=plain :client:test --tests 'io.oxia.client.grpc.OxiaStatusExceptionTest' --tests 'io.oxia.client.shard.ShardManagerTest' --tests 'io.oxia.client.grpc.GrpcRpcProviderTest' --rerun-tasks`\n- `./gradlew --console=plain :client:test --rerun-tasks`