### PR TITLE
ci: publish daily snapshots

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -16,6 +18,7 @@ concurrency:
 jobs:
   build:
     name: Release to Maven Central
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
     runs-on: cncf-ubuntu-8-32-x86
     steps:
       - name: Checkout code
@@ -38,6 +41,15 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Verify snapshot version
+        if: github.ref == 'refs/heads/main'
+        run: |
+          version="$(./gradlew properties -q | awk '/^version:/ {print $2}')"
+          if [[ "$version" != *-SNAPSHOT ]]; then
+            echo "Refusing to publish non-SNAPSHOT version from main: $version"
+            exit 1
+          fi
+
       - name: Release to Maven Central
         run: ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache
         env:
@@ -47,11 +59,11 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
 
       - name: Generate Javadocs
-        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
+        if: startsWith(github.ref, 'refs/tags/')
         run: ./gradlew :client-api:javadoc
 
       - name: Publish Javadocs
-        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
+        if: startsWith(github.ref, 'refs/tags/')
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.PAGES_DEPLOY_KEY }}


### PR DESCRIPTION
## Motivation
- Publish the current Java client SNAPSHOT artifact on a daily interval from `main`.
- Keep final release publishing tag-driven while allowing manual snapshot publishes from `main`.
- The current Gradle version is `0.8.0-SNAPSHOT`, which is the expected snapshot version.

## Modifications
- Added a daily `schedule` trigger to `ci-release.yaml`.
- Limited the release job to tag refs or `main` so manual dispatch does not publish arbitrary branches.
- Added a `main`-only version guard that refuses to publish unless Gradle reports a `-SNAPSHOT` version.
- Kept Javadocs publishing tag-only and removed the prerelease-specific guard.

## Testing
- Ran `actionlint` on the remaining workflows, ignoring the expected local warning for the custom CNCF runner label.
- Ran `git diff --check`.
- Verified `./gradlew properties -q` reports `version: 0.8.0-SNAPSHOT`.