### PR TITLE
perf: build read batch requests in place

### DIFF
--- a/client/src/main/java/io/oxia/client/batch/Operation.java
+++ b/client/src/main/java/io/oxia/client/batch/Operation.java
@@ -66,15 +66,14 @@ public sealed interface Operation<R> permits ReadOperation, WriteOperation {
                 @NonNull String key,
                 @NonNull GetOptions options)
                 implements ReadOperation<GetResult> {
-            GetRequest toProto() {
-                var req = new GetRequest();
+            /** Fills in the given request with this operation's fields. */
+            void toProto(GetRequest req) {
                 req.setKey(key)
                         .setComparisonType(options.comparisonType())
                         .setIncludeValue(options.includeValue());
                 if (options.secondaryIndexName() != null) {
                     req.setSecondaryIndexName(options.secondaryIndexName());
                 }
-                return req;
             }
 
             void complete(@NonNull GetResponse response) {
@@ -124,6 +123,7 @@ public sealed interface Operation<R> permits ReadOperation, WriteOperation {
                 }
             }
 
+            /** Fills in the given request with this operation's fields. */
             void toProto(PutRequest req) {
                 req.setKey(key).setValue(value);
                 partitionKey.ifPresent(req::setPartitionKey);
@@ -193,6 +193,7 @@ public sealed interface Operation<R> permits ReadOperation, WriteOperation {
                 }
             }
 
+            /** Fills in the given request with this operation's fields. */
             void toProto(DeleteRequest req) {
                 req.setKey(key);
                 expectedVersionId.ifPresent(req::setExpectedVersionId);
@@ -220,6 +221,7 @@ public sealed interface Operation<R> permits ReadOperation, WriteOperation {
                 @NonNull String startKeyInclusive,
                 @NonNull String endKeyExclusive)
                 implements WriteOperation<Void> {
+            /** Fills in the given request with this operation's fields. */
             void toProto(DeleteRangeRequest req) {
                 req.setStartInclusive(startKeyInclusive).setEndExclusive(endKeyExclusive);
             }

--- a/client/src/main/java/io/oxia/client/batch/ReadBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatch.java
@@ -104,7 +104,7 @@ final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadRes
         var req = new ReadRequest();
         req.setShard(getShardId());
         for (var g : gets) {
-            req.addGet().copyFrom(g.toProto());
+            g.toProto(req.addGet());
         }
         return req;
     }

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -465,11 +465,13 @@ class BatchTest {
         public void toProto() {
             batch.add(get);
             var request = batch.toProto();
+            var expectedGet = new io.oxia.proto.GetRequest();
+            get.toProto(expectedGet);
             assertThat(request)
                     .satisfies(
                             r -> {
                                 assertThat(r.getGetsCount()).isEqualTo(1);
-                                assertThat(r.getGetAt(0).toByteArray()).isEqualTo(get.toProto().toByteArray());
+                                assertThat(r.getGetAt(0).toByteArray()).isEqualTo(expectedGet.toByteArray());
                             });
         }
 

--- a/client/src/test/java/io/oxia/client/batch/OperationTest.java
+++ b/client/src/test/java/io/oxia/client/batch/OperationTest.java
@@ -39,6 +39,7 @@ import io.oxia.proto.DeleteRangeRequest;
 import io.oxia.proto.DeleteRangeResponse;
 import io.oxia.proto.DeleteRequest;
 import io.oxia.proto.DeleteResponse;
+import io.oxia.proto.GetRequest;
 import io.oxia.proto.GetResponse;
 import io.oxia.proto.KeyComparisonType;
 import io.oxia.proto.PutRequest;
@@ -69,7 +70,8 @@ class OperationTest {
 
         @Test
         void toProto() {
-            var request = op.toProto();
+            var request = new GetRequest();
+            op.toProto(request);
             assertThat(request.getKey()).isEqualTo(op.key());
         }
 


### PR DESCRIPTION
### Motivation

`ReadBatch.toProto()` built each get entry with `req.addGet().copyFrom(g.toProto())` — allocating a temporary `GetRequest` per get operation and then deep-copying it into the batch request (item 12 of the performance review).

### Modification

- `GetOperation.toProto()` now takes the target `GetRequest` and fills it in place — `g.toProto(req.addGet())` — mirroring how the write-path operations (`PutOperation`, `DeleteOperation`, `DeleteRangeOperation`) have always done it. The temporary object and the copy are gone.
- The fill-in contract is documented on all four `toProto()` methods.

### Verification

`OperationTest` and `BatchTest` proto-equality assertions updated to build the expected request through the in-place method, matching the write-path test style. Full `:client:test` suite including the testcontainers integration tests passes.