### PR TITLE
perf: switch sync range-scan iterator to gRPC manual flow control

### DIFF
--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -731,12 +731,19 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             Objects.requireNonNull(startKeyInclusive);
             Objects.requireNonNull(endKeyExclusive);
 
+            final var flowControl = consumer instanceof FlowControlledRangeScanConsumer fc ? fc : null;
+
             final Optional<String> partitionKey = OptionsUtils.getPartitionKey(options);
             final Optional<String> secondaryIndexName = OptionsUtils.getSecondaryIndexName(options);
             if (partitionKey.isPresent()) {
                 long shardId = shardManager.getShardForKey(partitionKey.get());
                 internalShardRangeScan(
-                        shardId, startKeyInclusive, endKeyExclusive, secondaryIndexName, timedConsumer);
+                        shardId,
+                        startKeyInclusive,
+                        endKeyExclusive,
+                        secondaryIndexName,
+                        timedConsumer,
+                        flowControl);
                 return;
             }
             final Set<Long> shardIds = shardManager.allShardIds();
@@ -744,7 +751,12 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                     new CompositeRangeScanConsumer(shardIds.size(), timedConsumer);
             for (Long shardId : shardIds) {
                 internalShardRangeScan(
-                        shardId, startKeyInclusive, endKeyExclusive, secondaryIndexName, multiShardConsumer);
+                        shardId,
+                        startKeyInclusive,
+                        endKeyExclusive,
+                        secondaryIndexName,
+                        multiShardConsumer,
+                        flowControl);
             }
         } catch (Exception e) {
             consumer.onError(e);
@@ -756,35 +768,62 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             String startKeyInclusive,
             String endKeyExclusive,
             Optional<String> secondaryIndexName,
-            RangeScanConsumer consumer) {
+            RangeScanConsumer consumer,
+            FlowControlledRangeScanConsumer flowControl) {
         var request = new RangeScanRequest();
         request.setShard(shardId).setStartInclusive(startKeyInclusive).setEndExclusive(endKeyExclusive);
         secondaryIndexName.ifPresent(request::setSecondaryIndexName);
-        rpcProvider.rangeScan(
-                request,
-                new CancelableStreamObserver<>() {
-                    @Override
-                    protected void handleNext(RangeScanResponse response) {
-                        for (int i = 0; i < response.getRecordsCount(); i++) {
-                            final boolean needNext =
-                                    consumer.onNext(ProtoUtil.getResultFromProto("", response.getRecordAt(i)));
-                            if (!needNext) {
-                                cancelAndComplete();
-                                return;
-                            }
-                        }
-                    }
+        var observer = new RangeScanShardObserver(consumer, flowControl);
+        rpcProvider.rangeScan(request, observer);
+        if (flowControl != null) {
+            flowControl.onStreamStarted(observer);
+        }
+    }
 
-                    @Override
-                    protected void handleError(Throwable t) {
-                        consumer.onError(t);
-                    }
+    private static final class RangeScanShardObserver
+            extends CancelableStreamObserver<RangeScanResponse>
+            implements FlowControlledRangeScanConsumer.StreamHandle {
+        private final RangeScanConsumer consumer;
+        private final FlowControlledRangeScanConsumer flowControl;
 
-                    @Override
-                    protected void handleComplete() {
-                        consumer.onCompleted();
-                    }
-                });
+        RangeScanShardObserver(
+                RangeScanConsumer consumer, FlowControlledRangeScanConsumer flowControl) {
+            super(flowControl != null);
+            this.consumer = consumer;
+            this.flowControl = flowControl;
+        }
+
+        @Override
+        protected void handleNext(RangeScanResponse response) {
+            for (int i = 0; i < response.getRecordsCount(); i++) {
+                final boolean needNext =
+                        consumer.onNext(ProtoUtil.getResultFromProto("", response.getRecordAt(i)));
+                if (!needNext) {
+                    cancelAndComplete();
+                    return;
+                }
+            }
+            if (flowControl != null) {
+                flowControl.onStreamIdle(this);
+            }
+        }
+
+        @Override
+        protected void handleError(Throwable t) {
+            consumer.onError(t);
+        }
+
+        @Override
+        protected void handleComplete() {
+            consumer.onCompleted();
+        }
+
+        @Override
+        public void requestNext() {
+            requestNextMessage();
+        }
+
+        // StreamHandle.cancel() is satisfied by CancelableStreamObserver.cancel()
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/FlowControlledRangeScanConsumer.java
+++ b/client/src/main/java/io/oxia/client/FlowControlledRangeScanConsumer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client;
+
+/**
+ * Internal contract implemented by {@link io.oxia.client.api.RangeScanConsumer}s that consume
+ * records on demand. When the consumer passed to a range scan implements this interface, the
+ * underlying gRPC streams are switched to manual flow control: after the records of a response have
+ * been delivered, the stream is paused until the consumer requests the next response through the
+ * stream handle. This lets a slow consumer apply backpressure to the server instead of blocking the
+ * gRPC transport threads.
+ */
+interface FlowControlledRangeScanConsumer {
+
+    /** Invoked once per underlying gRPC stream, after the stream has been started. */
+    void onStreamStarted(StreamHandle handle);
+
+    /**
+     * Invoked after all the records of a response have been delivered. The stream will not deliver
+     * further responses until {@link StreamHandle#requestNext()} is invoked.
+     */
+    void onStreamIdle(StreamHandle handle);
+
+    /** Control over a single underlying gRPC stream. Implementations are thread-safe. */
+    interface StreamHandle {
+        /** Requests the delivery of the next response on this stream. */
+        void requestNext();
+
+        /** Cancels this stream. */
+        void cancel();
+    }
+}

--- a/client/src/main/java/io/oxia/client/GetResultIterator.java
+++ b/client/src/main/java/io/oxia/client/GetResultIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,36 +17,81 @@ package io.oxia.client;
 
 import io.oxia.client.api.GetResult;
 import io.oxia.client.api.RangeScanConsumer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.SneakyThrows;
 
-public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer, AutoCloseable {
+public class GetResultIterator
+        implements Iterator<GetResult>,
+                RangeScanConsumer,
+                FlowControlledRangeScanConsumer,
+                AutoCloseable {
 
-    private GetResult pendingResult;
+    // Records received but not yet consumed. Bounded through flow control: each underlying
+    // stream has at most one response in flight, and idle streams are only resumed once the
+    // buffer has been drained.
+    private final Deque<GetResult> buffer = new ArrayDeque<>();
+
+    // A scan without a partition key opens one stream per shard, all feeding this iterator.
+    private final List<StreamHandle> streams = new ArrayList<>();
+    private final List<StreamHandle> idleStreams = new ArrayList<>();
+
     private Throwable error = null;
     private boolean completed = false;
     private boolean closed = false;
 
     @Override
-    @SneakyThrows
+    public void onStreamStarted(StreamHandle handle) {
+        boolean cancelNow;
+        synchronized (this) {
+            cancelNow = closed;
+            if (!cancelNow) {
+                streams.add(handle);
+            }
+        }
+        if (cancelNow) {
+            handle.cancel();
+        }
+    }
+
+    @Override
+    public void onStreamIdle(StreamHandle handle) {
+        boolean requestNow;
+        synchronized (this) {
+            if (closed) {
+                return;
+            }
+            requestNow = buffer.isEmpty();
+            if (!requestNow) {
+                idleStreams.add(handle);
+            }
+        }
+        // Invoked outside the monitor: with a direct executor gRPC can deliver the next
+        // response inline, re-entering onNext()/onError() from within this call.
+        if (requestNow) {
+            handle.requestNext();
+        }
+    }
+
+    @Override
     public synchronized boolean onNext(GetResult result) {
         if (closed) {
             return false;
         }
-        while (pendingResult != null && !closed) {
-            wait();
-        }
-        if (closed) {
-            return false;
-        }
-        pendingResult = result;
+        buffer.add(result);
         notifyAll();
         return true;
     }
 
     @Override
     public synchronized void onError(Throwable throwable) {
+        // Don't cancel the other streams here: onError can be invoked while holding another
+        // stream observer's lock, and cancelling a stream takes its observer's lock. The
+        // streams are cancelled by close().
         this.error = new Exception("Range scan error", throwable);
         notifyAll();
     }
@@ -60,7 +105,7 @@ public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer
     @Override
     @SneakyThrows
     public synchronized boolean hasNext() {
-        while (error == null && !completed && pendingResult == null && !closed) {
+        while (error == null && !completed && buffer.isEmpty() && !closed) {
             wait();
         }
 
@@ -68,36 +113,54 @@ public class GetResultIterator implements Iterator<GetResult>, RangeScanConsumer
             throw new RuntimeException(error);
         }
 
-        return pendingResult != null;
+        return !buffer.isEmpty();
     }
 
     @Override
     @SneakyThrows
-    public synchronized GetResult next() {
-        while (error == null && !completed && pendingResult == null && !closed) {
-            wait();
-        }
+    public GetResult next() {
+        GetResult res;
+        List<StreamHandle> toRequest = null;
+        synchronized (this) {
+            while (error == null && !completed && buffer.isEmpty() && !closed) {
+                wait();
+            }
 
-        if (error != null) {
-            throw new RuntimeException(error);
-        }
+            if (error != null) {
+                throw new RuntimeException(error);
+            }
 
-        if (pendingResult != null) {
-            GetResult res = pendingResult;
-            this.pendingResult = null;
-            notifyAll();
-            return res;
-        }
+            res = buffer.poll();
+            if (res == null) {
+                throw new NoSuchElementException();
+            }
 
-        throw new NoSuchElementException();
+            if (buffer.isEmpty() && !idleStreams.isEmpty()) {
+                toRequest = new ArrayList<>(idleStreams);
+                idleStreams.clear();
+            }
+        }
+        // Outside the monitor: see onStreamIdle().
+        if (toRequest != null) {
+            toRequest.forEach(StreamHandle::requestNext);
+        }
+        return res;
     }
 
     @Override
-    public synchronized void close() {
-        if (closed) {
-            return;
+    public void close() {
+        List<StreamHandle> toCancel;
+        synchronized (this) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            toCancel = new ArrayList<>(streams);
+            streams.clear();
+            idleStreams.clear();
+            buffer.clear();
+            notifyAll();
         }
-        closed = true;
-        notifyAll();
+        toCancel.forEach(StreamHandle::cancel);
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/observer/CancelableStreamObserver.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/CancelableStreamObserver.java
@@ -27,6 +27,7 @@ public abstract class CancelableStreamObserver<T> implements StreamObserver<T> {
     private static final String CANCELED = "canceled";
 
     private final ReentrantLock lock;
+    private final boolean manualFlowControl;
 
     @GuardedBy("lock")
     private boolean terminated;
@@ -35,7 +36,17 @@ public abstract class CancelableStreamObserver<T> implements StreamObserver<T> {
     private ClientCallStreamObserver<?> requestStream;
 
     public CancelableStreamObserver() {
+        this(false);
+    }
+
+    /**
+     * @param manualFlowControl when true, the stream is started with automatic inbound flow control
+     *     disabled: after one initial message, further messages are only delivered when {@link
+     *     #requestNextMessage()} is invoked.
+     */
+    public CancelableStreamObserver(boolean manualFlowControl) {
         this.lock = new ReentrantLock();
+        this.manualFlowControl = manualFlowControl;
         this.terminated = false;
         this.requestStream = null;
     }
@@ -87,6 +98,11 @@ public abstract class CancelableStreamObserver<T> implements StreamObserver<T> {
             if (terminated) {
                 previousStream = requestStream;
             } else {
+                if (manualFlowControl) {
+                    // Must happen before the call is started: injectRequestStream is invoked
+                    // from ClientResponseObserver.beforeStart()
+                    requestStream.disableAutoRequestWithInitial(1);
+                }
                 previousStream = this.requestStream;
                 this.requestStream = requestStream;
             }
@@ -96,6 +112,23 @@ public abstract class CancelableStreamObserver<T> implements StreamObserver<T> {
 
         if (previousStream != null) {
             previousStream.cancel(CANCELED, null);
+        }
+    }
+
+    /** Requests the next message on a stream using manual flow control. No-op once terminated. */
+    public final void requestNextMessage() {
+        final ClientCallStreamObserver<?> stream;
+        lock.lock();
+        try {
+            if (terminated) {
+                return;
+            }
+            stream = requestStream;
+        } finally {
+            lock.unlock();
+        }
+        if (stream != null) {
+            stream.request(1);
         }
     }
 

--- a/client/src/test/java/io/oxia/client/GetResultIteratorTest.java
+++ b/client/src/test/java/io/oxia/client/GetResultIteratorTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.oxia.client.api.GetResult;
+import io.oxia.client.api.Version;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@Timeout(30)
+class GetResultIteratorTest {
+
+    private static GetResult result(String key) {
+        return new GetResult(
+                key, new byte[0], new Version(0, 0, 0, 0, Optional.empty(), Optional.empty()));
+    }
+
+    private static class TestStreamHandle implements FlowControlledRangeScanConsumer.StreamHandle {
+        final AtomicInteger requested = new AtomicInteger();
+        final AtomicBoolean cancelled = new AtomicBoolean();
+
+        @Override
+        public void requestNext() {
+            requested.incrementAndGet();
+        }
+
+        @Override
+        public void cancel() {
+            cancelled.set(true);
+        }
+    }
+
+    @Test
+    void producerIsNeverBlocked() {
+        var it = new GetResultIterator();
+        for (int i = 0; i < 100; i++) {
+            assertThat(it.onNext(result("key-" + i))).isTrue();
+        }
+        it.onCompleted();
+
+        for (int i = 0; i < 100; i++) {
+            assertThat(it.hasNext()).isTrue();
+            assertThat(it.next().key()).isEqualTo("key-" + i);
+        }
+        assertThat(it.hasNext()).isFalse();
+        assertThatThrownBy(it::next).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void demandIsSignalledWhenBufferDrains() {
+        var it = new GetResultIterator();
+        var handle = new TestStreamHandle();
+        it.onStreamStarted(handle);
+
+        it.onNext(result("a"));
+        it.onNext(result("b"));
+        it.onStreamIdle(handle);
+
+        // Buffer is non-empty: the stream must stay parked
+        assertThat(handle.requested).hasValue(0);
+
+        assertThat(it.next().key()).isEqualTo("a");
+        assertThat(handle.requested).hasValue(0);
+
+        // Draining the last record must resume the parked stream
+        assertThat(it.next().key()).isEqualTo("b");
+        assertThat(handle.requested).hasValue(1);
+    }
+
+    @Test
+    void idleStreamIsResumedImmediatelyWhenBufferIsEmpty() {
+        var it = new GetResultIterator();
+        var handle = new TestStreamHandle();
+        it.onStreamStarted(handle);
+
+        it.onStreamIdle(handle);
+        assertThat(handle.requested).hasValue(1);
+    }
+
+    @Test
+    void closeCancelsAllStreams() {
+        var it = new GetResultIterator();
+        var handle1 = new TestStreamHandle();
+        var handle2 = new TestStreamHandle();
+        it.onStreamStarted(handle1);
+        it.onStreamStarted(handle2);
+
+        it.onNext(result("a"));
+        it.close();
+
+        assertThat(handle1.cancelled).isTrue();
+        assertThat(handle2.cancelled).isTrue();
+        assertThat(it.hasNext()).isFalse();
+        assertThat(it.onNext(result("b"))).isFalse();
+    }
+
+    @Test
+    void streamStartedAfterCloseIsCancelled() {
+        var it = new GetResultIterator();
+        it.close();
+
+        var handle = new TestStreamHandle();
+        it.onStreamStarted(handle);
+        assertThat(handle.cancelled).isTrue();
+    }
+
+    @Test
+    void errorPropagatesAndCloseCancelsStreams() {
+        var it = new GetResultIterator();
+        var handle = new TestStreamHandle();
+        it.onStreamStarted(handle);
+
+        it.onNext(result("a"));
+        it.onError(new RuntimeException("scan failed"));
+
+        assertThatThrownBy(it::hasNext)
+                .isInstanceOf(RuntimeException.class)
+                .hasRootCauseMessage("scan failed");
+
+        it.close();
+        assertThat(handle.cancelled).isTrue();
+    }
+
+    @Test
+    void concurrentProducerAndConsumer() throws Exception {
+        final int batches = 20;
+        final int recordsPerBatch = 5;
+
+        var it = new GetResultIterator();
+        var demand = new Semaphore(0);
+        var handle =
+                new FlowControlledRangeScanConsumer.StreamHandle() {
+                    @Override
+                    public void requestNext() {
+                        demand.release();
+                    }
+
+                    @Override
+                    public void cancel() {}
+                };
+
+        var producer =
+                new Thread(
+                        () -> {
+                            it.onStreamStarted(handle);
+                            for (int b = 0; b < batches; b++) {
+                                if (b > 0) {
+                                    try {
+                                        demand.acquire();
+                                    } catch (InterruptedException e) {
+                                        return;
+                                    }
+                                }
+                                for (int r = 0; r < recordsPerBatch; r++) {
+                                    it.onNext(result("key-" + (b * recordsPerBatch + r)));
+                                }
+                                it.onStreamIdle(handle);
+                            }
+                            it.onCompleted();
+                        });
+        producer.start();
+
+        List<String> keys = new ArrayList<>();
+        while (it.hasNext()) {
+            keys.add(it.next().key());
+        }
+        producer.join();
+
+        assertThat(keys).hasSize(batches * recordsPerBatch);
+        for (int i = 0; i < keys.size(); i++) {
+            assertThat(keys.get(i)).isEqualTo("key-" + i);
+        }
+    }
+}

--- a/client/src/test/java/io/oxia/client/grpc/observer/CancelableStreamObserverTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/observer/CancelableStreamObserverTest.java
@@ -103,10 +103,63 @@ class CancelableStreamObserverTest {
         verify(requestStream).cancel(eq("canceled"), isNull());
     }
 
+    @Test
+    void manualFlowControlDisablesAutoRequestOnInjection() {
+        var observer = new RecordingStreamObserver(true);
+        @SuppressWarnings("unchecked")
+        ClientCallStreamObserver<String> requestStream = mock(ClientCallStreamObserver.class);
+
+        observer.injectRequestStream(requestStream);
+
+        verify(requestStream).disableAutoRequestWithInitial(1);
+    }
+
+    @Test
+    void autoFlowControlByDefault() {
+        var observer = new RecordingStreamObserver();
+        @SuppressWarnings("unchecked")
+        ClientCallStreamObserver<String> requestStream = mock(ClientCallStreamObserver.class);
+
+        observer.injectRequestStream(requestStream);
+
+        verify(requestStream, never()).disableAutoRequestWithInitial(1);
+    }
+
+    @Test
+    void requestNextMessageForwardsToStream() {
+        var observer = new RecordingStreamObserver(true);
+        @SuppressWarnings("unchecked")
+        ClientCallStreamObserver<String> requestStream = mock(ClientCallStreamObserver.class);
+        observer.injectRequestStream(requestStream);
+
+        observer.requestNextMessage();
+
+        verify(requestStream).request(1);
+    }
+
+    @Test
+    void requestNextMessageIsNoOpOnceTerminated() {
+        var observer = new RecordingStreamObserver(true);
+        @SuppressWarnings("unchecked")
+        ClientCallStreamObserver<String> requestStream = mock(ClientCallStreamObserver.class);
+        observer.injectRequestStream(requestStream);
+
+        observer.cancel();
+        observer.requestNextMessage();
+
+        verify(requestStream, never()).request(1);
+    }
+
     private static final class RecordingStreamObserver extends CancelableStreamObserver<String> {
         private final AtomicInteger nextCount = new AtomicInteger();
         private final AtomicInteger errorCount = new AtomicInteger();
         private final AtomicInteger completedCount = new AtomicInteger();
+
+        RecordingStreamObserver() {}
+
+        RecordingStreamObserver(boolean manualFlowControl) {
+            super(manualFlowControl);
+        }
 
         @Override
         protected void handleNext(String value) {


### PR DESCRIPTION
### Motivation

The sync client's range-scan iterator (`GetResultIterator`) hands records from the gRPC transport thread to the application thread one at a time through a wait/notify slot: `onNext()` parks the transport thread until `next()` has consumed the previous record. That costs a lock handoff and two context switches per record, and a slow consumer stalls every RPC sharing that event loop, since the channels run with `directExecutor()`.

### Modification

- `CancelableStreamObserver` gains an optional manual flow-control mode: the request stream is started with `disableAutoRequestWithInitial(1)` and the observer exposes `requestNextMessage()`. The default mode is unchanged.
- When the consumer of a range scan is the sync iterator (internal `FlowControlledRangeScanConsumer` contract), each shard stream delivers one response at a time. Records are buffered in the iterator, so the transport thread never blocks; once the buffer drains, parked streams are resumed with `request(1)`. The buffer stays bounded to at most one in-flight response per shard, providing end-to-end backpressure to the server instead of stalling the event loop.
- `GetResultIterator.close()` now cancels the underlying shard streams directly. Previously a closed scan kept its streams open until the next record delivery observed the `false` return from `onNext()`.
- Consumers passed to the async `rangeScan()` API keep the existing push behavior.

### Verification

- New `GetResultIteratorTest` covers buffering, demand signalling, cancellation on close, error propagation, and a concurrent producer/consumer protocol test.
- `CancelableStreamObserverTest` extended for the manual flow-control mode.
- Full `:client:test` suite including the testcontainers integration tests passes locally (`testRangeScan`, `testRangeScanWithPartitionKey`, `testRangeScanCloseStopsIteration`, `testRangeScanEarlyStop`).