### PR TITLE
chore: release 0.9.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.oxia-db
-version=0.8.0
+version=0.9.0
 
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true


### PR DESCRIPTION
Bump version to 0.9.0 for the release.

Changes since v0.8.0: #341–#352 — performance improvements on the write/read hot paths, the new `maxPendingBytes` backpressure limit (#348), and the `batchLinger` deprecation (#346).