### PR TITLE
perf: route keys to shards with a binary search over the hash ranges

### DIFF
--- a/client/src/main/java/io/oxia/client/shard/HashRangeShardStrategy.java
+++ b/client/src/main/java/io/oxia/client/shard/HashRangeShardStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2025 The Oxia Authors
+ * Copyright © 2022-2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,11 @@ package io.oxia.client.shard;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.util.function.Function;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import net.openhft.hashing.LongHashFunction;
@@ -26,17 +29,46 @@ import net.openhft.hashing.LongHashFunction;
 @RequiredArgsConstructor
 class HashRangeShardStrategy implements ShardStrategy {
 
-    private final Function<String, Long> hashFn;
+    private final ToLongFunction<String> hashFn;
 
     @Override
     @NonNull
     public Predicate<Shard> acceptsKeyPredicate(@NonNull String key) {
-        long hash = hashFn.apply(key);
+        long hash = hashFn.applyAsLong(key);
         return shard ->
                 shard.hashRange().minInclusive() <= hash && hash <= shard.hashRange().maxInclusive();
     }
 
-    static final Function<String, Long> Xxh332Hash =
+    /**
+     * The hash ranges are non-overlapping: sort them by their lower bound and binary-search the key
+     * hash, so that the per-operation lookup is O(log n) and allocation-free.
+     */
+    @Override
+    public @NonNull ShardRouter createRouter(@NonNull Collection<Shard> shards) {
+        final Shard[] sorted = shards.toArray(new Shard[0]);
+        Arrays.sort(sorted, Comparator.comparingLong(s -> s.hashRange().minInclusive()));
+        final long[] minHashes = new long[sorted.length];
+        final long[] maxHashes = new long[sorted.length];
+        for (int i = 0; i < sorted.length; i++) {
+            minHashes[i] = sorted[i].hashRange().minInclusive();
+            maxHashes[i] = sorted[i].hashRange().maxInclusive();
+        }
+        return key -> {
+            final long hash = hashFn.applyAsLong(key);
+            int idx = Arrays.binarySearch(minHashes, hash);
+            if (idx < 0) {
+                // Not an exact match on a lower bound: take the floor entry, i.e. the one
+                // preceding the insertion point
+                idx = -idx - 2;
+            }
+            if (idx < 0 || hash > maxHashes[idx]) {
+                return null;
+            }
+            return sorted[idx];
+        };
+    }
+
+    static final ToLongFunction<String> Xxh332Hash =
             s -> LongHashFunction.xx3().hashBytes(s.getBytes(UTF_8)) & 0x00000000FFFFFFFFL;
 
     static final ShardStrategy Xxh332HashRangeShardStrategy = new HashRangeShardStrategy(Xxh332Hash);

--- a/client/src/main/java/io/oxia/client/shard/ShardAssignmentsContainer.java
+++ b/client/src/main/java/io/oxia/client/shard/ShardAssignmentsContainer.java
@@ -17,8 +17,8 @@ package io.oxia.client.shard;
 
 import com.google.common.base.Strings;
 import io.oxia.client.grpc.OxiaStatusException;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -28,6 +28,9 @@ public class ShardAssignmentsContainer {
     private final ConcurrentMap<Long, Shard> shards = new ConcurrentHashMap<>();
     private final ShardStrategy shardStrategy;
 
+    // Immutable lookup structure, rebuilt on each assignments update
+    private volatile ShardRouter router;
+
     @Getter private final String namespace;
 
     ShardAssignmentsContainer(ShardStrategy shardStrategy, String namespace) {
@@ -35,18 +38,16 @@ public class ShardAssignmentsContainer {
             throw new IllegalArgumentException("namespace must not be null or empty");
         }
         this.shardStrategy = shardStrategy;
+        this.router = shardStrategy.createRouter(List.of());
         this.namespace = namespace;
     }
 
     public long getShardForKey(String key) {
-        var test = shardStrategy.acceptsKeyPredicate(key);
-        Optional<Shard> shard = shards.values().stream().filter(test).findFirst();
-
-        if (shard.isPresent()) {
-            return shard.get().id();
-        } else {
+        Shard shard = router.getShardForKey(key);
+        if (shard == null) {
             throw OxiaStatusException.shardNotFound(key);
         }
+        return shard.id();
     }
 
     public String leader(long shardId) {
@@ -61,10 +62,11 @@ public class ShardAssignmentsContainer {
         return shard.leader();
     }
 
-    void update(ShardManager.ShardAssignmentChanges changes) {
+    synchronized void update(ShardManager.ShardAssignmentChanges changes) {
         changes.added().forEach(s -> shards.put(s.id(), s));
         changes.reassigned().forEach(s -> shards.put(s.id(), s));
         changes.removed().forEach(s -> shards.remove(s.id(), s));
+        router = shardStrategy.createRouter(shards.values());
     }
 
     Set<Long> allShardIds() {

--- a/client/src/main/java/io/oxia/client/shard/ShardRouter.java
+++ b/client/src/main/java/io/oxia/client/shard/ShardRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2026 The Oxia Authors
+ * Copyright © 2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,15 @@
  */
 package io.oxia.client.shard;
 
-import java.util.Collection;
-import java.util.function.Predicate;
 import lombok.NonNull;
 
-interface ShardStrategy {
-    @NonNull
-    Predicate<Shard> acceptsKeyPredicate(@NonNull String key);
+/**
+ * Immutable key-to-shard lookup structure. Rebuilt by the {@link ShardStrategy} whenever the shard
+ * assignments change, and queried on every client operation.
+ */
+@FunctionalInterface
+interface ShardRouter {
 
-    /**
-     * Builds the lookup structure used to route keys to shards. Invoked only when the shard
-     * assignments change, while the returned router is queried on every operation.
-     */
-    @NonNull
-    ShardRouter createRouter(@NonNull Collection<Shard> shards);
+    /** Returns the shard that owns the given key, or {@code null} when no shard matches. */
+    Shard getShardForKey(@NonNull String key);
 }

--- a/client/src/test/java/io/oxia/client/shard/HashRangeShardStrategyTest.java
+++ b/client/src/test/java/io/oxia/client/shard/HashRangeShardStrategyTest.java
@@ -17,7 +17,11 @@ package io.oxia.client.shard;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,5 +46,75 @@ class HashRangeShardStrategyTest {
         var predicate = strategy.acceptsKeyPredicate("key");
         var shard = new Shard(1, "leader", new HashRange(min, max));
         assertThat(predicate.test(shard)).isEqualTo(matches);
+    }
+
+    // The key itself is the hash, so that the probes below are explicit
+    private static final HashRangeShardStrategy keyAsHashStrategy =
+            new HashRangeShardStrategy(Long::parseLong);
+
+    private static Stream<Arguments> routerArgs() {
+        return Stream.of(
+                Arguments.of("5", -1L),
+                Arguments.of("10", 1L),
+                Arguments.of("15", 1L),
+                Arguments.of("19", 1L),
+                Arguments.of("20", 3L),
+                Arguments.of("29", 3L),
+                Arguments.of("30", 2L),
+                Arguments.of("39", 2L),
+                Arguments.of("40", -1L),
+                Arguments.of("45", -1L));
+    }
+
+    @ParameterizedTest
+    @MethodSource("routerArgs")
+    void routerFindsShardByHash(String key, long expectedShardId) {
+        // Deliberately unsorted, with a gap below 10 and above 39
+        var shards =
+                List.of(
+                        new Shard(2, "leader", new HashRange(30, 39)),
+                        new Shard(1, "leader", new HashRange(10, 19)),
+                        new Shard(3, "leader", new HashRange(20, 29)));
+        var router = keyAsHashStrategy.createRouter(shards);
+
+        var shard = router.getShardForKey(key);
+        if (expectedShardId < 0) {
+            assertThat(shard).isNull();
+        } else {
+            assertThat(shard).isNotNull();
+            assertThat(shard.id()).isEqualTo(expectedShardId);
+        }
+    }
+
+    @Test
+    void routerOnEmptyShards() {
+        var router = keyAsHashStrategy.createRouter(List.of());
+        assertThat(router.getShardForKey("0")).isNull();
+    }
+
+    @Test
+    void routerMatchesLinearScan() {
+        var random = new Random(0xacc7);
+        for (int iteration = 0; iteration < 100; iteration++) {
+            // Build random non-overlapping ranges, randomly dropping segments to create gaps
+            List<Shard> shards = new ArrayList<>();
+            long bound = 0;
+            for (int segment = 0; segment < 100; segment++) {
+                long min = bound + random.nextInt(100);
+                long max = min + random.nextInt(100);
+                if (random.nextBoolean()) {
+                    shards.add(new Shard(segment, "leader", new HashRange(min, max)));
+                }
+                bound = max + 1;
+            }
+
+            var router = keyAsHashStrategy.createRouter(shards);
+            for (int probe = 0; probe < 1_000; probe++) {
+                String key = Long.toString(random.nextLong(bound + 100));
+                var predicate = keyAsHashStrategy.acceptsKeyPredicate(key);
+                Shard expected = shards.stream().filter(predicate).findFirst().orElse(null);
+                assertThat(router.getShardForKey(key)).isEqualTo(expected);
+            }
+        }
     }
 }

--- a/client/src/test/java/io/oxia/client/shard/StaticShardStrategy.java
+++ b/client/src/test/java/io/oxia/client/shard/StaticShardStrategy.java
@@ -21,7 +21,9 @@ import io.oxia.client.OxiaClientBuilderImpl;
 import io.oxia.proto.NamespaceShardsAssignment;
 import io.oxia.proto.ShardAssignment;
 import io.oxia.proto.ShardAssignments;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -38,6 +40,20 @@ class StaticShardStrategy implements ShardStrategy {
         return Optional.ofNullable(assignments.get(key))
                 .map(a -> (Predicate<Shard>) s -> isEquivalent(s, a))
                 .orElse(s -> false);
+    }
+
+    @Override
+    public @NonNull ShardRouter createRouter(@NonNull Collection<Shard> shards) {
+        final List<Shard> snapshot = List.copyOf(shards);
+        return key -> {
+            final var test = acceptsKeyPredicate(key);
+            for (Shard shard : snapshot) {
+                if (test.test(shard)) {
+                    return shard;
+                }
+            }
+            return null;
+        };
     }
 
     public @NonNull StaticShardStrategy assign(@NonNull String key, @NonNull ShardAssignment shard) {

--- a/client/src/test/java/io/oxia/client/shard/Xxh332HashTest.java
+++ b/client/src/test/java/io/oxia/client/shard/Xxh332HashTest.java
@@ -36,6 +36,6 @@ public class Xxh332HashTest {
     @ParameterizedTest
     @MethodSource("hashArgs")
     void ranges(String key, long hash) {
-        assertThat(Xxh332Hash.apply(key)).isEqualTo(hash);
+        assertThat(Xxh332Hash.applyAsLong(key)).isEqualTo(hash);
     }
 }


### PR DESCRIPTION
### Motivation

`ShardAssignmentsContainer.getShardForKey()` runs on every `put`/`get`/`delete` and scanned all the shards linearly via `shards.values().stream().filter(test).findFirst()` — allocating a stream pipeline, a capturing `Predicate` and an `Optional` per call. With hundreds of shards the scan dominates the client-side cost of an operation. The hash function was also declared as `Function<String, Long>`, boxing the hash of every key.

### Modification

- New internal `ShardRouter`: an immutable lookup structure rebuilt by the `ShardStrategy` whenever the shard assignments change (rare), and queried on every operation (hot).
- `HashRangeShardStrategy` builds the router as the (non-overlapping) hash ranges sorted by lower bound, held in parallel `long[]` arrays: the per-key lookup is one xxh3 hash plus an `Arrays.binarySearch` — O(log n) and allocation-free.
- `ShardAssignmentsContainer` holds a `volatile ShardRouter`, rebuilt in `update()` (now `synchronized`, guarding the read-modify-rebuild against concurrent assignment updates).
- The hash function is now a `ToLongFunction<String>`.

### Verification

- New router tests in `HashRangeShardStrategyTest`: explicit boundary probes (exact lower/upper bounds, gaps between ranges, below/above all ranges, unsorted input), the empty-assignments case, and a seeded property test comparing the binary-search router against the previous linear predicate scan across 100 random range layouts × 1000 probes each.
- Full `:client:test` suite including the testcontainers integration tests passes locally.