### PR TITLE
chore: add agent PR workflow rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+## User Preferences
+
+- When creating Git branches for this user, never use a `codex/` branch prefix. Use a conventional non-`codex` prefix such as `fix/`, `feat/`, `test/`, `chore/`, or another user-specified branch name.
+- Do not push directly to `main` or other protected branches. For repository changes, create a branch, commit there, push the branch, and open a PR.
+- For changes that cannot go through a PR, such as deleting or moving remote tags, state that explicitly and wait for confirmation before running the command.


### PR DESCRIPTION
## Motivation
- Keep future repository changes on PR branches instead of direct pushes to protected branches.
- Make non-PR operations, such as tag deletion or movement, require explicit confirmation.

## Modifications
- Add `AGENTS.md` with the existing branch naming preference.
- Add a repo-local rule to use PRs for repository changes.
- Add a confirmation rule for tag/release operations that cannot go through PRs.

## Testing
- Not run; documentation/instruction-only change.