### PR TITLE
ci: restore Maven Central publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,22 @@ plugins {
     jacoco
     alias(libs.plugins.spotless)
     alias(libs.plugins.spotbugs)
+    alias(libs.plugins.maven.publish) apply false
 }
+
+val publishedArtifactIds =
+        mapOf(
+                "client-api" to "oxia-client-api",
+                "client" to "oxia-client",
+                "perf" to "oxia-perf",
+        )
+
+val publishedNames =
+        mapOf(
+                "client-api" to "Oxia Client API",
+                "client" to "Oxia Client",
+                "perf" to "Oxia Perf Client",
+        )
 
 allprojects {
     repositories {
@@ -32,6 +47,49 @@ subprojects {
     apply(plugin = "jacoco")
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "com.github.spotbugs")
+
+    publishedArtifactIds[project.name]?.let { artifactId: String ->
+        apply(plugin = "com.vanniktech.maven.publish")
+
+        extensions.configure<com.vanniktech.maven.publish.MavenPublishBaseExtension>("mavenPublishing") {
+            publishToMavenCentral()
+            signAllPublications()
+
+            coordinates(group.toString(), artifactId, version.toString())
+
+            pom {
+                name.set(publishedNames[project.name])
+                description.set("Oxia Client SDK for Java")
+                url.set("https://oxia-db.github.io")
+                inceptionYear.set("2022")
+
+                organization {
+                    name.set("The Oxia Authors")
+                    url.set("https://oxia-db.github.io/")
+                }
+
+                licenses {
+                    license {
+                        name.set("Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0")
+                    }
+                }
+
+                developers {
+                    developer {
+                        organization.set("The Oxia Authors")
+                        organizationUrl.set("https://oxia-db.github.io/")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:git://github.com/oxia-db/oxia-client-java.git")
+                    developerConnection.set("scm:git:ssh://github.com:oxia-db/oxia-client-java.git")
+                    url.set("https://github.com/oxia-db/oxia-client-java")
+                }
+            }
+        }
+    }
 
     java {
         toolchain {

--- a/client-api/src/main/java/io/oxia/client/api/GetResult.java
+++ b/client-api/src/main/java/io/oxia/client/api/GetResult.java
@@ -23,11 +23,11 @@ import java.util.Objects;
  *
  * <p>A {@code null} {@code GetResult} from a {@code get} call signals that no record exists for the
  * requested key. When {@link io.oxia.client.api.options.GetOption#ExcludeValue} is used, the {@code
- * value} field will be {@code null} but {@code key} and {@code version} are still populated.
+ * value} field will be an empty byte array but {@code key} and {@code version} are still populated.
  *
  * @param key the key of the record returned by the server (may differ from the key supplied to
  *     {@code get} when a non-equal {@link io.oxia.client.api.options.GetOption comparison} is used)
- * @param value the record's value, or {@code null} if the value was not requested
+ * @param value the record's value, or an empty byte array if the value was not requested
  * @param version metadata describing the record at the time it was read
  */
 public record GetResult(String key, byte[] value, Version version) {

--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -195,7 +195,7 @@ public interface OxiaClientBuilder {
     /**
      * Configure the keep alive timeout for the connection.
      *
-     * <p>Default is <code>5 sec</code>.
+     * <p>Default is <code>3 sec</code>.
      *
      * @param connectionKeepAliveTimeout the keep alive timeout duration
      * @return the builder instance


### PR DESCRIPTION
## Motivation
- The release workflow has called `./gradlew publishAllPublicationsToMavenCentral` since the Maven-to-Gradle migration in #261, but the Gradle build did not apply or configure any Maven Central publishing plugin, so the release task was missing.
- `GetResult` Javadoc introduced in #294 said excluded values are `null`, while both the old protobuf implementation and current LightProto implementation return an empty byte array.
- #295 changed the default connection keepalive timeout to 3 seconds but left the public builder Javadoc at 5 seconds.

## Modifications
- Apply the Vanniktech Maven Publish plugin to the published Gradle subprojects.
- Restore the historical Maven artifact IDs: `oxia-client-api`, `oxia-client`, and `oxia-perf`.
- Configure Maven Central publishing, signing, and POM metadata matching the old Maven metadata.
- Correct the `GetResult` and keepalive timeout Javadocs.

## Testing
- `./gradlew publishAllPublicationsToMavenCentral --dry-run --no-configuration-cache`
- `./gradlew spotlessApply check --no-configuration-cache`
- `./gradlew :client-api:generatePomFileForMavenPublication :client:generatePomFileForMavenPublication :perf:generatePomFileForMavenPublication --no-configuration-cache`
- Inspected generated POMs to verify artifact IDs and metadata.
