### PR TITLE
build: fix Dependabot alerts for log4j-core and opentelemetry-api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,18 @@ allprojects {
     repositories {
         mavenCentral()
     }
+
+    // The spotbugs configuration exists in the root project too, so the forced
+    // versions must apply to all projects, not just subprojects
+    plugins.withId("com.github.spotbugs") {
+        configurations.named("spotbugs") {
+            resolutionStrategy {
+                force("org.apache.logging.log4j:log4j-core:${rootProject.libs.versions.log4j.get()}")
+                force("org.apache.ant:ant:1.10.15")
+                force("org.apache.bcel:bcel:6.12.0")
+            }
+        }
+    }
 }
 
 subprojects {
@@ -164,14 +176,6 @@ subprojects {
     spotbugs {
         excludeFilter.set(rootProject.file("etc/findbugsExclude.xml"))
         onlyAnalyze.set(listOf("io.oxia.client.*"))
-    }
-
-    configurations.named("spotbugs") {
-        resolutionStrategy {
-            force("org.apache.logging.log4j:log4j-core:${rootProject.libs.versions.log4j.get()}")
-            force("org.apache.ant:ant:1.10.15")
-            force("org.apache.bcel:bcel:6.12.0")
-        }
     }
 
     jacoco {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 grpc = "1.75.0"
 netty = "4.1.131.Final"
 lightproto = "0.6.6"
-opentelemetry = "1.57.0"
+opentelemetry = "1.63.0"
 opentelemetry-semconv = "1.37.0"
 junit = "5.11.3"
 testcontainers = "1.20.4"
@@ -40,7 +40,7 @@ jmh-plugin = "0.7.3"
 # BOMs
 grpc-bom = { module = "io.grpc:grpc-bom", version.ref = "grpc" }
 opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry" }
-opentelemetry-bom-alpha = { module = "io.opentelemetry:opentelemetry-bom-alpha", version = "1.57.0-alpha" }
+opentelemetry-bom-alpha = { module = "io.opentelemetry:opentelemetry-bom-alpha", version = "1.63.0-alpha" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 
 # Compile dependencies


### PR DESCRIPTION
### Motivation

Fixes all 4 open Dependabot alerts:

- **log4j-core 2.23.1** (alerts #67, #68, #69 — CVE-2026-34477, CVE-2026-34478, CVE-2026-34480): the version catalog already pins log4j 2.26.0, but the forced versions for the `spotbugs` tool configuration only covered `subprojects`. The **root** project also applies the SpotBugs plugin, so its `spotbugs` configuration was still resolving log4j-core 2.23.1. Since Automatic Dependency Submission resolves every configuration, this single path kept the alerts open.

- **opentelemetry-api 1.57.0** (alert #72 — CVE-2026-45292, fixed in 1.62.0): Dependabot couldn't auto-bump it because the version is managed through the BOM platform.

### Modifications

- Move the spotbugs `resolutionStrategy` force block from `subprojects` to `allprojects` (guarded by `plugins.withId`) so the root project's configuration is covered too. Verified that the root `spotbugs` configuration now resolves log4j-core 2.26.0 and no configuration in any project resolves a version below 2.25.4.

- Bump OpenTelemetry 1.57.0 → 1.63.0 (latest stable), including the `opentelemetry-bom-alpha` version that is hardcoded in the catalog.

Once merged, the next Automatic Dependency Submission run on `main` should close all 4 alerts.