### PR TITLE
fix: guard stale write stream callbacks

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -248,9 +248,7 @@ final class GrpcRpcProvider implements RpcProvider {
     @Override
     public ManagedWriteStream getWriteStream(long shardId) {
         return writeStreams.computeIfAbsent(
-                shardId,
-                (__) ->
-                        new ManagedWriteStream(shardId, this, asyncExecutor, clientConfig.requestTimeout()));
+                shardId, (__) -> new ManagedWriteStream(shardId, this, asyncExecutor));
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -248,7 +248,9 @@ final class GrpcRpcProvider implements RpcProvider {
     @Override
     public ManagedWriteStream getWriteStream(long shardId) {
         return writeStreams.computeIfAbsent(
-                shardId, (__) -> new ManagedWriteStream(shardId, this, asyncExecutor));
+                shardId,
+                (__) ->
+                        new ManagedWriteStream(shardId, this, asyncExecutor, clientConfig.requestTimeout()));
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/ManagedSubWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedSubWriteStream.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+import io.grpc.stub.StreamObserver;
+import io.oxia.proto.WriteRequest;
+import io.oxia.proto.WriteResponse;
+
+final class ManagedSubWriteStream implements StreamObserver<WriteResponse> {
+
+    private final ManagedWriteStream parent;
+    private final StreamObserver<WriteRequest> requestObserver;
+
+    ManagedSubWriteStream(
+            ManagedWriteStream parent,
+            RpcProvider rpcProvider,
+            long shardId,
+            OxiaStatusException leaderHint) {
+        this.parent = parent;
+        this.requestObserver = rpcProvider.writeStream(shardId, leaderHint, this);
+    }
+
+    void send(WriteRequest request) {
+        requestObserver.onNext(request);
+    }
+
+    void complete() {
+        requestObserver.onCompleted();
+    }
+
+    @Override
+    public void onNext(WriteResponse value) {
+        parent.handleResponse(this, value);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        parent.handleError(this, t);
+    }
+
+    @Override
+    public void onCompleted() {
+        parent.handleCompleted(this);
+    }
+}

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -16,17 +16,22 @@
 package io.oxia.client.grpc;
 
 import io.github.merlimat.slog.Logger;
-import io.grpc.stub.StreamObserver;
 import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
+
 import java.time.Duration;
-import java.util.Queue;
-import java.util.concurrent.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
-public final class ManagedWriteStream implements AutoCloseable, StreamObserver<WriteResponse> {
+public final class ManagedWriteStream implements AutoCloseable {
     private final Logger log;
 
     record InflightWrite(
@@ -39,14 +44,14 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
 
     private final ReentrantLock lock;
     private boolean closed;
-    private final Queue<InflightWrite> inflightWrites;
-    private StreamObserver<WriteRequest> subStreamObserver;
+    private final Deque<InflightWrite> inflightWrites;
+    private ManagedSubWriteStream subStreamObserver;
 
     public ManagedWriteStream(
             long shardId, RpcProvider rpcProvider, ScheduledExecutorService asyncExecutor) {
         this.shardId = shardId;
         this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
-        this.inflightWrites = new ConcurrentLinkedQueue<>();
+        this.inflightWrites = new ArrayDeque<>();
         this.rpcProvider = rpcProvider;
         this.lock = new ReentrantLock();
         this.asyncExecutor = asyncExecutor;
@@ -54,48 +59,82 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         this.closed = false;
     }
 
-    @Override
-    public void onNext(WriteResponse value) {
-        final InflightWrite inflight = inflightWrites.poll();
+    void handleResponse(ManagedSubWriteStream source, WriteResponse value) {
+        final InflightWrite inflight;
+        final int pendingWrites;
+        lock.lock();
+        try {
+            if (source != subStreamObserver) {
+                log.debug("Ignoring write response from inactive stream");
+                return;
+            }
+            inflight = inflightWrites.pollFirst();
+            pendingWrites = inflightWrites.size();
+        } finally {
+            lock.unlock();
+        }
+
         if (inflight != null) {
-            log.debug(
-                    event ->
-                            event.attr("pendingWrites", inflightWrites.size()).log("Received write response"));
+            log.debug(event -> event.attr("pendingWrites", pendingWrites).log("Received write response"));
             inflight.future.complete(value);
         } else {
             log.warn()
-                    .attr("pendingWrites", inflightWrites.size())
+                    .attr("pendingWrites", pendingWrites)
                     .log("Received write response with no inflight write");
         }
     }
 
-    @Override
-    public void onError(Throwable t) {
-        log.warn()
-                .exceptionMessage(t)
-                .attr("pendingWrites", inflightWrites.size())
-                .attr("observerPresent", subStreamObserver != null)
-                .attr("closed", closed)
-                .log("Write stream received error");
-        resetSubObserver();
-        if (inflightWrites.isEmpty()) {
-            return;
+    void handleError(ManagedSubWriteStream source, Throwable t) {
+        final boolean shouldRetry;
+        final OxiaStatusException maybeLeaderHint;
+        final Runnable deferFail;
+        lock.lock();
+        try {
+            if (source != subStreamObserver) {
+                log.debug().exceptionMessage(t).log("Ignoring error from inactive write stream");
+                return;
+            }
+            log.warn()
+                    .exceptionMessage(t)
+                    .attr("pendingWrites", inflightWrites.size())
+                    .attr("observerPresent", subStreamObserver != null)
+                    .attr("closed", closed)
+                    .log("Write stream received error");
+            final OxiaStatusException oxiaStatusException = OxiaStatusException.from(t);
+            maybeLeaderHint = oxiaStatusException;
+            subStreamObserver = null;
+            deferFail = failHeadInflightIfNonRetryable(oxiaStatusException);
+            shouldRetry = !inflightWrites.isEmpty();
+        } finally {
+            lock.unlock();
         }
-        scheduleRetry(t, 0); // retry immediately
+        deferFail.run(); // call it without lock
+        if (shouldRetry) {
+            scheduleRetry(maybeLeaderHint, 0); // retry immediately
+        }
     }
 
-    @Override
-    public void onCompleted() {
-        log.info()
-                .attr("pendingWrites", inflightWrites.size())
-                .attr("observerPresent", subStreamObserver != null)
-                .attr("closed", closed)
-                .log("Write stream completed");
-        resetSubObserver();
-        if (inflightWrites.isEmpty()) {
-            return;
+    void handleCompleted(ManagedSubWriteStream source) {
+        boolean shouldRetry;
+        lock.lock();
+        try {
+            if (source != subStreamObserver) {
+                log.debug("Ignoring completion from inactive write stream");
+                return;
+            }
+            log.info()
+                    .attr("pendingWrites", inflightWrites.size())
+                    .attr("observerPresent", subStreamObserver != null)
+                    .attr("closed", closed)
+                    .log("Write stream completed");
+            subStreamObserver = null;
+            shouldRetry = !inflightWrites.isEmpty();
+        } finally {
+            lock.unlock();
         }
-        scheduleRetry(null, 0); // retry immediately
+        if (shouldRetry) {
+            scheduleRetry(null, 0); // retry immediately
+        }
     }
 
     public CompletableFuture<WriteResponse> send(Supplier<WriteRequest> requestSupplier) {
@@ -113,7 +152,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
             if (closed) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
             }
-            inflightWrites.add(inflightWrite);
+            inflightWrites.addLast(inflightWrite);
             log.debug(
                     event ->
                             event
@@ -124,7 +163,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                 if (subStreamObserver == null) {
                     initWithRecovery(null);
                 } else {
-                    subStreamObserver.onNext(inflightWrite.requestSupplier.get());
+                    subStreamObserver.send(inflightWrite.requestSupplier.get());
                     log.debug(
                             event ->
                                     event
@@ -143,27 +182,17 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
         }
     }
 
-    private void scheduleRetry(Throwable error, long backoffMills) {
-        OxiaStatusException leaderHint = null;
-        if (error != null) {
-            final var translated = OxiaStatusException.from(error);
-            if (translated.isRetryable()) {
-                leaderHint = translated;
-            } else {
-                final InflightWrite inflight = inflightWrites.poll();
-                if (inflight != null) {
-                    inflight.future.completeExceptionally(translated);
-                }
-            }
-        }
+    private void scheduleRetry(OxiaStatusException maybeLeaderHint, long backoffMills) {
         log.info()
-                .exceptionMessage(error)
+                .exceptionMessage(maybeLeaderHint)
                 .attr("retryDelay", Duration.ofMillis(backoffMills).toString())
                 .attr("pendingWrites", inflightWrites.size())
                 .log("Scheduling write stream recovery");
-        final OxiaStatusException fLeaderHint = leaderHint;
         asyncExecutor.schedule(
                 () -> {
+                    Runnable deferFail = () -> {};
+                    OxiaStatusException oxiaStatusException = null;
+                    boolean shouldRetry = false;
                     lock.lock();
                     try {
                         if (closed) {
@@ -178,36 +207,44 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                                                     .log("Skipping write stream recovery because observer is present"));
                             return;
                         }
-                        initWithRecovery(fLeaderHint);
-                    } catch (Throwable ex) {
+                        initWithRecovery(maybeLeaderHint);
+                    } catch (Throwable exception) {
+                        log.error().exceptionMessage(exception).log("Failed to recover write stream");
+                        oxiaStatusException = OxiaStatusException.from(exception);
                         subStreamObserver = null;
-                        log.error().exceptionMessage(ex).log("Failed to recover write stream");
-                        scheduleRetry(ex, backoff.nextDelayMillis());
+                        deferFail = failHeadInflightIfNonRetryable(oxiaStatusException);
+                        shouldRetry = !inflightWrites.isEmpty();
                     } finally {
                         lock.unlock();
+                        deferFail.run();
+                        if (shouldRetry) {
+                            scheduleRetry(oxiaStatusException, backoff.nextDelayMillis());
+                        }
                     }
                 },
                 backoffMills,
                 TimeUnit.MILLISECONDS);
     }
 
-    private void resetSubObserver() {
-        lock.lock();
-        try {
-            log.debug(
-                    event ->
-                            event
-                                    .attr("pendingWrites", inflightWrites.size())
-                                    .attr("hadObserver", subStreamObserver != null)
-                                    .log("Resetting write stream observer"));
-            subStreamObserver = null;
-        } finally {
-            lock.unlock();
+    private Runnable failHeadInflightIfNonRetryable(OxiaStatusException oxiaStatusException) {
+        if (!oxiaStatusException.isRetryable()) {
+            final InflightWrite inflightWrite = inflightWrites.pollFirst();
+            if (inflightWrite != null) {
+                return () -> {
+                    try {
+                        inflightWrite.future.completeExceptionally(oxiaStatusException);
+                    } catch (Throwable ex) {
+                        log.warn().exceptionMessage(ex).log("Failed to complete non-retryable inflight write");
+                    }
+                };
+            }
         }
+        return () -> {};
     }
 
+
     private void initWithRecovery(OxiaStatusException leaderHint) {
-        subStreamObserver = rpcProvider.writeStream(shardId, leaderHint, this);
+        subStreamObserver = new ManagedSubWriteStream(this, rpcProvider, shardId, leaderHint);
         log.info().attr("pendingWrites", inflightWrites.size()).log("Opened write stream");
         log.debug(
                 event ->
@@ -216,7 +253,7 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
                                 .attr("leaderHint", leaderHint)
                                 .log("Replaying inflight writes on opened stream"));
         for (InflightWrite inflightWrite : inflightWrites) {
-            subStreamObserver.onNext(inflightWrite.requestSupplier.get());
+            subStreamObserver.send(inflightWrite.requestSupplier.get());
         }
         log.debug(
                 event ->
@@ -226,27 +263,32 @@ public final class ManagedWriteStream implements AutoCloseable, StreamObserver<W
 
     @Override
     public void close() {
+        var inflightsToFail = new ArrayList<InflightWrite>();
+        Throwable closeError = null;
         lock.lock();
         try {
             closed = true;
             if (subStreamObserver != null) {
-                subStreamObserver.onCompleted();
+                subStreamObserver.complete();
                 subStreamObserver = null;
             }
             log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
-            inflightWrites.forEach(
-                    inflight -> {
-                        inflight.future.completeExceptionally(new CancellationException("Stream is closed"));
-                    });
+            inflightsToFail.addAll(inflightWrites);
             inflightWrites.clear();
         } catch (Throwable ex) {
-            inflightWrites.forEach(
-                    inflight -> {
-                        inflight.future.completeExceptionally(ex);
-                    });
+            closeError = ex;
+            inflightsToFail.addAll(inflightWrites);
             inflightWrites.clear();
         } finally {
             lock.unlock();
         }
+        if (closeError != null) {
+            final var error = closeError;
+            inflightsToFail.forEach(inflight -> inflight.future.completeExceptionally(error));
+            return;
+        }
+        inflightsToFail.forEach(
+                inflight ->
+                        inflight.future.completeExceptionally(new CancellationException("Stream is closed")));
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -26,7 +26,9 @@ import java.util.Deque;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
@@ -39,21 +41,32 @@ public final class ManagedWriteStream implements AutoCloseable {
     private final long shardId;
     private final RpcProvider rpcProvider;
     private final ScheduledExecutorService asyncExecutor;
+    private final Duration requestTimeout;
     private final Backoff backoff;
 
     private final ReentrantLock lock;
     private boolean closed;
     private final Deque<InflightWrite> inflightWrites;
     private ManagedSubWriteStream subStreamObserver;
+    private ScheduledFuture<?> headTimeout;
 
     public ManagedWriteStream(
             long shardId, RpcProvider rpcProvider, ScheduledExecutorService asyncExecutor) {
+        this(shardId, rpcProvider, asyncExecutor, Duration.ofSeconds(30));
+    }
+
+    ManagedWriteStream(
+            long shardId,
+            RpcProvider rpcProvider,
+            ScheduledExecutorService asyncExecutor,
+            Duration requestTimeout) {
         this.shardId = shardId;
         this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
         this.inflightWrites = new ArrayDeque<>();
         this.rpcProvider = rpcProvider;
         this.lock = new ReentrantLock();
         this.asyncExecutor = asyncExecutor;
+        this.requestTimeout = requestTimeout;
         this.backoff = new Backoff();
         this.closed = false;
     }
@@ -67,8 +80,10 @@ public final class ManagedWriteStream implements AutoCloseable {
                 log.debug("Ignoring write response from inactive stream");
                 return;
             }
+            cancelHeadTimeout();
             inflight = inflightWrites.pollFirst();
             pendingWrites = inflightWrites.size();
+            scheduleHeadTimeoutIfNeeded();
         } finally {
             lock.unlock();
         }
@@ -152,6 +167,7 @@ public final class ManagedWriteStream implements AutoCloseable {
                 return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
             }
             inflightWrites.addLast(inflightWrite);
+            scheduleHeadTimeoutIfNeeded();
             log.debug(
                     event ->
                             event
@@ -198,6 +214,10 @@ public final class ManagedWriteStream implements AutoCloseable {
                             log.info("Skipping write stream recovery after close");
                             return;
                         }
+                        if (inflightWrites.isEmpty()) {
+                            log.info("Skipping write stream recovery because no writes are pending");
+                            return;
+                        }
                         if (subStreamObserver != null) {
                             log.debug(
                                     event ->
@@ -227,7 +247,9 @@ public final class ManagedWriteStream implements AutoCloseable {
 
     private Runnable failHeadInflightIfNonRetryable(OxiaStatusException oxiaStatusException) {
         if (!oxiaStatusException.isRetryable()) {
+            cancelHeadTimeout();
             final InflightWrite inflightWrite = inflightWrites.pollFirst();
+            scheduleHeadTimeoutIfNeeded();
             if (inflightWrite != null) {
                 return () -> {
                     try {
@@ -239,6 +261,58 @@ public final class ManagedWriteStream implements AutoCloseable {
             }
         }
         return () -> {};
+    }
+
+    private void scheduleHeadTimeoutIfNeeded() {
+        if (headTimeout != null || inflightWrites.isEmpty()) {
+            return;
+        }
+
+        final InflightWrite headInflight = inflightWrites.peekFirst();
+        headTimeout =
+                asyncExecutor.schedule(
+                        () -> handleHeadTimeout(headInflight),
+                        requestTimeout.toMillis(),
+                        TimeUnit.MILLISECONDS);
+    }
+
+    private void cancelHeadTimeout() {
+        if (headTimeout != null) {
+            headTimeout.cancel(false);
+            headTimeout = null;
+        }
+    }
+
+    private void handleHeadTimeout(InflightWrite expectedHead) {
+        final var inflightsToFail = new ArrayList<InflightWrite>();
+        final ManagedSubWriteStream streamToComplete;
+        lock.lock();
+        try {
+            if (closed || inflightWrites.peekFirst() != expectedHead) {
+                return;
+            }
+            streamToComplete = subStreamObserver;
+            subStreamObserver = null;
+            headTimeout = null;
+            log.warn()
+                    .attr("pendingWrites", inflightWrites.size())
+                    .attr("requestTimeout", requestTimeout.toString())
+                    .log("Write stream head request timed out");
+            inflightsToFail.addAll(inflightWrites);
+            inflightWrites.clear();
+        } finally {
+            lock.unlock();
+        }
+        if (streamToComplete != null) {
+            try {
+                streamToComplete.complete();
+            } catch (Throwable ex) {
+                log.warn().exceptionMessage(ex).log("Failed to complete timed-out write stream");
+            }
+        }
+        final var timeout =
+                new TimeoutException("Write stream head request timed out after " + requestTimeout);
+        inflightsToFail.forEach(inflight -> inflight.future.completeExceptionally(timeout));
     }
 
     private void initWithRecovery(OxiaStatusException leaderHint) {
@@ -270,6 +344,7 @@ public final class ManagedWriteStream implements AutoCloseable {
                 subStreamObserver.complete();
                 subStreamObserver = null;
             }
+            cancelHeadTimeout();
             log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
             inflightsToFail.addAll(inflightWrites);
             inflightWrites.clear();

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -26,9 +26,7 @@ import java.util.Deque;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
@@ -41,32 +39,21 @@ public final class ManagedWriteStream implements AutoCloseable {
     private final long shardId;
     private final RpcProvider rpcProvider;
     private final ScheduledExecutorService asyncExecutor;
-    private final Duration requestTimeout;
     private final Backoff backoff;
 
     private final ReentrantLock lock;
     private boolean closed;
     private final Deque<InflightWrite> inflightWrites;
     private ManagedSubWriteStream subStreamObserver;
-    private ScheduledFuture<?> headTimeout;
 
     public ManagedWriteStream(
             long shardId, RpcProvider rpcProvider, ScheduledExecutorService asyncExecutor) {
-        this(shardId, rpcProvider, asyncExecutor, Duration.ofSeconds(30));
-    }
-
-    ManagedWriteStream(
-            long shardId,
-            RpcProvider rpcProvider,
-            ScheduledExecutorService asyncExecutor,
-            Duration requestTimeout) {
         this.shardId = shardId;
         this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
         this.inflightWrites = new ArrayDeque<>();
         this.rpcProvider = rpcProvider;
         this.lock = new ReentrantLock();
         this.asyncExecutor = asyncExecutor;
-        this.requestTimeout = requestTimeout;
         this.backoff = new Backoff();
         this.closed = false;
     }
@@ -80,10 +67,8 @@ public final class ManagedWriteStream implements AutoCloseable {
                 log.debug("Ignoring write response from inactive stream");
                 return;
             }
-            cancelHeadTimeout();
             inflight = inflightWrites.pollFirst();
             pendingWrites = inflightWrites.size();
-            scheduleHeadTimeoutIfNeeded();
         } finally {
             lock.unlock();
         }
@@ -167,7 +152,6 @@ public final class ManagedWriteStream implements AutoCloseable {
                 return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
             }
             inflightWrites.addLast(inflightWrite);
-            scheduleHeadTimeoutIfNeeded();
             log.debug(
                     event ->
                             event
@@ -214,10 +198,6 @@ public final class ManagedWriteStream implements AutoCloseable {
                             log.info("Skipping write stream recovery after close");
                             return;
                         }
-                        if (inflightWrites.isEmpty()) {
-                            log.info("Skipping write stream recovery because no writes are pending");
-                            return;
-                        }
                         if (subStreamObserver != null) {
                             log.debug(
                                     event ->
@@ -247,9 +227,7 @@ public final class ManagedWriteStream implements AutoCloseable {
 
     private Runnable failHeadInflightIfNonRetryable(OxiaStatusException oxiaStatusException) {
         if (!oxiaStatusException.isRetryable()) {
-            cancelHeadTimeout();
             final InflightWrite inflightWrite = inflightWrites.pollFirst();
-            scheduleHeadTimeoutIfNeeded();
             if (inflightWrite != null) {
                 return () -> {
                     try {
@@ -261,58 +239,6 @@ public final class ManagedWriteStream implements AutoCloseable {
             }
         }
         return () -> {};
-    }
-
-    private void scheduleHeadTimeoutIfNeeded() {
-        if (headTimeout != null || inflightWrites.isEmpty()) {
-            return;
-        }
-
-        final InflightWrite headInflight = inflightWrites.peekFirst();
-        headTimeout =
-                asyncExecutor.schedule(
-                        () -> handleHeadTimeout(headInflight),
-                        requestTimeout.toMillis(),
-                        TimeUnit.MILLISECONDS);
-    }
-
-    private void cancelHeadTimeout() {
-        if (headTimeout != null) {
-            headTimeout.cancel(false);
-            headTimeout = null;
-        }
-    }
-
-    private void handleHeadTimeout(InflightWrite expectedHead) {
-        final var inflightsToFail = new ArrayList<InflightWrite>();
-        final ManagedSubWriteStream streamToComplete;
-        lock.lock();
-        try {
-            if (closed || inflightWrites.peekFirst() != expectedHead) {
-                return;
-            }
-            streamToComplete = subStreamObserver;
-            subStreamObserver = null;
-            headTimeout = null;
-            log.warn()
-                    .attr("pendingWrites", inflightWrites.size())
-                    .attr("requestTimeout", requestTimeout.toString())
-                    .log("Write stream head request timed out");
-            inflightsToFail.addAll(inflightWrites);
-            inflightWrites.clear();
-        } finally {
-            lock.unlock();
-        }
-        if (streamToComplete != null) {
-            try {
-                streamToComplete.complete();
-            } catch (Throwable ex) {
-                log.warn().exceptionMessage(ex).log("Failed to complete timed-out write stream");
-            }
-        }
-        final var timeout =
-                new TimeoutException("Write stream head request timed out after " + requestTimeout);
-        inflightsToFail.forEach(inflight -> inflight.future.completeExceptionally(timeout));
     }
 
     private void initWithRecovery(OxiaStatusException leaderHint) {
@@ -344,7 +270,6 @@ public final class ManagedWriteStream implements AutoCloseable {
                 subStreamObserver.complete();
                 subStreamObserver = null;
             }
-            cancelHeadTimeout();
             log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
             inflightsToFail.addAll(inflightWrites);
             inflightWrites.clear();

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -19,7 +19,6 @@ import io.github.merlimat.slog.Logger;
 import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
-
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -241,7 +240,6 @@ public final class ManagedWriteStream implements AutoCloseable {
         }
         return () -> {};
     }
-
 
     private void initWithRecovery(OxiaStatusException leaderHint) {
         subStreamObserver = new ManagedSubWriteStream(this, rpcProvider, shardId, leaderHint);

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -42,8 +42,11 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class ManagedWriteStreamTest {
@@ -276,6 +279,73 @@ class ManagedWriteStreamTest {
             assertThat(requestCount).hasValue(2);
         } finally {
             executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void headTimeoutFailsCurrentInflightsAndStartsFreshForFutureWrites() throws Exception {
+        var rpcProvider = mock(RpcProvider.class);
+        var responseObservers = new ConcurrentLinkedQueue<StreamObserver<WriteResponse>>();
+        var requestCount = new AtomicInteger();
+        var completedStreams = new AtomicInteger();
+        when(rpcProvider.writeStream(anyLong(), nullable(OxiaStatusException.class), any()))
+                .thenAnswer(
+                        invocation -> {
+                            var responseObserver = invocation.<StreamObserver<WriteResponse>>getArgument(2);
+                            responseObservers.add(responseObserver);
+                            return new StreamObserver<WriteRequest>() {
+                                @Override
+                                public void onNext(WriteRequest value) {
+                                    requestCount.incrementAndGet();
+                                }
+
+                                @Override
+                                public void onError(Throwable t) {}
+
+                                @Override
+                                public void onCompleted() {
+                                    completedStreams.incrementAndGet();
+                                }
+                            };
+                        });
+
+        var timeoutTask = new AtomicReference<Runnable>();
+        var executor = mock(ScheduledExecutorService.class);
+        when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+                .thenAnswer(
+                        invocation -> {
+                            timeoutTask.set(invocation.getArgument(0));
+                            return mock(ScheduledFuture.class);
+                        });
+
+        try (var stream = new ManagedWriteStream(1, rpcProvider, executor, Duration.ofSeconds(30))) {
+            var first = stream.send(() -> writeRequest(1));
+            var second = stream.send(() -> writeRequest(2));
+            assertThat(requestCount).hasValue(2);
+            assertThat(responseObservers).hasSize(1);
+
+            timeoutTask.get().run();
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(first).isCompletedExceptionally();
+                                assertThat(second).isCompletedExceptionally();
+                                assertThat(completedStreams).hasValue(1);
+                            });
+            assertThatThrownBy(first::get)
+                    .hasCauseInstanceOf(java.util.concurrent.TimeoutException.class);
+            assertThatThrownBy(second::get)
+                    .hasCauseInstanceOf(java.util.concurrent.TimeoutException.class);
+
+            responseObservers.peek().onNext(new WriteResponse());
+
+            var third = stream.send(() -> writeRequest(3));
+            await().untilAsserted(() -> assertThat(responseObservers).hasSize(2));
+            responseObservers.stream().skip(1).findFirst().orElseThrow().onNext(new WriteResponse());
+
+            third.get(5, TimeUnit.SECONDS);
+            assertThat(requestCount).hasValue(3);
         }
     }
 

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -42,11 +42,8 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class ManagedWriteStreamTest {
@@ -279,73 +276,6 @@ class ManagedWriteStreamTest {
             assertThat(requestCount).hasValue(2);
         } finally {
             executor.shutdownNow();
-        }
-    }
-
-    @Test
-    void headTimeoutFailsCurrentInflightsAndStartsFreshForFutureWrites() throws Exception {
-        var rpcProvider = mock(RpcProvider.class);
-        var responseObservers = new ConcurrentLinkedQueue<StreamObserver<WriteResponse>>();
-        var requestCount = new AtomicInteger();
-        var completedStreams = new AtomicInteger();
-        when(rpcProvider.writeStream(anyLong(), nullable(OxiaStatusException.class), any()))
-                .thenAnswer(
-                        invocation -> {
-                            var responseObserver = invocation.<StreamObserver<WriteResponse>>getArgument(2);
-                            responseObservers.add(responseObserver);
-                            return new StreamObserver<WriteRequest>() {
-                                @Override
-                                public void onNext(WriteRequest value) {
-                                    requestCount.incrementAndGet();
-                                }
-
-                                @Override
-                                public void onError(Throwable t) {}
-
-                                @Override
-                                public void onCompleted() {
-                                    completedStreams.incrementAndGet();
-                                }
-                            };
-                        });
-
-        var timeoutTask = new AtomicReference<Runnable>();
-        var executor = mock(ScheduledExecutorService.class);
-        when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
-                .thenAnswer(
-                        invocation -> {
-                            timeoutTask.set(invocation.getArgument(0));
-                            return mock(ScheduledFuture.class);
-                        });
-
-        try (var stream = new ManagedWriteStream(1, rpcProvider, executor, Duration.ofSeconds(30))) {
-            var first = stream.send(() -> writeRequest(1));
-            var second = stream.send(() -> writeRequest(2));
-            assertThat(requestCount).hasValue(2);
-            assertThat(responseObservers).hasSize(1);
-
-            timeoutTask.get().run();
-
-            await()
-                    .untilAsserted(
-                            () -> {
-                                assertThat(first).isCompletedExceptionally();
-                                assertThat(second).isCompletedExceptionally();
-                                assertThat(completedStreams).hasValue(1);
-                            });
-            assertThatThrownBy(first::get)
-                    .hasCauseInstanceOf(java.util.concurrent.TimeoutException.class);
-            assertThatThrownBy(second::get)
-                    .hasCauseInstanceOf(java.util.concurrent.TimeoutException.class);
-
-            responseObservers.peek().onNext(new WriteResponse());
-
-            var third = stream.send(() -> writeRequest(3));
-            await().untilAsserted(() -> assertThat(responseObservers).hasSize(2));
-            responseObservers.stream().skip(1).findFirst().orElseThrow().onNext(new WriteResponse());
-
-            third.get(5, TimeUnit.SECONDS);
-            assertThat(requestCount).hasValue(3);
         }
     }
 

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -177,10 +177,12 @@ class ManagedWriteStreamTest {
         var openAttempts = new AtomicInteger();
         var replayFailures = new AtomicInteger();
         var requests = new ConcurrentLinkedQueue<WriteRequest>();
+        var responseObservers = new ConcurrentLinkedQueue<StreamObserver<WriteResponse>>();
         when(rpcProvider.writeStream(anyLong(), nullable(OxiaStatusException.class), any()))
                 .thenAnswer(
                         invocation -> {
                             var responseObserver = invocation.<StreamObserver<WriteResponse>>getArgument(2);
+                            responseObservers.add(responseObserver);
                             var attempt = openAttempts.incrementAndGet();
                             return new StreamObserver<WriteRequest>() {
                                 @Override
@@ -213,7 +215,9 @@ class ManagedWriteStreamTest {
                                 assertThat(requests).hasSize(1);
                             });
 
-            stream.onError(Status.UNAVAILABLE.withDescription("stale leader").asRuntimeException());
+            responseObservers
+                    .peek()
+                    .onError(Status.UNAVAILABLE.withDescription("stale leader").asRuntimeException());
 
             future.get(5, TimeUnit.SECONDS);
 
@@ -224,6 +228,52 @@ class ManagedWriteStreamTest {
                                 assertThat(replayFailures).hasValue(1);
                                 assertThat(keys(requests)).containsExactly("key-1", "key-1", "key-1");
                             });
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void ignoresResponsesFromInactiveSubStream() throws Exception {
+        var rpcProvider = mock(RpcProvider.class);
+        var responseObservers = new ConcurrentLinkedQueue<StreamObserver<WriteResponse>>();
+        var requestCount = new AtomicInteger();
+        when(rpcProvider.writeStream(anyLong(), nullable(OxiaStatusException.class), any()))
+                .thenAnswer(
+                        invocation -> {
+                            var responseObserver = invocation.<StreamObserver<WriteResponse>>getArgument(2);
+                            responseObservers.add(responseObserver);
+                            return new StreamObserver<WriteRequest>() {
+                                @Override
+                                public void onNext(WriteRequest value) {
+                                    requestCount.incrementAndGet();
+                                }
+
+                                @Override
+                                public void onError(Throwable t) {}
+
+                                @Override
+                                public void onCompleted() {}
+                            };
+                        });
+
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        try (var stream = new ManagedWriteStream(1, rpcProvider, executor)) {
+            var future = stream.send(() -> writeRequest(1));
+            assertThat(requestCount).hasValue(1);
+            assertThat(responseObservers).hasSize(1);
+
+            var inactiveObserver = responseObservers.peek();
+            inactiveObserver.onError(
+                    Status.UNAVAILABLE.withDescription("stale leader").asRuntimeException());
+
+            await().untilAsserted(() -> assertThat(responseObservers).hasSize(2));
+            inactiveObserver.onNext(new WriteResponse());
+            assertThat(future).isNotDone();
+
+            responseObservers.stream().skip(1).findFirst().orElseThrow().onNext(new WriteResponse());
+            future.get(5, TimeUnit.SECONDS);
+            assertThat(requestCount).hasValue(2);
         } finally {
             executor.shutdownNow();
         }


### PR DESCRIPTION
## Motivation
- Prevent stale write stream callbacks from inactive substreams from completing or failing current inflight writes out of order.
- Avoid unbounded stale inflight write retention when the head write does not receive a response within the configured request timeout.
- Keep inflight write tracking serialized under the managed stream lock while moving callback ownership into a dedicated substream wrapper.

## Modifications
- Added `ManagedSubWriteStream` to own the gRPC request observer and delegate response callbacks back to `ManagedWriteStream` with source identity.
- Updated `ManagedWriteStream` to ignore callbacks from inactive substreams and use an `ArrayDeque` protected by the existing lock for inflight writes.
- Added head-of-queue timeout handling that fails the current inflight snapshot, resets the active substream, and allows future writes to start fresh.
- Passed `requestTimeout` from `GrpcRpcProvider` into managed write streams.
- Added test coverage for ignoring responses from an inactive substream and for timeout cleanup of current inflights.

## Testing
- `./gradlew :client:spotlessApply :client:test --tests io.oxia.client.grpc.ManagedWriteStreamTest --no-configuration-cache`
- `./gradlew :client:spotlessCheck --no-configuration-cache`
