### PR TITLE
ci: skip Javadocs for prerelease tags

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -47,11 +47,11 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
 
       - name: Generate Javadocs
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
         run: ./gradlew :client-api:javadoc
 
       - name: Publish Javadocs
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.PAGES_DEPLOY_KEY }}


### PR DESCRIPTION
## Motivation
- Allow RC tags such as `v0.8.0-rc1` to publish Maven artifacts without overwriting the public `latest` Javadocs.
- Keep `latest` API docs aligned with final release tags only.
- Current project version is confirmed as `0.8.0-SNAPSHOT` in both `gradle.properties` and Gradle output.

## Modifications
- Added a prerelease guard to the release workflow Javadocs generation and publish steps.
- Javadocs now publish only for tag refs whose tag name does not contain `-`.

## Testing
- Ran `actionlint` on the remaining workflows, ignoring the expected local warning for the custom CNCF runner label.
- Ran `git diff --check` before committing.
- Verified `gradle.properties` contains `version=0.8.0-SNAPSHOT`.
- Verified `./gradlew properties -q` reports `version: 0.8.0-SNAPSHOT`.