### PR TITLE
chore: upgrade project to 0.8.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.oxia-db
-version=0.7.5
+version=0.8.0-SNAPSHOT
 
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true


### PR DESCRIPTION
## Motivation
- Put the Java client back onto the 0.8.0 development version after the release-version commit was reverted.

## Modifications
- Updated the Gradle project version from 0.7.5 to 0.8.0-SNAPSHOT.

## Testing
- ./gradlew build