### PR TITLE
perf: compute UTF-8 key sizes without materializing the bytes

### DIFF
--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -15,9 +15,8 @@
  */
 package io.oxia.client.batch;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.google.common.annotations.VisibleForTesting;
+import io.netty.buffer.ByteBufUtil;
 import io.oxia.client.grpc.ManagedWriteStream;
 import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.session.SessionManager;
@@ -57,14 +56,15 @@ final class WriteBatch extends BatchBase implements Batch {
         this.maxBatchSize = maxBatchSize;
     }
 
+    // ByteBufUtil.utf8Bytes() computes the UTF-8 encoded length without materializing the bytes
     int sizeOf(@NonNull Operation<?> operation) {
         if (operation instanceof Operation.WriteOperation.PutOperation p) {
-            return p.key().getBytes(UTF_8).length + p.value().length;
+            return ByteBufUtil.utf8Bytes(p.key()) + p.value().length;
         } else if (operation instanceof Operation.WriteOperation.DeleteOperation d) {
-            return d.key().getBytes(UTF_8).length;
+            return ByteBufUtil.utf8Bytes(d.key());
         } else if (operation instanceof Operation.WriteOperation.DeleteRangeOperation r) {
-            return r.startKeyInclusive().getBytes(UTF_8).length
-                    + r.endKeyExclusive().getBytes(UTF_8).length;
+            return ByteBufUtil.utf8Bytes(r.startKeyInclusive())
+                    + ByteBufUtil.utf8Bytes(r.endKeyExclusive());
         }
         return 0;
     }

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -64,6 +64,7 @@ import io.oxia.proto.OxiaClientGrpc;
 import io.oxia.proto.ReadRequest;
 import io.oxia.proto.ReadResponse;
 import io.oxia.proto.WriteResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -267,6 +268,35 @@ class BatchTest {
             assertThat(batch.puts).containsOnly(put);
             assertThat(batch.deletes).containsOnly(delete);
             assertThat(batch.deleteRanges).containsOnly(deleteRange);
+        }
+
+        @Test
+        public void sizeOfMatchesEncodedLength() {
+            // One, two, three and four byte UTF-8 sequences
+            String key = "a-é-世-🚀";
+            int keyBytes = key.getBytes(StandardCharsets.UTF_8).length;
+            byte[] value = new byte[10];
+
+            var sizedPut =
+                    new PutOperation(
+                            new CompletableFuture<>(),
+                            key,
+                            Optional.empty(),
+                            Optional.empty(),
+                            value,
+                            OptionalLong.empty(),
+                            OptionalLong.empty(),
+                            Optional.empty(),
+                            Collections.emptyList(),
+                            OptionalLong.empty(),
+                            OptionalLong.empty());
+            assertThat(batch.sizeOf(sizedPut)).isEqualTo(keyBytes + value.length);
+
+            var sizedDelete = new DeleteOperation(new CompletableFuture<>(), key, OptionalLong.empty());
+            assertThat(batch.sizeOf(sizedDelete)).isEqualTo(keyBytes);
+
+            var sizedDeleteRange = new DeleteRangeOperation(new CompletableFuture<>(), key, key);
+            assertThat(batch.sizeOf(sizedDeleteRange)).isEqualTo(2 * keyBytes);
         }
 
         @Test


### PR DESCRIPTION
### Motivation

`WriteBatch.sizeOf()` encoded the key with `String.getBytes(UTF_8)` just to measure its length, and it runs twice per write operation (once in `canAdd()` and once in `add()`), so every put/delete allocated two throwaway byte arrays on the batcher thread.

### Modification

Use Netty's `ByteBufUtil.utf8Bytes(CharSequence)` instead, which computes the encoded length without allocating (with an ASCII fast path). This adds no dependency: `netty-buffer` is already a direct dependency of the client module, since the lightproto-generated proto classes serialize into `ByteBuf`.

Chosen over Guava's `Utf8.encodedLength()` deliberately: Guava throws on unpaired surrogates, while Netty counts them as the `?` replacement byte — matching what `String.getBytes(UTF_8)` actually produced before.

### Verification

New `sizeOfMatchesEncodedLength` test in `BatchTest` with a key mixing 1/2/3/4-byte UTF-8 sequences, asserting `sizeOf` equals `getBytes(UTF_8).length`-based sizes for put, delete and delete-range operations. Full `:client:test` suite including the testcontainers integration tests passes locally.