### PR TITLE
fix: restore release publishing

### DIFF
--- a/.github/workflows/ci-maven-publish-release.yaml
+++ b/.github/workflows/ci-maven-publish-release.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    name: Release to Maven Central
+    name: Release Maven artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -38,8 +39,35 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Validate release version
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            echo "Release publishing must run from a tag ref, got ${GITHUB_REF_TYPE}:${GITHUB_REF_NAME}"
+            exit 1
+          fi
+
+          expected_version="${GITHUB_REF_NAME#v}"
+          project_version="$(./gradlew properties -q | awk '/^version:/ { print $2 }')"
+
+          if [[ "${project_version}" == *-SNAPSHOT ]]; then
+            echo "Cannot release snapshot version ${project_version}"
+            exit 1
+          fi
+
+          if [[ "${project_version}" != "${expected_version}" ]]; then
+            echo "Tag version ${expected_version} does not match project version ${project_version}"
+            exit 1
+          fi
+
+      - name: Publish to GitHub Packages
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository --no-configuration-cache
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+
       - name: Release to Maven Central
-        run: ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,19 @@ subprojects {
                 }
             }
         }
+
+        extensions.configure<org.gradle.api.publish.PublishingExtension>("publishing") {
+            repositories {
+                maven {
+                    name = "GitHubPackages"
+                    url = uri("https://maven.pkg.github.com/oxia-db/oxia-client-java")
+                    credentials {
+                        username = findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
+                        password = findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+                    }
+                }
+            }
+        }
     }
 
     java {

--- a/client/src/main/proto/io/streamnative/oxia/client.proto
+++ b/client/src/main/proto/io/streamnative/oxia/client.proto
@@ -314,13 +314,13 @@ message DeleteResponse {
 enum KeyComparisonType {
   // The stored key must be equal to the requested key
   EQUAL = 0;
-  // Search for a key that is the highest key that is <= to the requested key
+  // Search for a key that is the highest key that is less than or equal to the requested key
   FLOOR = 1;
-  // Search for a key that is the lowest key that is >= to the requested key
+  // Search for a key that is the lowest key that is greater than or equal to the requested key
   CEILING = 2;
-  // Search for a key that is the highest key that is < to the requested key
+  // Search for a key that is the highest key that is less than the requested key
   LOWER = 3;
-  // Search for a key that is the lowest key that is > to the requested key
+  // Search for a key that is the lowest key that is greater than the requested key
   HIGHER = 4;
 }
 


### PR DESCRIPTION
## Motivation
- Release tags should publish Java artifacts to GitHub Packages and release the Maven Central deployment.
- The current workflow only configured Maven Central and used the Maven Central upload task rather than the automatic release task.
- The 0.8.0 release also exposed generated Javadoc failures from raw comparison operators in proto comments.

## Modifications
- Added a GitHub Packages Maven repository for each published module.
- Granted the release workflow `packages: write` and added a GitHub Packages publish step using `GITHUB_TOKEN`.
- Switched Maven Central publishing to `publishAndReleaseToMavenCentral`.
- Added release guards for tag-only publishing, snapshot prevention, and tag/project-version matching.
- Reworded `KeyComparisonType` proto comments to avoid raw comparison operators in generated Javadocs.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-maven-publish-release.yaml"); puts "yaml ok"'`\n- `./gradlew help --task publishAllPublicationsToGitHubPackagesRepository`\n- `./gradlew help --task publishAndReleaseToMavenCentral`\n- `./gradlew :client:javadoc --no-configuration-cache`