### PR TITLE
chore: revert 0.8.0 release commits

### DIFF
--- a/client/src/main/proto/io/streamnative/oxia/client.proto
+++ b/client/src/main/proto/io/streamnative/oxia/client.proto
@@ -314,13 +314,13 @@ message DeleteResponse {
 enum KeyComparisonType {
   // The stored key must be equal to the requested key
   EQUAL = 0;
-  // Search for a key that is the highest key that is less than or equal to the requested key
+  // Search for a key that is the highest key that is <= to the requested key
   FLOOR = 1;
-  // Search for a key that is the lowest key that is greater than or equal to the requested key
+  // Search for a key that is the lowest key that is >= to the requested key
   CEILING = 2;
-  // Search for a key that is the highest key that is less than the requested key
+  // Search for a key that is the highest key that is < to the requested key
   LOWER = 3;
-  // Search for a key that is the lowest key that is greater than the requested key
+  // Search for a key that is the lowest key that is > to the requested key
   HIGHER = 4;
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.oxia-db
-version=0.8.0
+version=0.7.5
 
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true


### PR DESCRIPTION
## Motivation
- The `v0.8.0` release workflow uploaded successfully but the artifacts are not publicly available on Maven Central.
- Revert the direct-pushed release commits through a PR instead of changing `main` directly.

## Modifications
- Revert `chore: release 0.8.0`, restoring the project version to `0.7.5`.
- Revert `fix: make generated javadocs release-safe`, restoring the previous proto comments.

## Testing
- Not run; this only reverts the two release-related commits.

## Notes
- The remote tag `v0.8.0` still exists because tag deletion cannot go through a pull request.