### PR TITLE
fix: reset write stream observer after recovery failure

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -56,15 +56,29 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
 
     @Override
     public void onNext(WriteResponse value) {
+        final int pendingBefore = inflightWrites.size();
         final InflightWrite inflight = inflightWrites.poll();
         if (inflight != null) {
-            log.debug().attr("pendingWrites", inflightWrites.size()).log("Received write response");
+            log.debug()
+                    .attr("pendingWritesBefore", pendingBefore)
+                    .attr("pendingWritesAfter", inflightWrites.size())
+                    .log("Received write response");
             inflight.future.complete(value);
+        } else {
+            log.warn()
+                    .attr("pendingWritesBefore", pendingBefore)
+                    .log("Received write response with no inflight write");
         }
     }
 
     @Override
     public void onError(Throwable t) {
+        log.warn()
+                .exceptionMessage(t)
+                .attr("pendingWrites", inflightWrites.size())
+                .attr("observerPresent", subStreamObserver != null)
+                .attr("closed", closed)
+                .log("Write stream received error");
         resetSubObserver();
         if (inflightWrites.isEmpty()) {
             return;
@@ -74,6 +88,11 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
 
     @Override
     public void onCompleted() {
+        log.info()
+                .attr("pendingWrites", inflightWrites.size())
+                .attr("observerPresent", subStreamObserver != null)
+                .attr("closed", closed)
+                .log("Write stream completed");
         resetSubObserver();
         if (inflightWrites.isEmpty()) {
             return;
@@ -86,15 +105,27 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
         final InflightWrite inflightWrite = new InflightWrite(requestSupplier, future);
         try {
+            log.debug()
+                    .attr("pendingWritesBefore", inflightWrites.size())
+                    .attr("observerPresent", subStreamObserver != null)
+                    .attr("closed", closed)
+                    .log("Sending write request");
             if (closed) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
             }
             inflightWrites.add(inflightWrite);
+            log.debug()
+                    .attr("pendingWritesAfterQueue", inflightWrites.size())
+                    .attr("observerPresent", subStreamObserver != null)
+                    .log("Queued write request");
             try {
                 if (subStreamObserver == null) {
                     initWithRecovery(null);
                 } else {
                     subStreamObserver.onNext(inflightWrite.requestSupplier.get());
+                    log.debug()
+                            .attr("pendingWrites", inflightWrites.size())
+                            .log("Sent write request on existing stream");
                 }
             } catch (Throwable ex) {
                 log.warn().exceptionMessage(ex).log("Failed to send write request, retrying");
@@ -136,10 +167,14 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                             return;
                         }
                         if (subStreamObserver != null) {
+                            log.debug()
+                                    .attr("pendingWrites", inflightWrites.size())
+                                    .log("Skipping write stream recovery because observer is present");
                             return;
                         }
                         initWithRecovery(fLeaderHint);
                     } catch (Throwable ex) {
+                        subStreamObserver = null;
                         log.error().exceptionMessage(ex).log("Failed to recover write stream");
                         scheduleRetry(ex, backoff.nextDelayMillis());
                     } finally {
@@ -153,6 +188,10 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
     private void resetSubObserver() {
         lock.lock();
         try {
+            log.debug()
+                    .attr("pendingWrites", inflightWrites.size())
+                    .attr("hadObserver", subStreamObserver != null)
+                    .log("Resetting write stream observer");
             subStreamObserver = null;
         } finally {
             lock.unlock();
@@ -162,9 +201,14 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
     private void initWithRecovery(OxiaStatusException leaderHint) {
         subStreamObserver = rpcProvider.writeStream(shardId, leaderHint, this);
         log.info().attr("pendingWrites", inflightWrites.size()).log("Opened write stream");
+        log.debug()
+                .attr("pendingWrites", inflightWrites.size())
+                .attr("leaderHint", leaderHint)
+                .log("Replaying inflight writes on opened stream");
         for (InflightWrite inflightWrite : inflightWrites) {
             subStreamObserver.onNext(inflightWrite.requestSupplier.get());
         }
+        log.debug().attr("pendingWrites", inflightWrites.size()).log("Replayed inflight writes");
         backoff.reset();
     }
 

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -18,6 +18,11 @@ package io.oxia.client.grpc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.protobuf.Any;
 import com.google.rpc.ErrorInfo;
@@ -163,6 +168,64 @@ class ManagedWriteStreamTest {
             executor.shutdownNow();
             staleServer.shutdownNow();
             leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void resetsObserverWhenRecoveryReplayFails() throws Exception {
+        var rpcProvider = mock(RpcProvider.class);
+        var openAttempts = new AtomicInteger();
+        var replayFailures = new AtomicInteger();
+        var requests = new ConcurrentLinkedQueue<WriteRequest>();
+        when(rpcProvider.writeStream(anyLong(), nullable(OxiaStatusException.class), any()))
+                .thenAnswer(
+                        invocation -> {
+                            var responseObserver = invocation.<StreamObserver<WriteResponse>>getArgument(2);
+                            var attempt = openAttempts.incrementAndGet();
+                            return new StreamObserver<WriteRequest>() {
+                                @Override
+                                public void onNext(WriteRequest value) {
+                                    requests.add(value);
+                                    if (attempt == 2) {
+                                        replayFailures.incrementAndGet();
+                                        throw Status.UNAVAILABLE.withDescription("failed replay").asRuntimeException();
+                                    }
+                                    if (attempt == 3) {
+                                        responseObserver.onNext(new WriteResponse());
+                                    }
+                                }
+
+                                @Override
+                                public void onError(Throwable t) {}
+
+                                @Override
+                                public void onCompleted() {}
+                            };
+                        });
+
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        try (var stream = new ManagedWriteStream(1, rpcProvider, executor)) {
+            var future = stream.send(() -> writeRequest(1));
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(openAttempts).hasValue(1);
+                                assertThat(requests).hasSize(1);
+                            });
+
+            stream.onError(Status.UNAVAILABLE.withDescription("stale leader").asRuntimeException());
+
+            future.get(5, TimeUnit.SECONDS);
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(openAttempts).hasValue(3);
+                                assertThat(replayFailures).hasValue(1);
+                                assertThat(keys(requests)).containsExactly("key-1", "key-1", "key-1");
+                            });
+        } finally {
+            executor.shutdownNow();
         }
     }
 


### PR DESCRIPTION
## Motivation
- A write stream recovery can fail after assigning `subStreamObserver`, leaving the stream with pending writes and a non-null observer.
- Later scheduled recoveries then skip because the observer is present, so pending writes are never replayed.

## Modifications
- Reset `subStreamObserver` when scheduled write stream recovery throws before scheduling the next retry.
- Keep the diagnostic write stream logs for pending write and observer state.
- Add a regression test covering a replay failure after stream recovery opens.

## Testing
- `./gradlew --console=plain :client:spotlessCheck`
- `./gradlew --console=plain :client:test --tests 'io.oxia.client.grpc.ManagedWriteStreamTest' --rerun-tasks`