### PR TITLE
api: deprecate batchLinger, which has no effect

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -89,7 +89,7 @@ public interface OxiaClientBuilder {
      * @deprecated Batching is adaptive: operations are grouped while a batch is in progress and a
      *     batch is flushed as soon as no more operations are pending, so this setting has no effect.
      */
-    @Deprecated(since = "0.8.0", forRemoval = true)
+    @Deprecated(since = "0.9.0", forRemoval = true)
     OxiaClientBuilder batchLinger(Duration batchLinger);
 
     /**

--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -84,16 +84,12 @@ public interface OxiaClientBuilder {
     /**
      * Specify the maximum time to wait for a batch to be sent.
      *
-     * <p>Default is <code>5 millis</code>
-     *
-     * <p>A larger linger time might help in creating batches with more ops in them and thus might
-     * improve the overall throughput.
-     *
-     * <p>A shorter linger time might help in minimizing the latency.
-     *
      * @param batchLinger the batch linger duration
      * @return the builder instance
+     * @deprecated Batching is adaptive: operations are grouped while a batch is in progress and a
+     *     batch is flushed as soon as no more operations are pending, so this setting has no effect.
      */
+    @Deprecated(since = "0.8.0", forRemoval = true)
     OxiaClientBuilder batchLinger(Duration batchLinger);
 
     /**

--- a/client/src/main/java/io/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/oxia/client/ClientConfig.java
@@ -24,7 +24,6 @@ import lombok.NonNull;
 public record ClientConfig(
         @NonNull String serviceAddress,
         @NonNull Duration requestTimeout,
-        @NonNull Duration batchLinger,
         int maxRequestsPerBatch,
         int maxBatchSize,
         @NonNull Duration sessionTimeout,

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -43,7 +43,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OxiaClientBuilderImpl implements OxiaClientBuilder {
 
+    @Deprecated(since = "0.8.0", forRemoval = true)
     public static final Duration DefaultBatchLinger = Duration.ofMillis(5);
+
     public static final int DefaultMaxRequestsPerBatch = 1000;
     public static final int DefaultMaxBatchSize = 128 * 1024;
     public static final Duration DefaultRequestTimeout = Duration.ofSeconds(30);
@@ -54,7 +56,12 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
 
     @NonNull protected final String serviceAddress;
     @NonNull protected Duration requestTimeout = DefaultRequestTimeout;
-    @NonNull protected Duration batchLinger = DefaultBatchLinger;
+
+    // Unused, but kept so that loadConfig() keeps accepting the "batchLinger" property
+    @Deprecated(since = "0.8.0", forRemoval = true)
+    @NonNull
+    protected Duration batchLinger = DefaultBatchLinger;
+
     protected int maxRequestsPerBatch = DefaultMaxRequestsPerBatch;
     @NonNull protected Duration sessionTimeout = DefaultSessionTimeout;
 
@@ -86,6 +93,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
         return this;
     }
 
+    @Deprecated(since = "0.8.0", forRemoval = true)
     @Override
     public @NonNull OxiaClientBuilder batchLinger(@NonNull Duration batchLinger) {
         if (batchLinger.isNegative() || batchLinger.equals(ZERO)) {
@@ -266,7 +274,6 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
         return new ClientConfig(
                 serviceAddress,
                 requestTimeout,
-                batchLinger,
                 maxRequestsPerBatch,
                 DefaultMaxBatchSize,
                 sessionTimeout,

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -43,7 +43,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OxiaClientBuilderImpl implements OxiaClientBuilder {
 
-    @Deprecated(since = "0.8.0", forRemoval = true)
+    @Deprecated(since = "0.9.0", forRemoval = true)
     public static final Duration DefaultBatchLinger = Duration.ofMillis(5);
 
     public static final int DefaultMaxRequestsPerBatch = 1000;
@@ -58,7 +58,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     @NonNull protected Duration requestTimeout = DefaultRequestTimeout;
 
     // Unused, but kept so that loadConfig() keeps accepting the "batchLinger" property
-    @Deprecated(since = "0.8.0", forRemoval = true)
+    @Deprecated(since = "0.9.0", forRemoval = true)
     @NonNull
     protected Duration batchLinger = DefaultBatchLinger;
 
@@ -93,7 +93,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
         return this;
     }
 
-    @Deprecated(since = "0.8.0", forRemoval = true)
+    @Deprecated(since = "0.9.0", forRemoval = true)
     @Override
     public @NonNull OxiaClientBuilder batchLinger(@NonNull Duration batchLinger) {
         if (batchLinger.isNegative() || batchLinger.equals(ZERO)) {

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -99,7 +99,6 @@ class BatchTest {
             new ClientConfig(
                     "address",
                     Duration.ofMillis(100),
-                    Duration.ofMillis(1000),
                     10,
                     1024 * 1024,
                     Duration.ofMillis(1000),
@@ -540,7 +539,6 @@ class BatchTest {
         ClientConfig config =
                 new ClientConfig(
                         "address",
-                        ZERO,
                         ZERO,
                         1,
                         1024 * 1024,

--- a/client/src/test/java/io/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherTest.java
@@ -55,7 +55,6 @@ class BatcherTest {
             new ClientConfig(
                     "address",
                     Duration.ofMillis(100),
-                    Duration.ofMillis(1000),
                     10,
                     1024 * 1024,
                     Duration.ofMillis(1000),

--- a/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
@@ -61,7 +61,6 @@ class SessionManagerTest {
                 new ClientConfig(
                         "address",
                         Duration.ofSeconds(1),
-                        Duration.ofMillis(1),
                         1,
                         1024,
                         Duration.ofSeconds(10),

--- a/client/src/test/java/io/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionTest.java
@@ -69,7 +69,6 @@ class SessionTest {
                 new ClientConfig(
                         "address",
                         Duration.ZERO,
-                        Duration.ZERO,
                         1,
                         1024 * 1024,
                         sessionTimeout,

--- a/etc/findbugsExclude.xml
+++ b/etc/findbugsExclude.xml
@@ -29,6 +29,12 @@
     <Bug pattern="URF_UNREAD_FIELD" />
   </Match>
   <Match>
+    <!-- Deprecated, kept only so that loadConfig() keeps accepting the "batchLinger" property -->
+    <Class name="io.oxia.client.OxiaClientBuilderImpl" />
+    <Field name="batchLinger" />
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
+  </Match>
+  <Match>
     <Package name="io.oxia.client" />
     <Bug pattern="CT_CONSTRUCTOR_THROW" />
   </Match>

--- a/perf/src/main/java/io/oxia/client/perf/PerfArguments.java
+++ b/perf/src/main/java/io/oxia/client/perf/PerfArguments.java
@@ -59,11 +59,6 @@ public class PerfArguments {
     int valueSize = 128;
 
     @Parameter(
-            names = {"--batch-linger-ms"},
-            description = "Batch linger time")
-    long batchLingerMs = OxiaClientBuilderImpl.DefaultBatchLinger.toMillis();
-
-    @Parameter(
             names = {"--max-requests-per-batch"},
             description = "Maximum requests per batch")
     int maxRequestsPerBatch = OxiaClientBuilderImpl.DefaultMaxRequestsPerBatch;

--- a/perf/src/main/java/io/oxia/client/perf/PerfClient.java
+++ b/perf/src/main/java/io/oxia/client/perf/PerfClient.java
@@ -85,7 +85,6 @@ public class PerfClient {
 
     AsyncOxiaClient client =
         OxiaClientBuilder.create(arguments.serviceAddr)
-            .batchLinger(Duration.ofMillis(arguments.batchLingerMs))
             .maxRequestsPerBatch(arguments.maxRequestsPerBatch)
             .requestTimeout(Duration.ofMillis(arguments.requestTimeoutMs))
             .namespace(arguments.namespace)


### PR DESCRIPTION
### Motivation

Batching has been adaptive for a while: operations are grouped while a batch is in flight, and a batch is flushed as soon as no more operations are pending. The `Batcher` never reads the configured linger, so `batchLinger` silently does nothing while its javadoc still promised throughput/latency tuning.

### Modification

- `OxiaClientBuilder.batchLinger()` is now `@Deprecated(since = "0.9.0", forRemoval = true)`, with javadoc explaining the adaptive behavior. The impl setter and `DefaultBatchLinger` constant are deprecated as well; the setter keeps its argument validation.
- Removed the internal plumbing: the `ClientConfig.batchLinger` component and the perf tool's `--batch-linger-ms` flag (note: passing that flag to the perf tool now fails as an unknown option).
- The deprecated builder *field* is intentionally kept: `loadConfig(Properties)` resolves property names to fields reflectively, so removing it would make existing config files containing a `batchLinger` entry throw `Invalid configuration property`. A scoped SpotBugs exclusion documents the write-only field.

### Verification

Full `:client:test` suite including the testcontainers integration tests passes; `check` (spotless + spotbugs) passes on all modules. Existing `loadConfig` tests still cover the property being accepted.
