### PR TITLE
perf: dispatch notifications with a plain loop instead of parallelStream

### DIFF
--- a/client/src/main/java/io/oxia/client/CompositeConsumer.java
+++ b/client/src/main/java/io/oxia/client/CompositeConsumer.java
@@ -29,6 +29,8 @@ public class CompositeConsumer<T> implements Consumer<T> {
 
     @Override
     public void accept(T t) {
-        callbacks.parallelStream().forEach(c -> c.accept(t));
+        for (Consumer<T> callback : callbacks) {
+            callback.accept(t);
+        }
     }
 }

--- a/client/src/test/java/io/oxia/client/CompositeConsumerTest.java
+++ b/client/src/test/java/io/oxia/client/CompositeConsumerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CompositeConsumerTest {
+
+    @Test
+    void deliversEveryEventToEveryCallbackInOrder() {
+        var composite = new CompositeConsumer<Integer>();
+        List<Integer> received1 = new ArrayList<>();
+        List<Integer> received2 = new ArrayList<>();
+        composite.add(received1::add);
+        composite.add(received2::add);
+
+        for (int i = 0; i < 100; i++) {
+            composite.accept(i);
+        }
+
+        List<Integer> expected = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            expected.add(i);
+        }
+        assertThat(received1).isEqualTo(expected);
+        assertThat(received2).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
### Motivation

`CompositeConsumer.accept()` ran `callbacks.parallelStream().forEach(...)` for every single notification delivered by `ShardNotificationReceiver` (and for every shard-assignment change), paying the fork-join stream setup cost per event for a set that typically holds one or two callbacks.

### Modification

Iterate the callbacks directly. Semantics are effectively unchanged:

- Per-callback event ordering was already preserved: the parallel `forEach` is a blocking terminal operation, so successive events were dispatched sequentially. The parallelism only ever applied across *different* callbacks for the *same* event — now they run sequentially on the shard's stream thread.
- Cross-shard concurrency is unaffected (one stream per shard, each on its own thread); per-key ordering holds as before since a key maps to a single shard.

### Verification

New `CompositeConsumerTest` asserting every registered callback receives every event in order. Full `:client:test` suite including the testcontainers integration tests (`NotificationIt`) passes locally.