### PR TITLE
fix: timeout stuck write streams

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -247,8 +247,15 @@ final class GrpcRpcProvider implements RpcProvider {
 
     @Override
     public ManagedWriteStream getWriteStream(long shardId) {
-        return writeStreams.computeIfAbsent(
-                shardId, (__) -> new ManagedWriteStream(shardId, this, asyncExecutor));
+        return writeStreams.compute(
+                shardId,
+                (__, existingStream) -> {
+                    if (existingStream == null || existingStream.isClosed()) {
+                        return new ManagedWriteStream(
+                                shardId, this, asyncExecutor, clientConfig.requestTimeout());
+                    }
+                    return existingStream;
+                });
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -23,31 +23,38 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.NonNull;
 
 public final class ManagedWriteStream implements AutoCloseable {
     private final Logger log;
 
     record InflightWrite(
-            Supplier<WriteRequest> requestSupplier, CompletableFuture<WriteResponse> future) {}
+            Supplier<WriteRequest> requestSupplier,
+            CompletableFuture<WriteResponse> future,
+            long timestampMs) {}
 
     private final long shardId;
     private final RpcProvider rpcProvider;
     private final ScheduledExecutorService asyncExecutor;
     private final Backoff backoff;
+    private final long requestTimeoutMs;
+    private final ScheduledFuture<?> timeoutScheduler;
 
     private final ReentrantLock lock;
-    private boolean closed;
+    @Getter private volatile boolean closed;
+    private OxiaStatusException closedError;
     private final Deque<InflightWrite> inflightWrites;
     private ManagedSubWriteStream subStreamObserver;
 
     public ManagedWriteStream(
-            long shardId, RpcProvider rpcProvider, ScheduledExecutorService asyncExecutor) {
+            long shardId,
+            RpcProvider rpcProvider,
+            ScheduledExecutorService asyncExecutor,
+            @NonNull Duration requestTimeout) {
         this.shardId = shardId;
         this.log = Logger.get(ManagedWriteStream.class).with().attr("shard", shardId).build();
         this.inflightWrites = new ArrayDeque<>();
@@ -56,6 +63,36 @@ public final class ManagedWriteStream implements AutoCloseable {
         this.asyncExecutor = asyncExecutor;
         this.backoff = new Backoff();
         this.closed = false;
+        this.requestTimeoutMs = requestTimeout.toMillis();
+        final long timeoutInterval = Math.max(requestTimeoutMs / 10, Duration.ofSeconds(1).toMillis());
+        this.timeoutScheduler =
+                asyncExecutor.scheduleWithFixedDelay(
+                        () -> {
+                            final OxiaStatusException timeoutError;
+                            lock.lock();
+                            try {
+                                final InflightWrite inflightWrite = inflightWrites.peekFirst();
+                                if (inflightWrite == null) {
+                                    return;
+                                }
+                                final long requestAgeMs = System.currentTimeMillis() - inflightWrite.timestampMs;
+                                if (requestAgeMs < requestTimeoutMs) {
+                                    return;
+                                }
+                                log.warn()
+                                        .attr("requestAgeMs", requestAgeMs)
+                                        .attr("requestTimeoutMs", requestTimeoutMs)
+                                        .attr("pendingWrites", inflightWrites.size())
+                                        .log("Write stream timed out, close and re-create it.");
+                                timeoutError = OxiaStatusException.timeout(new TimeoutException());
+                            } finally {
+                                lock.unlock();
+                            }
+                            close(timeoutError);
+                        },
+                        timeoutInterval,
+                        timeoutInterval,
+                        TimeUnit.MILLISECONDS);
     }
 
     void handleResponse(ManagedSubWriteStream source, WriteResponse value) {
@@ -139,7 +176,8 @@ public final class ManagedWriteStream implements AutoCloseable {
     public CompletableFuture<WriteResponse> send(Supplier<WriteRequest> requestSupplier) {
         lock.lock();
         final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
-        final InflightWrite inflightWrite = new InflightWrite(requestSupplier, future);
+        final InflightWrite inflightWrite =
+                new InflightWrite(requestSupplier, future, System.currentTimeMillis());
         try {
             log.debug(
                     event ->
@@ -149,7 +187,7 @@ public final class ManagedWriteStream implements AutoCloseable {
                                     .attr("closed", closed)
                                     .log("Sending write request"));
             if (closed) {
-                return CompletableFuture.failedFuture(new IllegalStateException("Stream is closed"));
+                return CompletableFuture.failedFuture(closedError);
             }
             inflightWrites.addLast(inflightWrite);
             log.debug(
@@ -261,32 +299,35 @@ public final class ManagedWriteStream implements AutoCloseable {
 
     @Override
     public void close() {
-        var inflightsToFail = new ArrayList<InflightWrite>();
-        Throwable closeError = null;
+        close(OxiaStatusException.resourceUnavailable("Write stream is closed"));
+    }
+
+    private void close(@NonNull OxiaStatusException error) {
+        final ArrayList<InflightWrite> inflightsToFail;
         lock.lock();
         try {
             closed = true;
+            closedError = error;
+            timeoutScheduler.cancel(false);
             if (subStreamObserver != null) {
                 subStreamObserver.complete();
                 subStreamObserver = null;
             }
-            log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
-            inflightsToFail.addAll(inflightWrites);
-            inflightWrites.clear();
         } catch (Throwable ex) {
-            closeError = ex;
-            inflightsToFail.addAll(inflightWrites);
-            inflightWrites.clear();
+            log.warn().exceptionMessage(ex).log("Failed to close write stream");
         } finally {
+            log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
+            inflightsToFail = new ArrayList<>(inflightWrites);
+            inflightWrites.clear();
             lock.unlock();
         }
-        if (closeError != null) {
-            final var error = closeError;
-            inflightsToFail.forEach(inflight -> inflight.future.completeExceptionally(error));
-            return;
-        }
         inflightsToFail.forEach(
-                inflight ->
-                        inflight.future.completeExceptionally(new CancellationException("Stream is closed")));
+                inflight -> {
+                    try {
+                        inflight.future.completeExceptionally(error);
+                    } catch (Throwable ex) {
+                        log.warn().exceptionMessage(ex).log("Failed to complete inflight write");
+                    }
+                });
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -20,9 +20,7 @@ import io.oxia.client.util.Backoff;
 import io.oxia.proto.WriteRequest;
 import io.oxia.proto.WriteResponse;
 import java.time.Duration;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
@@ -70,7 +68,8 @@ public final class ManagedWriteStream implements AutoCloseable {
         this.timeoutScheduler =
                 asyncExecutor.scheduleWithFixedDelay(
                         () -> {
-                            final OxiaStatusException timeoutError;
+                            List<InflightWrite> inflightsToFail = null;
+                            OxiaStatusException oxiaStatusException = null;
                             lock.lock();
                             try {
                                 final InflightWrite inflightWrite = inflightWrites.peekFirst();
@@ -87,11 +86,20 @@ public final class ManagedWriteStream implements AutoCloseable {
                                         .attr("requestTimeoutMs", requestTimeoutMs)
                                         .attr("pendingWrites", inflightWrites.size())
                                         .log("Write stream timed out, close and re-create it.");
-                                timeoutError = OxiaStatusException.timeout(new TimeoutException());
+                                oxiaStatusException = OxiaStatusException.timeout(new TimeoutException());
+                                inflightsToFail = close0(oxiaStatusException);
                             } finally {
                                 lock.unlock();
+                                if (inflightsToFail != null) {
+                                    for (InflightWrite inflight : inflightsToFail) {
+                                        try {
+                                            inflight.future.completeExceptionally(oxiaStatusException);
+                                        } catch (Throwable ex) {
+                                            log.warn().exceptionMessage(ex).log("Failed to complete inflight write");
+                                        }
+                                    }
+                                }
                             }
-                            close(timeoutError);
                         },
                         timeoutInterval,
                         timeoutInterval,
@@ -306,37 +314,44 @@ public final class ManagedWriteStream implements AutoCloseable {
     }
 
     private void close(@NonNull OxiaStatusException error) {
-        final ArrayList<InflightWrite> inflightsToFail;
+        List<InflightWrite> inflightsToFail = null;
         lock.lock();
         try {
-            if (closed) {
-                return;
-            }
-            closed = true;
-            closedError = error;
-            timeoutScheduler.cancel(false);
-            if (subStreamObserver != null) {
-                try {
-                    subStreamObserver.complete();
-                } catch (Throwable ex) {
-                    log.warn().exceptionMessage(ex).log("Failed to close write stream");
-                } finally {
-                    subStreamObserver = null;
-                }
-            }
-            log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
-            inflightsToFail = new ArrayList<>(inflightWrites);
-            inflightWrites.clear();
+            inflightsToFail = close0(error);
         } finally {
             lock.unlock();
+            if (inflightsToFail != null) {
+                inflightsToFail.forEach(
+                        inflight -> {
+                            try {
+                                inflight.future.completeExceptionally(error);
+                            } catch (Throwable ex) {
+                                log.warn().exceptionMessage(ex).log("Failed to complete inflight write");
+                            }
+                        });
+            }
         }
-        inflightsToFail.forEach(
-                inflight -> {
-                    try {
-                        inflight.future.completeExceptionally(error);
-                    } catch (Throwable ex) {
-                        log.warn().exceptionMessage(ex).log("Failed to complete inflight write");
-                    }
-                });
+    }
+
+    private List<InflightWrite> close0(OxiaStatusException error) {
+        if (closed) {
+            return null;
+        }
+        closed = true;
+        closedError = error;
+        timeoutScheduler.cancel(false);
+        if (subStreamObserver != null) {
+            var closingObserver = subStreamObserver;
+            subStreamObserver = null;
+            try {
+                closingObserver.complete();
+            } catch (Throwable ex) {
+                log.warn().exceptionMessage(ex).log("Failed to close write stream");
+            }
+        }
+        log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
+        final var inflightsToFail = new ArrayList<>(inflightWrites);
+        inflightWrites.clear();
+        return inflightsToFail;
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -35,13 +35,14 @@ public final class ManagedWriteStream implements AutoCloseable {
     record InflightWrite(
             Supplier<WriteRequest> requestSupplier,
             CompletableFuture<WriteResponse> future,
-            long timestampMs) {}
+            long timestampNanos) {}
 
     private final long shardId;
     private final RpcProvider rpcProvider;
     private final ScheduledExecutorService asyncExecutor;
     private final Backoff backoff;
     private final long requestTimeoutMs;
+    private final long requestTimeoutNanos;
     private final ScheduledFuture<?> timeoutScheduler;
 
     private final ReentrantLock lock;
@@ -64,6 +65,7 @@ public final class ManagedWriteStream implements AutoCloseable {
         this.backoff = new Backoff();
         this.closed = false;
         this.requestTimeoutMs = requestTimeout.toMillis();
+        this.requestTimeoutNanos = requestTimeout.toNanos();
         final long timeoutInterval = Math.max(requestTimeoutMs / 10, Duration.ofSeconds(1).toMillis());
         this.timeoutScheduler =
                 asyncExecutor.scheduleWithFixedDelay(
@@ -75,10 +77,11 @@ public final class ManagedWriteStream implements AutoCloseable {
                                 if (inflightWrite == null) {
                                     return;
                                 }
-                                final long requestAgeMs = System.currentTimeMillis() - inflightWrite.timestampMs;
-                                if (requestAgeMs < requestTimeoutMs) {
+                                final long requestAgeNanos = System.nanoTime() - inflightWrite.timestampNanos;
+                                if (requestAgeNanos < requestTimeoutNanos) {
                                     return;
                                 }
+                                final long requestAgeMs = TimeUnit.NANOSECONDS.toMillis(requestAgeNanos);
                                 log.warn()
                                         .attr("requestAgeMs", requestAgeMs)
                                         .attr("requestTimeoutMs", requestTimeoutMs)
@@ -177,7 +180,7 @@ public final class ManagedWriteStream implements AutoCloseable {
         lock.lock();
         final CompletableFuture<WriteResponse> future = new CompletableFuture<>();
         final InflightWrite inflightWrite =
-                new InflightWrite(requestSupplier, future, System.currentTimeMillis());
+                new InflightWrite(requestSupplier, future, System.nanoTime());
         try {
             log.debug(
                     event ->
@@ -306,19 +309,25 @@ public final class ManagedWriteStream implements AutoCloseable {
         final ArrayList<InflightWrite> inflightsToFail;
         lock.lock();
         try {
+            if (closed) {
+                return;
+            }
             closed = true;
             closedError = error;
             timeoutScheduler.cancel(false);
             if (subStreamObserver != null) {
-                subStreamObserver.complete();
-                subStreamObserver = null;
+                try {
+                    subStreamObserver.complete();
+                } catch (Throwable ex) {
+                    log.warn().exceptionMessage(ex).log("Failed to close write stream");
+                } finally {
+                    subStreamObserver = null;
+                }
             }
-        } catch (Throwable ex) {
-            log.warn().exceptionMessage(ex).log("Failed to close write stream");
-        } finally {
             log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
             inflightsToFail = new ArrayList<>(inflightWrites);
             inflightWrites.clear();
+        } finally {
             lock.unlock();
         }
         inflightsToFail.forEach(

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
@@ -17,6 +17,7 @@ package io.oxia.client.grpc;
 
 import static io.oxia.client.grpc.OxiaStatusCode.RESOURCE_UNAVAILABLE;
 import static io.oxia.client.grpc.OxiaStatusCode.SHARD_NOT_FOUND;
+import static io.oxia.client.grpc.OxiaStatusCode.TIMEOUT;
 import static io.oxia.client.grpc.OxiaStatusCode.UNKNOWN;
 
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -24,10 +25,10 @@ import com.google.rpc.ErrorInfo;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
+import io.oxia.client.util.CompletableFutures;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import lombok.Getter;
 import lombok.NonNull;
 
@@ -82,15 +83,23 @@ public class OxiaStatusException extends RuntimeException {
                 null);
     }
 
+    public static @NonNull OxiaStatusException resourceUnavailable(@NonNull String message) {
+        return new OxiaStatusException(RESOURCE_UNAVAILABLE, Map.of(), message, null);
+    }
+
+    public static @NonNull OxiaStatusException timeout(@NonNull Throwable error) {
+        return new OxiaStatusException(
+                TIMEOUT, Map.of(), "Request timed out", CompletableFutures.unwrapException(error));
+    }
+
     public static @NonNull OxiaStatusException from(@NonNull Throwable error) {
-        Throwable cause = error;
+        Throwable cause = CompletableFutures.unwrapException(error);
         try {
-            while ((cause instanceof CompletionException || cause instanceof ExecutionException)
-                    && cause.getCause() != null) {
-                cause = cause.getCause();
-            }
             if (cause instanceof OxiaStatusException oxiaError) {
                 return oxiaError;
+            }
+            if (cause instanceof TimeoutException) {
+                return timeout(cause);
             }
             if (!(cause instanceof StatusException || cause instanceof StatusRuntimeException)) {
                 return new OxiaStatusException(UNKNOWN, Map.of(), cause.getMessage(), cause);

--- a/client/src/main/java/io/oxia/client/util/CompletableFutures.java
+++ b/client/src/main/java/io/oxia/client/util/CompletableFutures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.oxia.client.grpc;
+package io.oxia.client.util;
 
-/** Oxia-specific status codes translated from current ErrorInfo or legacy GRPC statuses. */
-public enum OxiaStatusCode {
-    ABORTED,
-    INVALID_SESSION_TIMEOUT,
-    SESSION_NOT_FOUND,
-    NAMESPACE_NOT_FOUND,
-    SHARD_NOT_FOUND,
-    INVALID_TERM,
-    INVALID_STATUS,
-    NOTIFICATIONS_NOT_ENABLED,
-    NODE_IS_NOT_MEMBER,
-    NODE_IS_NOT_LEADER,
-    NOT_INITIALIZED,
-    RESOURCE_CONFLICT,
-    RESOURCE_UNAVAILABLE,
-    TIMEOUT,
-    UNKNOWN
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+public final class CompletableFutures {
+    private CompletableFutures() {}
+
+    public static Throwable unwrapException(Throwable error) {
+        Throwable cause = error;
+        while ((cause instanceof CompletionException || cause instanceof ExecutionException)
+                && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
 }

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -120,6 +120,46 @@ class ManagedWriteStreamTest {
     }
 
     @Test
+    void ignoresSynchronousResponseDuringClose() throws Exception {
+        var rpcProvider = mock(RpcProvider.class);
+        when(rpcProvider.writeStream(anyLong(), nullable(OxiaStatusException.class), any()))
+                .thenAnswer(
+                        invocation -> {
+                            var responseObserver = invocation.<StreamObserver<WriteResponse>>getArgument(2);
+                            return new StreamObserver<WriteRequest>() {
+                                @Override
+                                public void onNext(WriteRequest value) {}
+
+                                @Override
+                                public void onError(Throwable t) {}
+
+                                @Override
+                                public void onCompleted() {
+                                    responseObserver.onNext(new WriteResponse());
+                                }
+                            };
+                        });
+
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        try (var stream = new ManagedWriteStream(1, rpcProvider, executor, Duration.ofSeconds(30))) {
+            var pending = stream.send(() -> writeRequest(1));
+
+            stream.close();
+
+            assertThatThrownBy(() -> pending.get(5, TimeUnit.SECONDS))
+                    .hasCauseInstanceOf(OxiaStatusException.class)
+                    .satisfies(
+                            error -> {
+                                var oxiaError = (OxiaStatusException) error.getCause();
+                                assertThat(oxiaError.getStatusCode())
+                                        .isEqualTo(OxiaStatusCode.RESOURCE_UNAVAILABLE);
+                            });
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void timeoutClosesCurrentStreamAndNextLookupCreatesNewStream() throws Exception {
         Server server =
                 writeServer(

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -161,6 +161,14 @@ class ManagedWriteStreamTest {
                             });
 
             await().untilAsserted(() -> assertThat(firstStream.isClosed()).isTrue());
+            firstStream.close();
+            assertThatThrownBy(() -> firstStream.send(() -> writeRequest(2)).get())
+                    .hasCauseInstanceOf(OxiaStatusException.class)
+                    .satisfies(
+                            error -> {
+                                var oxiaError = (OxiaStatusException) error.getCause();
+                                assertThat(oxiaError.getStatusCode()).isEqualTo(OxiaStatusCode.TIMEOUT);
+                            });
             assertThat(provider.getWriteStream(1)).isNotSameAs(firstStream);
         } finally {
             executor.shutdownNow();

--- a/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/ManagedWriteStreamTest.java
@@ -39,7 +39,6 @@ import io.oxia.proto.WriteResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Queue;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -57,7 +56,7 @@ class ManagedWriteStreamTest {
         var config = clientConfig(address);
 
         try (var provider = new GrpcRpcProvider(config, executor, shard -> address);
-                var stream = new ManagedWriteStream(1, provider, executor)) {
+                var stream = new ManagedWriteStream(1, provider, executor, config.requestTimeout())) {
             var first = writeRequest(1);
             var second = writeRequest(2);
 
@@ -75,7 +74,7 @@ class ManagedWriteStreamTest {
     }
 
     @Test
-    void closeCancelsPendingWritesAndRejectsNewWrites() throws Exception {
+    void closeFailsPendingWritesAndRejectsNewWrites() throws Exception {
         Server server =
                 writeServer(
                         new OxiaClientGrpc.OxiaClientImplBase() {
@@ -99,15 +98,70 @@ class ManagedWriteStreamTest {
         var config = clientConfig(address);
 
         try (var provider = new GrpcRpcProvider(config, executor, shard -> address);
-                var stream = new ManagedWriteStream(1, provider, executor)) {
-            CompletableFuture<WriteResponse> pending = stream.send(() -> writeRequest(1));
+                var stream = new ManagedWriteStream(1, provider, executor, config.requestTimeout())) {
+            var pending = stream.send(() -> writeRequest(1));
 
             stream.close();
 
             assertThat(pending).isCompletedExceptionally();
             assertThatThrownBy(pending::get)
-                    .isInstanceOf(java.util.concurrent.CancellationException.class);
+                    .hasCauseInstanceOf(OxiaStatusException.class)
+                    .satisfies(
+                            error -> {
+                                var oxiaError = (OxiaStatusException) error.getCause();
+                                assertThat(oxiaError.getStatusCode())
+                                        .isEqualTo(OxiaStatusCode.RESOURCE_UNAVAILABLE);
+                            });
             assertThat(stream.send(() -> writeRequest(2))).isCompletedExceptionally();
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void timeoutClosesCurrentStreamAndNextLookupCreatesNewStream() throws Exception {
+        Server server =
+                writeServer(
+                        new OxiaClientGrpc.OxiaClientImplBase() {
+                            @Override
+                            public StreamObserver<WriteRequest> writeStream(
+                                    StreamObserver<WriteResponse> responseObserver) {
+                                return new StreamObserver<>() {
+                                    @Override
+                                    public void onNext(WriteRequest value) {}
+
+                                    @Override
+                                    public void onError(Throwable t) {}
+
+                                    @Override
+                                    public void onCompleted() {}
+                                };
+                            }
+                        });
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address)
+                                        .requestTimeout(Duration.ofMillis(50))
+                                        .connectionBackoff(Duration.ofMillis(10), Duration.ofMillis(50)))
+                        .getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shard -> address)) {
+            var firstStream = provider.getWriteStream(1);
+            var timedOut = firstStream.send(() -> writeRequest(1));
+
+            assertThatThrownBy(() -> timedOut.get(5, TimeUnit.SECONDS))
+                    .hasCauseInstanceOf(OxiaStatusException.class)
+                    .satisfies(
+                            error -> {
+                                var oxiaError = (OxiaStatusException) error.getCause();
+                                assertThat(oxiaError.getStatusCode()).isEqualTo(OxiaStatusCode.TIMEOUT);
+                            });
+
+            await().untilAsserted(() -> assertThat(firstStream.isClosed()).isTrue());
+            assertThat(provider.getWriteStream(1)).isNotSameAs(firstStream);
         } finally {
             executor.shutdownNow();
             server.shutdownNow();
@@ -150,7 +204,7 @@ class ManagedWriteStreamTest {
         var config = clientConfig(staleAddress);
 
         try (var provider = new GrpcRpcProvider(config, executor, shard -> staleAddress);
-                var stream = new ManagedWriteStream(1, provider, executor)) {
+                var stream = new ManagedWriteStream(1, provider, executor, config.requestTimeout())) {
             var firstFuture = stream.send(() -> writeRequest(1));
             var secondFuture = stream.send(() -> writeRequest(2));
 
@@ -206,7 +260,7 @@ class ManagedWriteStreamTest {
                         });
 
         var executor = Executors.newSingleThreadScheduledExecutor();
-        try (var stream = new ManagedWriteStream(1, rpcProvider, executor)) {
+        try (var stream = new ManagedWriteStream(1, rpcProvider, executor, Duration.ofSeconds(30))) {
             var future = stream.send(() -> writeRequest(1));
             await()
                     .untilAsserted(
@@ -258,7 +312,7 @@ class ManagedWriteStreamTest {
                         });
 
         var executor = Executors.newSingleThreadScheduledExecutor();
-        try (var stream = new ManagedWriteStream(1, rpcProvider, executor)) {
+        try (var stream = new ManagedWriteStream(1, rpcProvider, executor, Duration.ofSeconds(30))) {
             var future = stream.send(() -> writeRequest(1));
             assertThat(requestCount).hasValue(1);
             assertThat(responseObservers).hasSize(1);

--- a/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
@@ -27,6 +27,7 @@ import io.grpc.protobuf.StatusProto;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
 
 class OxiaStatusExceptionTest {
@@ -191,6 +192,18 @@ class OxiaStatusExceptionTest {
 
         assertThat(OxiaStatusException.from(new CompletionException(error))).isSameAs(error);
         assertThat(OxiaStatusException.from(new ExecutionException(error))).isSameAs(error);
+    }
+
+    @Test
+    void returnsTimeoutOxiaError() {
+        var timeout = new TimeoutException("timed out");
+
+        var translated = OxiaStatusException.from(new CompletionException(timeout));
+
+        assertThat(translated.getStatusCode()).isEqualTo(OxiaStatusCode.TIMEOUT);
+        assertThat(translated).hasMessage("Request timed out");
+        assertThat(translated).hasCause(timeout);
+        assertThat(translated.isRetryable()).isFalse();
     }
 
     @Test

--- a/client/src/test/java/io/oxia/client/util/CompletableFuturesTest.java
+++ b/client/src/test/java/io/oxia/client/util/CompletableFuturesTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+class CompletableFuturesTest {
+    @Test
+    void unwrapsCompletionAndExecutionExceptions() {
+        var cause = new IllegalStateException("failed");
+
+        assertThat(
+                        CompletableFutures.unwrapException(
+                                new CompletionException(new ExecutionException(cause))))
+                .isSameAs(cause);
+    }
+
+    @Test
+    void returnsOriginalExceptionWhenThereIsNoWrapper() {
+        var cause = new IllegalStateException("failed");
+
+        assertThat(CompletableFutures.unwrapException(cause)).isSameAs(cause);
+    }
+}


### PR DESCRIPTION
## Motivation
- Stuck write streams can leave pending writes unresolved when the server never responds.
- Closed write streams should surface typed Oxia errors and allow the provider to replace timed-out streams.

## Modifications
- Add write-stream request timeout tracking and close timed-out streams with `OxiaStatusCode.TIMEOUT`.
- Replace closed per-shard write streams in `GrpcRpcProvider`.
- Add `OxiaStatusException` helpers for timeouts and resource-unavailable close errors.
- Add `CompletableFutures.unwrapException` and focused tests for exception translation and write-stream timeout behavior.

## Testing
- `./gradlew :client:spotlessCheck`
- `./gradlew :client:test`