### PR TITLE
fix: avoid write stream retry in rpc provider

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -256,29 +256,22 @@ final class GrpcRpcProvider implements RpcProvider {
             long shardId,
             OxiaStatusException leaderHint,
             StreamObserver<WriteResponse> responseObserver) {
-        final var guardedObserver = ManagedObservers.toGuardedStreamObserver(responseObserver);
         final var hint = new AtomicReference<>(leaderHint);
-        return Failsafe.with(getRetryPolicy("write stream", hint))
-                .get(
-                        () -> {
-                            final var future = new CompletableFuture<Void>();
-                            final var barrierObserver =
-                                    ManagedObservers.toBarrierStreamObserver(guardedObserver, future);
-                            final var headers = new Metadata();
-                            headers.put(NAMESPACE_KEY, clientConfig.namespace());
-                            headers.put(SHARD_ID_KEY, Long.toString(shardId));
-                            final var requestObserver =
-                                    connectionManager
-                                            .getConnection(getLeader(shardId, hint))
-                                            .stub()
-                                            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers))
-                                            .writeStream(barrierObserver);
-                            // we don't need to wait for the stream to be ready, only need to check if it fail
-                            // fast
-                            future.complete(null);
-                            future.join();
-                            return requestObserver;
-                        });
+        final var future = new CompletableFuture<Void>();
+        final var barrierObserver = ManagedObservers.toBarrierStreamObserver(responseObserver, future);
+        final var headers = new Metadata();
+        headers.put(NAMESPACE_KEY, clientConfig.namespace());
+        headers.put(SHARD_ID_KEY, Long.toString(shardId));
+        final var requestObserver =
+                connectionManager
+                        .getConnection(getLeader(shardId, hint))
+                        .stub()
+                        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers))
+                        .writeStream(barrierObserver);
+        // we don't need to wait for the stream to be ready, only need to check if it's fast failed
+        future.complete(null);
+        future.join();
+        return requestObserver;
     }
 
     @Override

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -16,7 +16,9 @@
 package io.oxia.client.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import com.google.protobuf.Any;
 import com.google.rpc.ErrorInfo;
@@ -46,6 +48,7 @@ import io.oxia.proto.RangeScanResponse;
 import io.oxia.proto.ReadRequest;
 import io.oxia.proto.ReadResponse;
 import io.oxia.proto.SessionHeartbeat;
+import io.oxia.proto.WriteResponse;
 import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -403,6 +406,50 @@ class GrpcRpcProviderTest {
         } finally {
             executor.shutdownNow();
             leaderServer.shutdownNow();
+        }
+    }
+
+    @Test
+    void writeStreamDoesNotRetryLeaderLookupFailure() throws Exception {
+        var lookupAttempts = new AtomicInteger();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create("localhost:0")
+                                        .connectionBackoff(Duration.ofSeconds(5), Duration.ofSeconds(5)))
+                        .getClientConfig();
+
+        try (var provider =
+                new GrpcRpcProvider(
+                        config,
+                        executor,
+                        shardId -> {
+                            lookupAttempts.incrementAndGet();
+                            throw OxiaStatusException.leaderNotAvailable(shardId);
+                        })) {
+            assertTimeoutPreemptively(
+                    Duration.ofMillis(500),
+                    () ->
+                            assertThatThrownBy(
+                                            () ->
+                                                    provider.writeStream(
+                                                            1,
+                                                            null,
+                                                            new StreamObserver<WriteResponse>() {
+                                                                @Override
+                                                                public void onNext(WriteResponse value) {}
+
+                                                                @Override
+                                                                public void onError(Throwable t) {}
+
+                                                                @Override
+                                                                public void onCompleted() {}
+                                                            }))
+                                    .isInstanceOf(OxiaStatusException.class));
+
+            assertThat(lookupAttempts).hasValue(1);
+        } finally {
+            executor.shutdownNow();
         }
     }
 


### PR DESCRIPTION
## Motivation
- `GrpcRpcProvider.writeStream()` retried stream-open failures synchronously, which could hold `oxia-client-async` executor threads during retry backoff.
- `ManagedWriteStream` already owns write-stream recovery and replay, so retrying in both layers can starve other client recovery work such as shard assignment refresh.

## Runtime Evidence
Captured adapter logs from the stuck run showed write-stream retries sleeping for 30s on the shared client executor threads:

```text
[oxia-client-async-1-7] WARN io.oxia.client.grpc.GrpcRpcProvider - Retrying write stream after PT30S. attempt=12 exception=Leader not available for shard : 31
[oxia-client-async-1-9] WARN io.oxia.client.grpc.GrpcRpcProvider - Retrying write stream after PT30S. attempt=12 exception=Leader not available for shard : 16
[oxia-client-async-1-3] WARN io.oxia.client.grpc.GrpcRpcProvider - Retrying write stream after PT30S. attempt=12 exception=Leader not available for shard : 6
```

The old synchronous call path blocks the `oxia-client-async-*` worker inside Failsafe retry backoff:

```text
"oxia-client-async-1-7" TIMED_WAITING (sleeping)
  at java.base/java.lang.Thread.sleep(Native Method)
  at dev.failsafe.internal.RetryPolicyExecutor.lambda$apply$0(RetryPolicyExecutor.java:89)
  at dev.failsafe.spi.SyncExecutionImpl.executeSync(SyncExecutionImpl.java)
  at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:375)
  at dev.failsafe.FailsafeExecutor.get(FailsafeExecutor.java)
  at io.oxia.client.grpc.GrpcRpcProvider.writeStream(GrpcRpcProvider.java:261)
  at io.oxia.client.grpc.ManagedWriteStream.initWithRecovery(ManagedWriteStream.java:210)
  at io.oxia.client.grpc.ManagedWriteStream.lambda$scheduleRetry$3(ManagedWriteStream.java:181)
  at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java)
  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
  at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java)
  at java.base/java.lang.Thread.run(Thread.java)
```

## Modifications
- Removed the synchronous Failsafe retry loop from `GrpcRpcProvider.writeStream()`.
- Kept write-stream open as a single attempt that throws to the caller on failure.
- Added a regression test that verifies retryable leader lookup failures are not retried by `writeStream()`.

## Testing
- `./gradlew :client:check`
- `./gradlew build`
- `./gradlew :client:test --tests 'io.oxia.client.it.NotificationIt.testDeleteRange' --rerun-tasks`
