### PR TITLE
ci: wait for VALIDATED instead of PUBLISHED on Maven Central release

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -44,7 +44,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_mavenCentralDeploymentValidation: PUBLISHED
+          ORG_GRADLE_PROJECT_mavenCentralDeploymentValidation: VALIDATED
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
 


### PR DESCRIPTION
## Problem

The v0.9.0 release job [failed](https://github.com/oxia-db/oxia-client-java/actions/runs/27449675071) even though all artifacts published successfully to Maven Central.

The workflow set `mavenCentralDeploymentValidation: PUBLISHED`, so the [vanniktech plugin](https://github.com/vanniktech/gradle-maven-publish-plugin) polled until the deployment reached the final `PUBLISHED` state. Central's propagation to repo1 took **over an hour** that day, exceeding the plugin's default `SONATYPE_CLOSE_TIMEOUT_SECONDS` of 900s:

```
Deployment validation timed out after 900s. Last known state: PUBLISHING
```

The deployment had already passed validation and was in `PUBLISHING` — the publish was fine; only the workflow's wait timed out.

## Fix

Wait for `VALIDATED` instead of `PUBLISHED`. The job blocks until Central accepts the uploaded bundle (a minute or two), then Central publishes asynchronously.

This still guards against the failure mode that originally motivated `PUBLISHED` (the v0.7.5 incident, where a bundle never reached Central): a `VALIDATED` deployment with automatic publishing is guaranteed to publish. The only thing we give up is the workflow confirming repo1 propagation before going green — which is outside our control and not worth tying up a CI runner for an hour (or flaking when it exceeds even a raised timeout).