### PR TITLE
ci: keep Maven releases tag-only

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -18,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: Release to Maven Central
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: cncf-ubuntu-8-32-x86
     steps:
       - name: Checkout code
@@ -40,15 +38,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      - name: Verify snapshot version
-        if: github.ref == 'refs/heads/main'
-        run: |
-          version="$(./gradlew properties -q | awk '/^version:/ {print $2}')"
-          if [[ "$version" != *-SNAPSHOT ]]; then
-            echo "Refusing to publish non-SNAPSHOT version from main: $version"
-            exit 1
-          fi
 
       - name: Release to Maven Central
         run: ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache


### PR DESCRIPTION
## Motivation
- Keep Java client publishing aligned with the proven public Maven Central path used by `v0.6.0` through `v0.7.4` under `io.github.oxia-db`.
- Avoid daily/manual `main` snapshot publishes until Central Portal snapshots are explicitly enabled.
- Avoid GitHub Packages for public snapshots because Maven consumers need GitHub authentication.

## Modifications
- Removed the daily release workflow schedule.
- Restricted the release job to tag refs only.
- Removed the `main` snapshot-version guard because `main` no longer publishes artifacts.
- Left final `v*` tag releases and tag-only Javadocs publishing intact.

## Testing
- Ran `actionlint` on the remaining workflows, ignoring the expected local warning for the custom CNCF runner label.
- Ran `git diff --check`.