### PR TITLE
perf: rewrite CompareWithSlash without substring allocations

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -15,13 +15,19 @@
  */
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+    alias(libs.plugins.jmh)
 }
 
-rootProject.name = "oxia-java"
+dependencies {
+    jmh(project(":client"))
+}
 
-include("client-api")
-include("client")
-include("perf")
+jmh {
+    // Reports allocations (gc.alloc.rate.norm) along with the timings
+    profilers.set(listOf("gc"))
+}
 
-include("benchmarks")
+// The JMH-generated sources don't pass the static analysis
+tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {
+    enabled = false
+}

--- a/benchmarks/src/jmh/java/io/oxia/client/CompareWithSlashBenchmark.java
+++ b/benchmarks/src/jmh/java/io/oxia/client/CompareWithSlashBenchmark.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2022-2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Compares {@link CompareWithSlash} against the substring-based implementation it replaced. The
+ * sort benchmarks model the multi-shard list() result merge. Run with {@code ./gradlew
+ * :benchmarks:jmh}; the GC profiler reports the per-operation allocations.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+public class CompareWithSlashBenchmark {
+
+    /** The substring-based implementation that predates the index-based rewrite. */
+    private static final Comparator<String> LEGACY =
+            (a, b) -> {
+                while (a.length() > 0 && b.length() > 0) {
+                    var idxA = a.indexOf('/');
+                    var idxB = b.indexOf('/');
+                    if (idxA < 0 && idxB < 0) {
+                        return Integer.compare(a.compareTo(b), 0);
+                    } else if (idxA < 0) {
+                        return -1;
+                    } else if (idxB < 0) {
+                        return +1;
+                    }
+
+                    var spanA = a.substring(0, idxA);
+                    var spanB = b.substring(0, idxB);
+
+                    var spanRes = Integer.compare(spanA.compareTo(spanB), 0);
+                    if (spanRes != 0) {
+                        return spanRes;
+                    }
+
+                    a = a.substring(idxA + 1);
+                    b = b.substring(idxB + 1);
+                }
+
+                if (a.length() < b.length()) {
+                    return -1;
+                } else if (a.length() > 0) {
+                    return +1;
+                } else {
+                    return 0;
+                }
+            };
+
+    @Param({"1000", "100000"})
+    int numKeys;
+
+    private String[] keys;
+
+    @Setup
+    public void setup() {
+        var random = new Random(0xacc7);
+        keys = new String[numKeys];
+        for (int i = 0; i < numKeys; i++) {
+            // Multi-segment keys sharing prefixes, as a sorted list() merge would see them
+            keys[i] =
+                    "/registry/tenant-%02d/namespace-%02d/key-%08d"
+                            .formatted(random.nextInt(10), random.nextInt(100), random.nextInt(1_000_000));
+        }
+    }
+
+    @Benchmark
+    public int pairwiseCompare() {
+        int acc = 0;
+        for (int i = 1; i < keys.length; i++) {
+            acc += CompareWithSlash.INSTANCE.compare(keys[i - 1], keys[i]);
+        }
+        return acc;
+    }
+
+    @Benchmark
+    public int pairwiseCompareLegacy() {
+        int acc = 0;
+        for (int i = 1; i < keys.length; i++) {
+            acc += LEGACY.compare(keys[i - 1], keys[i]);
+        }
+        return acc;
+    }
+
+    @Benchmark
+    public String[] sort() {
+        String[] copy = keys.clone();
+        Arrays.sort(copy, CompareWithSlash.INSTANCE);
+        return copy;
+    }
+
+    @Benchmark
+    public String[] sortLegacy() {
+        String[] copy = keys.clone();
+        Arrays.sort(copy, LEGACY);
+        return copy;
+    }
+}

--- a/client/src/main/java/io/oxia/client/CompareWithSlash.java
+++ b/client/src/main/java/io/oxia/client/CompareWithSlash.java
@@ -23,11 +23,15 @@ enum CompareWithSlash implements Comparator<String> {
     INSTANCE {
         @Override
         public int compare(@NonNull String a, @NonNull String b) {
-            while (a.length() > 0 && b.length() > 0) {
-                var idxA = a.indexOf('/');
-                var idxB = b.indexOf('/');
+            final int lenA = a.length();
+            final int lenB = b.length();
+            int ia = 0;
+            int ib = 0;
+            while (ia < lenA && ib < lenB) {
+                int idxA = a.indexOf('/', ia);
+                int idxB = b.indexOf('/', ib);
                 if (idxA < 0 && idxB < 0) {
-                    return Integer.compare(a.compareTo(b), 0);
+                    return Integer.signum(compareSpans(a, ia, lenA, b, ib, lenB));
                 } else if (idxA < 0) {
                     return -1;
                 } else if (idxB < 0) {
@@ -35,27 +39,39 @@ enum CompareWithSlash implements Comparator<String> {
                 }
 
                 // At this point, both slices have '/'
-                var spanA = a.substring(0, idxA);
-                var spanB = b.substring(0, idxB);
-
-                var spanRes = Integer.compare(spanA.compareTo(spanB), 0);
+                int spanRes = compareSpans(a, ia, idxA, b, ib, idxB);
                 if (spanRes != 0) {
-                    return spanRes;
+                    return Integer.signum(spanRes);
                 }
 
-                a = a.substring(idxA + 1);
-                b = b.substring(idxB + 1);
+                ia = idxA + 1;
+                ib = idxB + 1;
             }
 
-            if (a.length() < b.length()) {
+            final int remainingA = lenA - ia;
+            final int remainingB = lenB - ib;
+            if (remainingA < remainingB) {
                 return -1;
-            } else if (a.length() > 0) {
+            } else if (remainingA > 0) {
                 return +1;
             } else {
                 return 0;
             }
         }
     };
+
+    /** Compares the [from, to) regions of the two strings, like {@link String#compareTo} does. */
+    private static int compareSpans(String a, int fromA, int toA, String b, int fromB, int toB) {
+        final int lim = Math.min(toA - fromA, toB - fromB);
+        for (int i = 0; i < lim; i++) {
+            char ca = a.charAt(fromA + i);
+            char cb = b.charAt(fromB + i);
+            if (ca != cb) {
+                return ca - cb;
+            }
+        }
+        return (toA - fromA) - (toB - fromB);
+    }
 
     static boolean withinRange(
             @NonNull String startKeyInclusive, @NonNull String endKeyExclusive, @NonNull String key) {

--- a/client/src/test/java/io/oxia/client/CompareWithSlashTest.java
+++ b/client/src/test/java/io/oxia/client/CompareWithSlashTest.java
@@ -17,6 +17,7 @@ package io.oxia.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 class CompareWithSlashTest {
@@ -53,5 +54,61 @@ class CompareWithSlashTest {
         assertThat(CompareWithSlash.withinRange("aaaaa", "aaaac", "aaaab")).isTrue();
         assertThat(CompareWithSlash.withinRange("aaaaa", "aaaac", "aaaac")).isFalse();
         assertThat(CompareWithSlash.withinRange("aaaaa", "aaaac", "aaaa")).isFalse();
+    }
+
+    @Test
+    void compareMatchesLegacyImplementation() {
+        var random = new Random(0xacc7);
+        char[] alphabet = {'a', 'b', 'c', '/'};
+        for (int i = 0; i < 100_000; i++) {
+            String a = randomKey(random, alphabet);
+            String b = randomKey(random, alphabet);
+            assertThat(CompareWithSlash.INSTANCE.compare(a, b))
+                    .as("compare(%s, %s)", a, b)
+                    .isEqualTo(legacyCompare(a, b));
+        }
+    }
+
+    private static String randomKey(Random random, char[] alphabet) {
+        int len = random.nextInt(12);
+        var sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            sb.append(alphabet[random.nextInt(alphabet.length)]);
+        }
+        return sb.toString();
+    }
+
+    /** The substring-based implementation that predates the index-based rewrite. */
+    private static int legacyCompare(String a, String b) {
+        while (a.length() > 0 && b.length() > 0) {
+            var idxA = a.indexOf('/');
+            var idxB = b.indexOf('/');
+            if (idxA < 0 && idxB < 0) {
+                return Integer.compare(a.compareTo(b), 0);
+            } else if (idxA < 0) {
+                return -1;
+            } else if (idxB < 0) {
+                return +1;
+            }
+
+            var spanA = a.substring(0, idxA);
+            var spanB = b.substring(0, idxB);
+
+            var spanRes = Integer.compare(spanA.compareTo(spanB), 0);
+            if (spanRes != 0) {
+                return spanRes;
+            }
+
+            a = a.substring(idxA + 1);
+            b = b.substring(idxB + 1);
+        }
+
+        if (a.length() < b.length()) {
+            return -1;
+        } else if (a.length() > 0) {
+            return +1;
+        } else {
+            return 0;
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ shadow = "9.4.1"
 spotless = "8.3.0"
 spotbugs-plugin = "6.1.12"
 maven-publish-plugin = "0.36.0"
+jmh-plugin = "0.7.3"
 
 [libraries]
 # BOMs
@@ -105,3 +106,4 @@ shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugs-plugin" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish-plugin" }
+jmh = { id = "me.champeau.jmh", version.ref = "jmh-plugin" }


### PR DESCRIPTION
### Motivation

`CompareWithSlash` allocated two substrings per path segment per comparison. Sorting the merged result of a multi-shard `list()` with N keys of K segments churns O(N log N × K) short-lived strings — and it runs on whichever gRPC transport thread completes the last shard future.

### Modification

- Rewrite the comparator index-based: walk both strings with cursors and compare segments with a char-wise region compare that matches `String.compareTo()` semantics. Zero allocation, exact `-1/0/+1` results preserved.
- Property test: 100k random key pairs (empty segments, leading/trailing/consecutive slashes) asserted equal to the previous implementation, embedded in the test as the reference.
- New `benchmarks` module using the `me.champeau.jmh` Gradle plugin with the GC profiler always enabled (`./gradlew :benchmarks:jmh`). The benchmark keeps the legacy comparator inline as the baseline.

### Benchmark results

Apple M-series, JDK 17, keys shaped like `/registry/tenant-NN/namespace-NN/key-NNNNNNNN`:

| Benchmark | keys | legacy | rewritten | allocations: legacy → new |
|---|---|---|---|---|
| pairwise compare sweep | 1k | 78.7 µs | 33.4 µs (2.4×) | 574 KB → 0 B |
| pairwise compare sweep | 100k | 8.0 ms | 4.1 ms (1.9×) | 57 MB → 0 B |
| full sort | 1k | 891 µs | 420 µs (2.1×) | 6.2 MB → 7.2 KB |
| full sort | 100k | 187 ms | 90 ms (2.1×) | 1.21 GB → 862 KB |

The remaining allocation in the sort rows is the benchmark's own `keys.clone()`; the comparator itself is allocation-free.

### Verification

Existing `CompareWithSlashTest` cases (exact comparison values) pass unchanged, plus the new 100k-pair equivalence property test. Full `:client:test` suite including the testcontainers integration tests passes; `check` passes on all modules (SpotBugs is disabled for the benchmarks module — the JMH-generated sources don't pass analysis).