### PR TITLE
fix: avoid range scan API breakage

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/AsyncOxiaClient.java
+++ b/client-api/src/main/java/io/oxia/client/api/AsyncOxiaClient.java
@@ -218,6 +218,38 @@ public interface AsyncOxiaClient extends AutoCloseable {
             Set<RangeScanOption> options);
 
     /**
+     * Scan any existing records within the specified range of keys, allowing the consumer to stop
+     * iteration early.
+     *
+     * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
+     *     the range.
+     * @param endKeyExclusive The key that declares the end of the range, and is <b>excluded</b> from
+     *     the range.
+     * @param consumer A {@link CancelableRangeScanConsumer} that will be invoked with the records or
+     *     errors.
+     */
+    void rangeScanWithCancellation(
+            String startKeyInclusive, String endKeyExclusive, CancelableRangeScanConsumer consumer);
+
+    /**
+     * Scan any existing records within the specified range of keys, allowing the consumer to stop
+     * iteration early.
+     *
+     * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
+     *     the range.
+     * @param endKeyExclusive The key that declares the end of the range, and is <b>excluded</b> from
+     *     the range.
+     * @param consumer A {@link CancelableRangeScanConsumer} that will be invoked with the records or
+     *     errors.
+     * @param options the range scan options
+     */
+    void rangeScanWithCancellation(
+            String startKeyInclusive,
+            String endKeyExclusive,
+            CancelableRangeScanConsumer consumer,
+            Set<RangeScanOption> options);
+
+    /**
      * Registers a callback to receive Oxia {@link Notification record change notifications}. Multiple
      * callbacks can be registered.
      *

--- a/client-api/src/main/java/io/oxia/client/api/CancelableRangeScanConsumer.java
+++ b/client-api/src/main/java/io/oxia/client/api/CancelableRangeScanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,36 +16,26 @@
 package io.oxia.client.api;
 
 /**
- * Callback used by {@link AsyncOxiaClient#rangeScan(String, String, RangeScanConsumer)} to deliver
- * records, errors, and the completion signal for a streaming range scan.
+ * Callback used by {@link AsyncOxiaClient#rangeScanWithCancellation(String, String,
+ * CancelableRangeScanConsumer)} to deliver records while allowing callers to stop a streaming range
+ * scan early.
  *
  * <p>Exactly one of {@link #onError(Throwable)} or {@link #onCompleted()} is invoked per scan, and
- * always after the final {@link #onNext(GetResult)} call.
- *
- * <pre>{@code
- * client.rangeScan("a", "z", new RangeScanConsumer() {
- *     public void onNext(GetResult result) {
- *         process(result);
- *     }
- *     public void onError(Throwable t) { log.warn("scan failed", t); }
- *     public void onCompleted() { log.info("scan finished"); }
- * });
- * }</pre>
- *
- * <p>For early stop support, see {@link AsyncOxiaClient#rangeScanWithCancellation(String, String,
- * CancelableRangeScanConsumer)}.
- *
- * <p>For a synchronous, iterator-style alternative, see {@link SyncOxiaClient#rangeScan(String,
- * String)}.
+ * always after the final {@link #onNext(GetResult)} call. Returning {@code false} from {@code
+ * onNext} stops iteration early; implementations that support cancellation cancel the underlying
+ * server stream and invoke {@link #onCompleted()} once.
  */
-public interface RangeScanConsumer {
+public interface CancelableRangeScanConsumer {
 
     /**
      * Invoked for each record returned by the range scan operation.
      *
      * @param result The GetResult for the record.
+     * @return {@code true} to keep receiving records, {@code false} to stop the iteration. When
+     *     {@code false} is returned, no further {@link #onNext} invocations will be made and {@link
+     *     #onCompleted()} will be invoked once.
      */
-    void onNext(GetResult result);
+    boolean onNext(GetResult result);
 
     /**
      * Invoked when an error occurs during the range scan operation.

--- a/client-api/src/main/java/io/oxia/client/api/CloseableIterable.java
+++ b/client-api/src/main/java/io/oxia/client/api/CloseableIterable.java
@@ -21,7 +21,7 @@ package io.oxia.client.api;
  * <p>Intended for use with try-with-resources:
  *
  * <pre>{@code
- * try (CloseableIterable<GetResult> scan = client.rangeScan(start, end)) {
+ * try (CloseableIterable<GetResult> scan = client.rangeScanCloseable(start, end)) {
  *     for (GetResult r : scan) {
  *         if (done) break;
  *     }

--- a/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
+++ b/client-api/src/main/java/io/oxia/client/api/SyncOxiaClient.java
@@ -184,9 +184,8 @@ public interface SyncOxiaClient extends AutoCloseable {
     /**
      * Scan any existing records within the specified range of keys.
      *
-     * <p>The returned iterable holds an active server stream and should be closed (e.g. via
-     * try-with-resources) when iteration is abandoned before completion, otherwise the stream is only
-     * torn down when iteration runs to its natural end.
+     * <p>For cancellation when iteration is abandoned before completion, use {@link
+     * #rangeScanCloseable(String, String)}.
      *
      * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
      *     the range.
@@ -194,14 +193,13 @@ public interface SyncOxiaClient extends AutoCloseable {
      *     the range.
      * @return An iterable object that will provide all the records and their version objects.
      */
-    CloseableIterable<GetResult> rangeScan(String startKeyInclusive, String endKeyExclusive);
+    Iterable<GetResult> rangeScan(String startKeyInclusive, String endKeyExclusive);
 
     /**
      * Scan any existing records within the specified range of keys.
      *
-     * <p>The returned iterable holds an active server stream and should be closed (e.g. via
-     * try-with-resources) when iteration is abandoned before completion, otherwise the stream is only
-     * torn down when iteration runs to its natural end.
+     * <p>For cancellation when iteration is abandoned before completion, use {@link
+     * #rangeScanCloseable(String, String, Set)}.
      *
      * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
      *     the range.
@@ -210,7 +208,35 @@ public interface SyncOxiaClient extends AutoCloseable {
      * @param options the range scan options
      * @return An iterable object that will provide all the records and their version objects.
      */
-    CloseableIterable<GetResult> rangeScan(
+    Iterable<GetResult> rangeScan(
+            String startKeyInclusive, String endKeyExclusive, Set<RangeScanOption> options);
+
+    /**
+     * Scan any existing records within the specified range of keys, returning an iterable that can be
+     * closed when iteration is abandoned before completion.
+     *
+     * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
+     *     the range.
+     * @param endKeyExclusive The key that declares the end of the range, and is <b>excluded</b> from
+     *     the range.
+     * @return A closeable iterable object that will provide all the records and their version
+     *     objects.
+     */
+    CloseableIterable<GetResult> rangeScanCloseable(String startKeyInclusive, String endKeyExclusive);
+
+    /**
+     * Scan any existing records within the specified range of keys, returning an iterable that can be
+     * closed when iteration is abandoned before completion.
+     *
+     * @param startKeyInclusive The key that declares start of the range, and is <b>included</b> from
+     *     the range.
+     * @param endKeyExclusive The key that declares the end of the range, and is <b>excluded</b> from
+     *     the range.
+     * @param options the range scan options
+     * @return A closeable iterable object that will provide all the records and their version
+     *     objects.
+     */
+    CloseableIterable<GetResult> rangeScanCloseable(
             String startKeyInclusive, String endKeyExclusive, Set<RangeScanOption> options);
 
     /**

--- a/client-api/src/main/java/io/oxia/client/api/package-info.java
+++ b/client-api/src/main/java/io/oxia/client/api/package-info.java
@@ -75,7 +75,7 @@
  * <pre>{@code
  * List<String> keys = client.list("a", "z");
  *
- * try (CloseableIterable<GetResult> scan = client.rangeScan("a", "z")) {
+ * try (CloseableIterable<GetResult> scan = client.rangeScanCloseable("a", "z")) {
  *     for (GetResult r : scan) {
  *         // process r
  *     }

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -19,6 +19,7 @@ import io.grpc.netty.shaded.io.netty.util.concurrent.DefaultThreadFactory;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.oxia.client.api.AsyncOxiaClient;
+import io.oxia.client.api.CancelableRangeScanConsumer;
 import io.oxia.client.api.GetResult;
 import io.oxia.client.api.Notification;
 import io.oxia.client.api.PutResult;
@@ -697,10 +698,47 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             @NonNull String endKeyExclusive,
             @NonNull RangeScanConsumer consumer,
             @NonNull Set<RangeScanOption> options) {
+        rangeScanWithCancellation(
+                startKeyInclusive,
+                endKeyExclusive,
+                new CancelableRangeScanConsumer() {
+                    @Override
+                    public boolean onNext(GetResult result) {
+                        consumer.onNext(result);
+                        return true;
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        consumer.onError(throwable);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        consumer.onCompleted();
+                    }
+                },
+                options);
+    }
+
+    @Override
+    public void rangeScanWithCancellation(
+            @NonNull String startKeyInclusive,
+            @NonNull String endKeyExclusive,
+            @NonNull CancelableRangeScanConsumer consumer) {
+        rangeScanWithCancellation(startKeyInclusive, endKeyExclusive, consumer, Collections.emptySet());
+    }
+
+    @Override
+    public void rangeScanWithCancellation(
+            @NonNull String startKeyInclusive,
+            @NonNull String endKeyExclusive,
+            @NonNull CancelableRangeScanConsumer consumer,
+            @NonNull Set<RangeScanOption> options) {
         gaugePendingRangeScanRequests.increment();
 
-        final RangeScanConsumer timedConsumer =
-                new RangeScanConsumer() {
+        final CancelableRangeScanConsumer timedConsumer =
+                new CancelableRangeScanConsumer() {
                     final long startTime = System.nanoTime();
                     final AtomicLong totalSize = new AtomicLong();
 
@@ -756,7 +794,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             String startKeyInclusive,
             String endKeyExclusive,
             Optional<String> secondaryIndexName,
-            RangeScanConsumer consumer) {
+            CancelableRangeScanConsumer consumer) {
         var request = new RangeScanRequest();
         request.setShard(shardId).setStartInclusive(startKeyInclusive).setEndExclusive(endKeyExclusive);
         secondaryIndexName.ifPresent(request::setSecondaryIndexName);

--- a/client/src/main/java/io/oxia/client/GetResultIterator.java
+++ b/client/src/main/java/io/oxia/client/GetResultIterator.java
@@ -15,13 +15,14 @@
  */
 package io.oxia.client;
 
+import io.oxia.client.api.CancelableRangeScanConsumer;
 import io.oxia.client.api.GetResult;
-import io.oxia.client.api.RangeScanConsumer;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import lombok.SneakyThrows;
 
-public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer, AutoCloseable {
+public class GetResultIterator
+        implements Iterator<GetResult>, CancelableRangeScanConsumer, AutoCloseable {
 
     private GetResult pendingResult;
     private Throwable error = null;

--- a/client/src/main/java/io/oxia/client/SyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/SyncOxiaClientImpl.java
@@ -163,13 +163,27 @@ class SyncOxiaClientImpl implements SyncOxiaClient {
     }
 
     @Override
-    public CloseableIterable<GetResult> rangeScan(
+    public Iterable<GetResult> rangeScan(
             @NonNull String startKeyInclusive, @NonNull String endKeyExclusive) {
         return rangeScan(startKeyInclusive, endKeyExclusive, Collections.emptySet());
     }
 
     @Override
-    public CloseableIterable<GetResult> rangeScan(
+    public Iterable<GetResult> rangeScan(
+            @NonNull String startKeyInclusive,
+            @NonNull String endKeyExclusive,
+            Set<RangeScanOption> options) {
+        return rangeScanCloseable(startKeyInclusive, endKeyExclusive, options);
+    }
+
+    @Override
+    public CloseableIterable<GetResult> rangeScanCloseable(
+            @NonNull String startKeyInclusive, @NonNull String endKeyExclusive) {
+        return rangeScanCloseable(startKeyInclusive, endKeyExclusive, Collections.emptySet());
+    }
+
+    @Override
+    public CloseableIterable<GetResult> rangeScanCloseable(
             @NonNull String startKeyInclusive,
             @NonNull String endKeyExclusive,
             Set<RangeScanOption> options) {
@@ -184,7 +198,7 @@ class SyncOxiaClientImpl implements SyncOxiaClient {
                 }
                 GetResultIterator gri = new GetResultIterator();
                 active.add(gri);
-                asyncClient.rangeScan(startKeyInclusive, endKeyExclusive, gri, options);
+                asyncClient.rangeScanWithCancellation(startKeyInclusive, endKeyExclusive, gri, options);
                 return gri;
             }
 

--- a/client/src/main/java/io/oxia/client/operation/rangescan/CompositeRangeScanConsumer.java
+++ b/client/src/main/java/io/oxia/client/operation/rangescan/CompositeRangeScanConsumer.java
@@ -15,17 +15,17 @@
  */
 package io.oxia.client.operation.rangescan;
 
+import io.oxia.client.api.CancelableRangeScanConsumer;
 import io.oxia.client.api.GetResult;
-import io.oxia.client.api.RangeScanConsumer;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class CompositeRangeScanConsumer implements RangeScanConsumer {
-    private final RangeScanConsumer delegate;
+public class CompositeRangeScanConsumer implements CancelableRangeScanConsumer {
+    private final CancelableRangeScanConsumer delegate;
     private final ReentrantLock lock;
     private int pendingCompletedRequests;
     private boolean completed;
 
-    public CompositeRangeScanConsumer(int shards, RangeScanConsumer delegate) {
+    public CompositeRangeScanConsumer(int shards, CancelableRangeScanConsumer delegate) {
         this.pendingCompletedRequests = shards;
         this.delegate = delegate;
         this.completed = false;

--- a/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
@@ -28,9 +28,9 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.oxia.client.api.CancelableRangeScanConsumer;
 import io.oxia.client.api.GetResult;
 import io.oxia.client.api.PutResult;
-import io.oxia.client.api.RangeScanConsumer;
 import io.oxia.client.api.Version;
 import io.oxia.client.api.options.DeleteOption;
 import io.oxia.client.batch.BatchManager;
@@ -566,11 +566,11 @@ class AsyncOxiaClientImplTest {
         final List<GetResult> results = new ArrayList<>();
         final AtomicInteger onErrorCount = new AtomicInteger(0);
         final AtomicInteger onCompletedCount = new AtomicInteger(0);
-        final Supplier<RangeScanConsumer> newShardRangeScanConsumer =
+        final Supplier<CancelableRangeScanConsumer> newShardRangeScanConsumer =
                 () ->
                         new CompositeRangeScanConsumer(
                                 shards,
-                                new RangeScanConsumer() {
+                                new CancelableRangeScanConsumer() {
                                     @Override
                                     public boolean onNext(GetResult result) {
                                         results.add(result);
@@ -683,8 +683,8 @@ class AsyncOxiaClientImplTest {
         final AtomicInteger onErrorCount = new AtomicInteger(0);
         final AtomicInteger onCompletedCount = new AtomicInteger(0);
 
-        final RangeScanConsumer userConsumer =
-                new RangeScanConsumer() {
+        final CancelableRangeScanConsumer userConsumer =
+                new CancelableRangeScanConsumer() {
                     @Override
                     public boolean onNext(GetResult result) {
                         results.add(result);

--- a/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
+++ b/client/src/test/java/io/oxia/client/it/OxiaClientIT.java
@@ -35,6 +35,7 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.oxia.client.api.AsyncOxiaClient;
+import io.oxia.client.api.CancelableRangeScanConsumer;
 import io.oxia.client.api.CloseableIterable;
 import io.oxia.client.api.GetResult;
 import io.oxia.client.api.Notification;
@@ -43,7 +44,6 @@ import io.oxia.client.api.Notification.KeyDeleted;
 import io.oxia.client.api.Notification.KeyModified;
 import io.oxia.client.api.OxiaClientBuilder;
 import io.oxia.client.api.PutResult;
-import io.oxia.client.api.RangeScanConsumer;
 import io.oxia.client.api.SyncOxiaClient;
 import io.oxia.client.api.exceptions.KeyAlreadyExistsException;
 import io.oxia.client.api.exceptions.UnexpectedVersionIdException;
@@ -580,7 +580,8 @@ class OxiaClientIT {
                 syncClient.put(String.format("rs-close-%02d", i), Integer.toString(i).getBytes());
             }
 
-            try (CloseableIterable<GetResult> scan = syncClient.rangeScan("rs-close-", "rs-close-~")) {
+            try (CloseableIterable<GetResult> scan =
+                    syncClient.rangeScanCloseable("rs-close-", "rs-close-~")) {
                 int count = 0;
                 for (GetResult ignored : scan) {
                     count++;
@@ -590,7 +591,7 @@ class OxiaClientIT {
             }
 
             // After close, the iterable can no longer be iterated.
-            CloseableIterable<GetResult> scan = syncClient.rangeScan("rs-close-", "rs-close-~");
+            CloseableIterable<GetResult> scan = syncClient.rangeScanCloseable("rs-close-", "rs-close-~");
             scan.close();
             assertThatThrownBy(scan::iterator).isInstanceOf(IllegalStateException.class);
         }
@@ -608,10 +609,10 @@ class OxiaClientIT {
         CountDownLatch completed = new CountDownLatch(1);
         AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
-        client.rangeScan(
+        client.rangeScanWithCancellation(
                 "rs-stop-",
                 "rs-stop-~",
-                new RangeScanConsumer() {
+                new CancelableRangeScanConsumer() {
                     @Override
                     public boolean onNext(GetResult result) {
                         onNextCalls.incrementAndGet();


### PR DESCRIPTION
## Motivation
- PR #287 added early-stop support for range scans but changed existing public API signatures before release.
- Keep the original RangeScanConsumer and SyncOxiaClient.rangeScan shapes while still exposing cancellation as opt-in API.

## Modifications
- Restore RangeScanConsumer.onNext(GetResult) to void.
- Add CancelableRangeScanConsumer and AsyncOxiaClient.rangeScanWithCancellation(...) for early-stop scans.
- Restore SyncOxiaClient.rangeScan(...) to Iterable<GetResult> and add rangeScanCloseable(...) for callers that need try-with-resources cleanup.
- Route the concrete async and sync implementations through the cancellation-aware internals, and update tests/docs to use the new opt-in methods.

## Testing
- ./gradlew spotlessApply :client:test --tests io.oxia.client.AsyncOxiaClientImplTest
- git diff --check
- ./gradlew :client:test was attempted earlier and failed in Docker/Testcontainers Ryuk setup for IT classes, not in range-scan unit coverage.
