### PR TITLE
chore: release 0.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.oxia-db
-version=0.8.0-SNAPSHOT
+version=0.8.0
 
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true


### PR DESCRIPTION
## Motivation
- Prepare the Java client for the `0.8.0` Maven Central release.
- The release workflow is now tag-only and targets the public Maven Central path under `io.github.oxia-db`.

## Modifications
- Changed `gradle.properties` from `0.8.0-SNAPSHOT` to `0.8.0`.

## Testing
- Verified `./gradlew properties -q` reports `version: 0.8.0`.
- Ran `actionlint` on the remaining workflows, ignoring the expected local warning for the custom CNCF runner label.
- Ran `git diff --check`.
