### PR TITLE
ci: publish snapshots to GitHub Packages

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    name: Release to Maven Central
+    name: Publish Maven artifacts
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
     runs-on: cncf-ubuntu-8-32-x86
     steps:
@@ -50,7 +51,18 @@ jobs:
             exit 1
           fi
 
+      - name: Publish snapshot to GitHub Packages
+        if: github.ref == 'refs/heads/main'
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository --no-configuration-cache
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+
       - name: Release to Maven Central
+        if: startsWith(github.ref, 'refs/tags/')
         run: ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.gradle.api.publish.PublishingExtension
+
 plugins {
     `java-library`
     jacoco
@@ -86,6 +88,27 @@ subprojects {
                     connection.set("scm:git:git://github.com/oxia-db/oxia-client-java.git")
                     developerConnection.set("scm:git:ssh://github.com:oxia-db/oxia-client-java.git")
                     url.set("https://github.com/oxia-db/oxia-client-java")
+                }
+            }
+        }
+
+        extensions.configure<PublishingExtension>("publishing") {
+            repositories {
+                maven {
+                    name = "GitHubPackages"
+                    url = uri("https://maven.pkg.github.com/oxia-db/oxia-client-java")
+                    credentials {
+                        username =
+                                providers.gradleProperty("githubPackagesUsername")
+                                        .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                                        .orElse("")
+                                        .get()
+                        password =
+                                providers.gradleProperty("githubPackagesPassword")
+                                        .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                                        .orElse("")
+                                        .get()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Motivation
- The daily/manual snapshot workflow was attempting to publish `0.8.0-SNAPSHOT` to Maven Central snapshots and failed with `403 Forbidden`.
- Snapshot artifacts should publish to GitHub Packages Maven for this repository.
- Keep final `v*` releases publishing to Maven Central.

## Modifications
- Added a `GitHubPackages` Maven repository for the published Gradle subprojects.
- Granted the release workflow `packages: write` permission.
- Changed `main` snapshot publishes to run `publishAllPublicationsToGitHubPackagesRepository` with `GITHUB_TOKEN` credentials.
- Kept Maven Central publishing restricted to tag refs.

## Testing
- Ran `actionlint` on the remaining workflows, ignoring the expected local warning for the custom CNCF runner label.
- Ran `git diff --check`.
- Ran `./gradlew tasks --all` and verified GitHub Packages publish tasks are generated.
- Ran `./gradlew publishAllPublicationsToGitHubPackagesRepository --dry-run --no-configuration-cache` and verified it selects `client-api`, `client`, and `perf` publish tasks.
- Verified `./gradlew properties -q` reports `version: 0.8.0-SNAPSHOT`.