### PR TITLE
fix: make generated Javadocs release-safe

### DIFF
--- a/client/src/main/proto/io/streamnative/oxia/client.proto
+++ b/client/src/main/proto/io/streamnative/oxia/client.proto
@@ -314,13 +314,13 @@ message DeleteResponse {
 enum KeyComparisonType {
   // The stored key must be equal to the requested key
   EQUAL = 0;
-  // Search for a key that is the highest key that is <= to the requested key
+  // Search for a key that is the highest key that is less than or equal to the requested key
   FLOOR = 1;
-  // Search for a key that is the lowest key that is >= to the requested key
+  // Search for a key that is the lowest key that is greater than or equal to the requested key
   CEILING = 2;
-  // Search for a key that is the highest key that is < to the requested key
+  // Search for a key that is the highest key that is less than the requested key
   LOWER = 3;
-  // Search for a key that is the lowest key that is > to the requested key
+  // Search for a key that is the lowest key that is greater than the requested key
   HIGHER = 4;
 }
 


### PR DESCRIPTION
## Motivation
- The retagged `v0.8.0` release workflow failed before publishing artifacts.
- The failure came from `:client:javadoc`, where generated proto Javadocs contained raw `<` and `<=` text in comments.

## Modifications
- Reworded the `KeyComparisonType` proto comments to avoid raw comparison symbols in generated Javadocs.

## Testing
- Ran `./gradlew :client:javadoc --no-configuration-cache`.
- Ran `git diff --check`.

## Release note
- After this PR merges, `v0.8.0` needs to be moved/recreated again to the new merged commit so the release workflow runs against the fixed source.