### PR TITLE
perf: lock-free fast path for the session lookup

### DIFF
--- a/client/src/main/java/io/oxia/client/session/SessionManager.java
+++ b/client/src/main/java/io/oxia/client/session/SessionManager.java
@@ -61,6 +61,13 @@ public class SessionManager
 
     @NonNull
     public CompletableFuture<Session> getSession(long shardId) {
+        // Lock-free fast path: this runs on every ephemeral put, and compute() locks the map
+        // bin even when the session already exists
+        final CompletableFuture<Session> existing = sessions.get(shardId);
+        if (isUsable(existing)) {
+            return existing;
+        }
+
         final Lock rLock = closedLock.readLock();
         try {
             rLock.lock();
@@ -68,22 +75,20 @@ public class SessionManager
                 return failedFuture(new IllegalStateException("Session manager is closed"));
             }
             return sessions.compute(
-                    shardId,
-                    (key, existing) -> {
-                        if (existing != null && !existing.isCompletedExceptionally()) {
-                            if (!existing.isDone()) {
-                                return existing;
-                            }
-                            final Session session = existing.join();
-                            if (!session.isClosed()) { // ignore closed session
-                                return existing;
-                            }
-                        }
-                        return createSession(shardId);
-                    });
+                    shardId, (key, current) -> isUsable(current) ? current : createSession(shardId));
         } finally {
             rLock.unlock();
         }
+    }
+
+    private static boolean isUsable(CompletableFuture<Session> sessionFuture) {
+        if (sessionFuture == null || sessionFuture.isCompletedExceptionally()) {
+            return false;
+        }
+        if (!sessionFuture.isDone()) {
+            return true;
+        }
+        return !sessionFuture.join().isClosed(); // ignore closed sessions
     }
 
     @Override


### PR DESCRIPTION
### Motivation

`SessionManager.getSession()` runs on every ephemeral put, and it took the `closed` read-lock plus the `ConcurrentHashMap.compute()` bin lock even when the session already existed — `compute()` always locks the bin, so all the ephemeral writers of a shard serialize through it (item 6 of the performance review).

### Modification

- Check the map with a plain `get()` first and return the cached session future without taking any lock.
- The reuse predicate (not completed exceptionally, and either still pending or not closed) is extracted into `isUsable()`, shared by the fast path and the `compute()` fallback so the two cannot drift. The slow path is unchanged.
- Semantic nuance: the fast path does not take the `closed` read-lock, so a `getSession()` racing with `close()` can observe a session that is being torn down, where it previously got the "Session manager is closed" failure. That window only exists during client shutdown, and the operation fails either way since the batch managers are closed first.

### Verification

Existing `SessionManagerTest` coverage exercises both paths: cached-session reuse (now via the fast path), recreation after exceptional completion and after session expiry, and closed-manager behavior. Full `:client:test` suite including the testcontainers integration tests passes.