### PR TITLE
ci: release Maven Central deployments automatically

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -40,10 +40,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Release to Maven Central
-        run: ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralDeploymentValidation: PUBLISHED
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
 


### PR DESCRIPTION
## Motivation
- The current release workflow uploads Maven Central deployments but leaves them user-managed in Central Portal.
- The v0.8.0 workflow passed after the Javadoc fix, but Maven Central still does not list 0.8.0 because the deployment was not released.

## Modifications
- Run `publishAndReleaseToMavenCentral` instead of `publishAllPublicationsToMavenCentral`.
- Set Maven Central deployment validation to `PUBLISHED` so the workflow waits for public publication.

## Testing
- Ran `git diff --check`.
- Ran `./gradlew publishAndReleaseToMavenCentral --dry-run --no-configuration-cache -PmavenCentralDeploymentValidation=PUBLISHED`.