### PR TITLE
feat: share transport resources across client instances

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -251,6 +251,26 @@ public interface OxiaClientBuilder {
     OxiaClientBuilder enableTls(boolean enableTls);
 
     /**
+     * Build this client on top of a shared {@link SharedResources} pool.
+     *
+     * <p>The client will use the pool's background thread pool, gRPC connection pool and
+     * shard-assignment stream instead of creating its own, so that many clients in the same process
+     * share a single transport footprint. Closing the client only releases its own per-client state
+     * (sessions, notifications, batching); the shared resources live until the pool is closed.
+     *
+     * <p>Transport-level settings (TLS, authentication, connection keep-alive and pool size) are
+     * taken from the pool. Setting any of them on this builder together with {@code sharedResources}
+     * is a configuration error and makes {@link #asyncClient()} / {@link #syncClient()} throw an
+     * {@link IllegalArgumentException}. Per-client settings such as namespace, client identifier and
+     * timeouts still apply.
+     *
+     * @param sharedResources the shared resources pool, or {@code null} to build a standalone client
+     *     that owns its own resources
+     * @return the builder instance
+     */
+    OxiaClientBuilder sharedResources(SharedResources sharedResources);
+
+    /**
      * Load the configuration from the specified configuration file.
      *
      * @param configPath the path of the configuration file

--- a/client-api/src/main/java/io/oxia/client/api/SharedResources.java
+++ b/client-api/src/main/java/io/oxia/client/api/SharedResources.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.api;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.oxia.client.internal.DefaultImplementation;
+import java.time.Duration;
+
+/**
+ * A pool of resources that can be shared by multiple Oxia client instances in the same JVM process.
+ *
+ * <p>Each standalone client normally owns a full footprint: a background thread pool, its own gRPC
+ * connections to every data server, and its own shard-assignment stream per namespace. When many
+ * clients (or many sessions) run in a single process, this footprint dominates. A {@code
+ * SharedResources} lets those clients multiplex over a shared transport instead:
+ *
+ * <ul>
+ *   <li>a single background thread pool;
+ *   <li>a single pool of gRPC connections;
+ *   <li>a single shard-assignment stream per {@code (serviceAddress, namespace)}.
+ * </ul>
+ *
+ * <p>Each client keeps its own sessions, ephemeral records, notifications and batching — closing an
+ * individual client only releases that per-client state. The shared resources live until this
+ * object is {@link #close() closed}.
+ *
+ * <pre>{@code
+ * try (SharedResources shared = SharedResources.builder().numWorkerThreads(4).build()) {
+ *     AsyncOxiaClient c1 = OxiaClientBuilder.create("localhost:6648")
+ *             .sharedResources(shared)
+ *             .clientIdentifier("app-1")
+ *             .asyncClient()
+ *             .join();
+ *     // c1..cN share the executor, connections and shard-assignment stream.
+ * } // releases the shared executor, connections and shard managers
+ * }</pre>
+ *
+ * <p>Transport-level settings (TLS, authentication, connection keep-alive and pool size) are
+ * governed by this object; a client built with {@link OxiaClientBuilder#sharedResources(
+ * SharedResources)} inherits them. Setting any transport-level option on such a client is a
+ * configuration error, rejected with an {@link IllegalArgumentException} — configure them here
+ * instead, and only share a pool between clients whose transport settings match.
+ */
+public interface SharedResources extends AutoCloseable {
+
+    /**
+     * Create a new builder for a {@link SharedResources} pool.
+     *
+     * @return the builder instance
+     */
+    static Builder builder() {
+        return DefaultImplementation.getSharedResourcesBuilder();
+    }
+
+    /** Release the shared executor, connections and shard-assignment streams. */
+    @Override
+    void close();
+
+    /** Builder for a {@link SharedResources} pool. */
+    interface Builder {
+
+        /**
+         * Set the number of threads in the shared background thread pool.
+         *
+         * <p>Default is the number of available processors.
+         *
+         * @param numWorkerThreads the number of worker threads
+         * @return the builder instance
+         */
+        Builder numWorkerThreads(int numWorkerThreads);
+
+        /**
+         * Configure whether to enable TLS for the shared connections.
+         *
+         * <p>Default is {@code false}.
+         *
+         * @param enableTls true to enable TLS
+         * @return the builder instance
+         */
+        Builder enableTls(boolean enableTls);
+
+        /**
+         * Configure the authentication used by the shared connections.
+         *
+         * @param authentication the authentication instance
+         * @return the builder instance
+         */
+        Builder authentication(Authentication authentication);
+
+        /**
+         * Configure the keep-alive interval for the shared connections.
+         *
+         * <p>Default is {@code 10 sec}.
+         *
+         * @param keepAliveTime the keep-alive interval
+         * @return the builder instance
+         */
+        Builder connectionKeepAliveTime(Duration keepAliveTime);
+
+        /**
+         * Configure the keep-alive timeout for the shared connections.
+         *
+         * <p>Default is {@code 3 sec}.
+         *
+         * @param keepAliveTimeout the keep-alive timeout
+         * @return the builder instance
+         */
+        Builder connectionKeepAliveTimeout(Duration keepAliveTimeout);
+
+        /**
+         * Configure the connection backoff policy for the shared connections.
+         *
+         * <p>Defaults are {@code min=100millis, max=30sec}.
+         *
+         * @param minDelay the minimum delay between retries
+         * @param maxDelay the maximum delay between retries
+         * @return the builder instance
+         */
+        Builder connectionBackoff(Duration minDelay, Duration maxDelay);
+
+        /**
+         * Configure the maximum number of shared connections to each Oxia server node.
+         *
+         * <p>Default is {@code 1}.
+         *
+         * @param connections the maximum number of connections
+         * @return the builder instance
+         */
+        Builder maxConnectionPerNode(int connections);
+
+        /**
+         * Configure the OpenTelemetry instance used for shared-resource metrics.
+         *
+         * <p>By default, the global OpenTelemetry instance is used if available.
+         *
+         * @param openTelemetry an OpenTelemetry instance
+         * @return the builder instance
+         */
+        Builder openTelemetry(OpenTelemetry openTelemetry);
+
+        /**
+         * Build the {@link SharedResources} pool.
+         *
+         * @return the shared resources instance
+         */
+        SharedResources build();
+    }
+}

--- a/client-api/src/main/java/io/oxia/client/internal/DefaultImplementation.java
+++ b/client-api/src/main/java/io/oxia/client/internal/DefaultImplementation.java
@@ -16,7 +16,9 @@
 package io.oxia.client.internal;
 
 import io.oxia.client.api.OxiaClientBuilder;
+import io.oxia.client.api.SharedResources;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 
 /**
  * This class loads the implementation for {@link OxiaClientBuilder} and allows you to decouple the
@@ -29,6 +31,12 @@ public class DefaultImplementation {
     private static final Constructor<?> CONSTRUCTOR;
 
     private static final String IMPL_CLASS_NAME = "io.oxia.client.OxiaClientBuilderImpl";
+
+    private static final String SHARED_RESOURCES_IMPL_CLASS_NAME =
+            "io.oxia.client.SharedResourcesImpl";
+
+    private static final Method SHARED_RESOURCES_BUILDER =
+            ReflectionUtils.getStaticMethod(SHARED_RESOURCES_IMPL_CLASS_NAME, "builder");
 
     static {
         Constructor<?> impl;
@@ -52,5 +60,15 @@ public class DefaultImplementation {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Access the actual implementation of the {@link SharedResources.Builder}.
+     *
+     * @return a new builder for a shared-resources pool
+     */
+    public static SharedResources.Builder getSharedResourcesBuilder() {
+        return ReflectionUtils.catchExceptions(
+                () -> (SharedResources.Builder) SHARED_RESOURCES_BUILDER.invoke(null));
     }
 }

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -108,8 +108,55 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                         writeBatchManager,
                         sessionManager,
                         config.requestTimeout(),
-                        config.maxPendingBytes());
+                        config.maxPendingBytes(),
+                        true);
         return shardManager.start().thenApply(v -> client);
+    }
+
+    /**
+     * Create a client that borrows its executor, connection pool and shard-assignment stream from a
+     * shared {@link SharedResourcesImpl} pool. Closing the returned client only tears down its own
+     * per-client state (sessions, notifications, batchers); the shared resources live until the pool
+     * itself is closed.
+     */
+    static @NonNull CompletableFuture<AsyncOxiaClient> newInstance(
+            @NonNull ClientConfig config, @NonNull SharedResourcesImpl sharedResources) {
+        final ScheduledExecutorService asyncExecutor = sharedResources.executor();
+        final var connectionManager = sharedResources.connectionManager();
+        var instrumentProvider = new InstrumentProvider(config.openTelemetry(), config.namespace());
+        return sharedResources
+                .getOrCreateShardManager(config)
+                .thenApply(
+                        shardManager -> {
+                            var rpcProvider =
+                                    RpcProvider.create(
+                                            config, asyncExecutor, connectionManager, shardManager::leader);
+                            var notificationManager =
+                                    new NotificationManager(
+                                            asyncExecutor, rpcProvider, shardManager, instrumentProvider);
+                            shardManager.addCallback(notificationManager);
+                            var readBatchManager =
+                                    BatchManager.newReadBatchManager(config, rpcProvider, instrumentProvider);
+                            var sessionManager =
+                                    new SessionManager(asyncExecutor, config, rpcProvider, instrumentProvider);
+                            shardManager.addCallback(sessionManager);
+                            var writeBatchManager =
+                                    BatchManager.newWriteBatchManager(
+                                            config, rpcProvider, sessionManager, instrumentProvider);
+                            return new AsyncOxiaClientImpl(
+                                    config.clientIdentifier(),
+                                    asyncExecutor,
+                                    instrumentProvider,
+                                    rpcProvider,
+                                    shardManager,
+                                    notificationManager,
+                                    readBatchManager,
+                                    writeBatchManager,
+                                    sessionManager,
+                                    config.requestTimeout(),
+                                    config.maxPendingBytes(),
+                                    false);
+                        });
     }
 
     private final @NonNull String clientIdentifier;
@@ -147,6 +194,13 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
 
     private final ScheduledExecutorService scheduledExecutor;
 
+    /**
+     * Whether this client owns the {@link #scheduledExecutor} and {@link #shardManager}. {@code true}
+     * for standalone clients (they close them on {@link #close()}); {@code false} for clients backed
+     * by a shared-resources pool (which owns and closes them).
+     */
+    private final boolean ownsResources;
+
     AsyncOxiaClientImpl(
             @NonNull String clientIdentifier,
             @NonNull ScheduledExecutorService scheduledExecutor,
@@ -158,7 +212,8 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             @NonNull BatchManager writeBatchManager,
             @NonNull SessionManager sessionManager,
             Duration requestTimeout,
-            long maxPendingBytes) {
+            long maxPendingBytes,
+            boolean ownsResources) {
         this.clientIdentifier = clientIdentifier;
         this.pendingBytesLimiter = new PendingBytesLimiter(maxPendingBytes);
         this.instrumentProvider = instrumentProvider;
@@ -169,6 +224,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         this.writeBatchManager = writeBatchManager;
         this.sessionManager = sessionManager;
         this.scheduledExecutor = scheduledExecutor;
+        this.ownsResources = ownsResources;
         this.requestTimeoutMs = requestTimeout.toMillis();
 
         counterPutBytes =
@@ -876,13 +932,24 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             return;
         }
         closed = true;
+        if (!ownsResources) {
+            // Detach from the shared shard-assignment stream so it stops dispatching to this client.
+            shardManager.removeCallback(sessionManager);
+            shardManager.removeCallback(notificationManager);
+        }
         readBatchManager.close();
         writeBatchManager.close();
         sessionManager.close();
         notificationManager.close();
-        shardManager.close();
+        if (ownsResources) {
+            shardManager.close();
+        }
+        // In shared mode the RpcProvider does not own the connection pool, so this only closes the
+        // per-client write streams; the shared connections stay open for other clients.
         rpcProvider.close();
-        scheduledExecutor.shutdownNow();
+        if (ownsResources) {
+            scheduledExecutor.shutdownNow();
+        }
     }
 
     private void checkIfClosed() {

--- a/client/src/main/java/io/oxia/client/CompositeConsumer.java
+++ b/client/src/main/java/io/oxia/client/CompositeConsumer.java
@@ -27,6 +27,10 @@ public class CompositeConsumer<T> implements Consumer<T> {
         callbacks.add(callback);
     }
 
+    public void remove(Consumer<T> callback) {
+        callbacks.remove(callback);
+    }
+
     @Override
     public void accept(T t) {
         for (Consumer<T> callback : callbacks) {

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -23,6 +23,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.oxia.client.api.AsyncOxiaClient;
 import io.oxia.client.api.Authentication;
 import io.oxia.client.api.OxiaClientBuilder;
+import io.oxia.client.api.SharedResources;
 import io.oxia.client.api.SyncOxiaClient;
 import io.oxia.client.api.exceptions.OxiaException;
 import io.oxia.client.api.exceptions.UnsupportedAuthenticationException;
@@ -32,7 +33,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.LinkedHashSet;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -86,6 +89,15 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     protected Duration connectionKeepAliveTimeout = Duration.ofSeconds(3);
 
     protected int maxConnectionsPerNode = DefaultMaxConnectionPerNode;
+
+    @Nullable protected SharedResources sharedResources;
+
+    /**
+     * Names of the transport-level settings that were explicitly configured on this builder. These
+     * are owned by the {@link #sharedResources} pool when one is attached, so setting them here is a
+     * configuration error that {@link #asyncClient()} rejects.
+     */
+    private final Set<String> explicitTransportSettings = new LinkedHashSet<>();
 
     @Override
     public @NonNull OxiaClientBuilder requestTimeout(@NonNull Duration requestTimeout) {
@@ -179,6 +191,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     @Override
     public OxiaClientBuilder authentication(Authentication authentication) {
         this.authentication = authentication;
+        explicitTransportSettings.add("authentication");
         return this;
     }
 
@@ -196,18 +209,21 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                     "maxConnectionPerNode must be greater than zero: " + connections);
         }
         this.maxConnectionsPerNode = connections;
+        explicitTransportSettings.add("maxConnectionPerNode");
         return this;
     }
 
     @Override
     public OxiaClientBuilder connectionKeepAliveTimeout(Duration connectionKeepAliveTimeout) {
         this.connectionKeepAliveTimeout = connectionKeepAliveTimeout;
+        explicitTransportSettings.add("connectionKeepAliveTimeout");
         return this;
     }
 
     @Override
     public OxiaClientBuilder connectionKeepAliveTime(Duration keepAliveTime) {
         this.connectionKeepAliveTime = keepAliveTime;
+        explicitTransportSettings.add("connectionKeepAliveTime");
         return this;
     }
 
@@ -217,12 +233,20 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
         this.authPluginClassName = authPluginClassName;
         this.authParams = authParamsString;
         this.authentication = AuthenticationFactory.create(authPluginClassName, authParamsString);
+        explicitTransportSettings.add("authentication");
         return this;
     }
 
     @Override
     public OxiaClientBuilder enableTls(boolean enableTls) {
         this.enableTls = enableTls;
+        explicitTransportSettings.add("enableTls");
+        return this;
+    }
+
+    @Override
+    public OxiaClientBuilder sharedResources(SharedResources sharedResources) {
+        this.sharedResources = sharedResources;
         return this;
     }
 
@@ -270,6 +294,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                 } else {
                     field.set(this, properties.getProperty(name));
                 }
+                recordExplicitTransportSetting(name);
             } catch (NoSuchFieldException | IllegalAccessException e) {
                 throw new IllegalArgumentException("Invalid configuration property: " + name);
             }
@@ -289,8 +314,33 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
         return this;
     }
 
+    /** Record, by builder-property name, that a shared-resources-owned transport setting was set. */
+    private void recordExplicitTransportSetting(String propertyName) {
+        switch (propertyName) {
+            case "enableTls", "connectionKeepAliveTime", "connectionKeepAliveTimeout" ->
+                    explicitTransportSettings.add(propertyName);
+            case "maxConnectionsPerNode" -> explicitTransportSettings.add("maxConnectionPerNode");
+            case "authPluginClassName", "authParams" -> explicitTransportSettings.add("authentication");
+            default -> {
+                // Not a transport-level setting owned by the shared-resources pool.
+            }
+        }
+    }
+
     @Override
     public @NonNull CompletableFuture<AsyncOxiaClient> asyncClient() {
+        if (sharedResources != null) {
+            if (!explicitTransportSettings.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Transport-level settings "
+                                + explicitTransportSettings
+                                + " are governed by the shared-resources pool and must not also be set on a "
+                                + "client that uses sharedResources(...); configure them on "
+                                + "SharedResources.builder() instead.");
+            }
+            return AsyncOxiaClientImpl.newInstance(
+                    getClientConfig(), (SharedResourcesImpl) sharedResources);
+        }
         return AsyncOxiaClientImpl.newInstance(getClientConfig());
     }
 

--- a/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
+++ b/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
@@ -232,6 +232,7 @@ public class SharedResourcesImpl implements SharedResources {
                             OxiaClientBuilderImpl.DefaultMaxRequestsPerBatch,
                             OxiaClientBuilderImpl.DefaultMaxBatchSize,
                             OxiaClientBuilderImpl.DefaultMaxPendingBytes,
+                            OxiaClientBuilderImpl.DefaultBatchingThreads,
                             OxiaClientBuilderImpl.DefaultSessionTimeout,
                             "oxia-shared-resources",
                             openTelemetry,

--- a/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
+++ b/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
+import io.grpc.netty.shaded.io.netty.util.concurrent.DefaultThreadFactory;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.oxia.client.api.Authentication;
+import io.oxia.client.api.SharedResources;
+import io.oxia.client.grpc.ConnectionManager;
+import io.oxia.client.grpc.RpcProvider;
+import io.oxia.client.metrics.InstrumentProvider;
+import io.oxia.client.shard.ShardManager;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.NonNull;
+
+/**
+ * Default {@link SharedResources} implementation.
+ *
+ * <p>Owns the resources that can be shared by many client instances in the same JVM:
+ *
+ * <ul>
+ *   <li>a single background {@link ScheduledExecutorService};
+ *   <li>a single {@link ConnectionManager} (gRPC channel pool) — namespaces are applied per-RPC, so
+ *       connections are namespace-agnostic and shared across all clients;
+ *   <li>one shard-assignment stream ({@link ShardManager}) per {@code (serviceAddress, namespace)}.
+ * </ul>
+ *
+ * <p>Transport-level settings (TLS, authentication, keep-alive, connection pool size) are governed
+ * by this object and configured through its {@link Builder}. When a client is built with {@link
+ * io.oxia.client.api.OxiaClientBuilder#sharedResources(SharedResources)}, setting any of them on
+ * that client is rejected; per-client settings such as namespace, client identifier, session and
+ * request timeouts still apply.
+ */
+public class SharedResourcesImpl implements SharedResources {
+    private static final Logger log = Logger.get(SharedResourcesImpl.class);
+
+    private final ScheduledExecutorService executor;
+    private final ConnectionManager connectionManager;
+    private final OpenTelemetry openTelemetry;
+    private final Map<NamespaceKey, SharedNamespace> namespaces = new ConcurrentHashMap<>();
+    private volatile boolean closed;
+
+    public static SharedResources.Builder builder() {
+        return new Builder();
+    }
+
+    SharedResourcesImpl(int numWorkerThreads, @NonNull ClientConfig transportConfig) {
+        this.executor =
+                Executors.newScheduledThreadPool(
+                        numWorkerThreads, new DefaultThreadFactory("oxia-client-shared"));
+        this.connectionManager = new ConnectionManager(transportConfig, executor);
+        this.openTelemetry = transportConfig.openTelemetry();
+    }
+
+    ScheduledExecutorService executor() {
+        return executor;
+    }
+
+    ConnectionManager connectionManager() {
+        return connectionManager;
+    }
+
+    /** The number of currently-open shared connections. Exposed to demonstrate connection sharing. */
+    @VisibleForTesting
+    public int getConnectionCount() {
+        return connectionManager.getConnectionCount();
+    }
+
+    /** The number of distinct {@code (serviceAddress, namespace)} shard managers currently held. */
+    @VisibleForTesting
+    int namespaceCount() {
+        return namespaces.size();
+    }
+
+    /**
+     * Return the shared shard-assignment manager for the {@code (serviceAddress, namespace)} of the
+     * given config, creating and starting it on first use. The returned future completes once the
+     * initial shard assignments have been received.
+     */
+    CompletableFuture<ShardManager> getOrCreateShardManager(@NonNull ClientConfig config) {
+        if (closed) {
+            return CompletableFuture.failedFuture(
+                    new IllegalStateException("SharedResources has been closed"));
+        }
+        var key = new NamespaceKey(config.serviceAddress(), config.namespace());
+        var ns = namespaces.computeIfAbsent(key, k -> createNamespace(config));
+        return ns.started().thenApply(v -> ns.shardManager());
+    }
+
+    private SharedNamespace createNamespace(@NonNull ClientConfig config) {
+        // The shard-assignment stream is shared, so attribute its metrics to the pool's OpenTelemetry
+        // rather than to whichever client happened to create the namespace first.
+        var instrumentProvider = new InstrumentProvider(openTelemetry, config.namespace());
+        var shardManagerRef = new AtomicReference<ShardManager>();
+        var rpcProvider =
+                RpcProvider.create(
+                        config, executor, connectionManager, shardId -> shardManagerRef.get().leader(shardId));
+        var shardManager =
+                new ShardManager(executor, rpcProvider, instrumentProvider, config.namespace());
+        shardManagerRef.set(shardManager);
+        return new SharedNamespace(rpcProvider, shardManager, shardManager.start());
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        // Close the shard managers first (stops assignment-stream retries), then their RpcProviders,
+        // then the shared connection pool and finally the executor.
+        for (SharedNamespace ns : namespaces.values()) {
+            ns.shardManager().close();
+            try {
+                ns.rpcProvider().close();
+            } catch (Exception e) {
+                log.warn().exception(e).log("Failed to close shared shard RpcProvider");
+            }
+        }
+        namespaces.clear();
+        try {
+            connectionManager.close();
+        } catch (Exception e) {
+            log.warn().exception(e).log("Failed to close shared connection manager");
+        }
+        executor.shutdownNow();
+    }
+
+    record NamespaceKey(String serviceAddress, String namespace) {}
+
+    private record SharedNamespace(
+            RpcProvider rpcProvider, ShardManager shardManager, CompletableFuture<Void> started) {}
+
+    /** Builder for {@link SharedResourcesImpl}. */
+    public static final class Builder implements SharedResources.Builder {
+        private int numWorkerThreads = Runtime.getRuntime().availableProcessors();
+        private boolean enableTls = OxiaClientBuilderImpl.DefaultEnableTls;
+        private Authentication authentication;
+        private Duration connectionKeepAliveTime = Duration.ofSeconds(10);
+        private Duration connectionKeepAliveTimeout = Duration.ofSeconds(3);
+        private Duration connectionBackoffMinDelay = Duration.ofMillis(100);
+        private Duration connectionBackoffMaxDelay = Duration.ofSeconds(30);
+        private int maxConnectionPerNode = OxiaClientBuilderImpl.DefaultMaxConnectionPerNode;
+        private OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
+
+        @Override
+        public SharedResources.Builder numWorkerThreads(int numWorkerThreads) {
+            if (numWorkerThreads <= 0) {
+                throw new IllegalArgumentException(
+                        "numWorkerThreads must be greater than zero: " + numWorkerThreads);
+            }
+            this.numWorkerThreads = numWorkerThreads;
+            return this;
+        }
+
+        @Override
+        public SharedResources.Builder enableTls(boolean enableTls) {
+            this.enableTls = enableTls;
+            return this;
+        }
+
+        @Override
+        public SharedResources.Builder authentication(Authentication authentication) {
+            this.authentication = authentication;
+            return this;
+        }
+
+        @Override
+        public SharedResources.Builder connectionKeepAliveTime(@NonNull Duration keepAliveTime) {
+            this.connectionKeepAliveTime = keepAliveTime;
+            return this;
+        }
+
+        @Override
+        public SharedResources.Builder connectionKeepAliveTimeout(@NonNull Duration keepAliveTimeout) {
+            this.connectionKeepAliveTimeout = keepAliveTimeout;
+            return this;
+        }
+
+        @Override
+        public SharedResources.Builder connectionBackoff(
+                @NonNull Duration minDelay, @NonNull Duration maxDelay) {
+            this.connectionBackoffMinDelay = minDelay;
+            this.connectionBackoffMaxDelay = maxDelay;
+            return this;
+        }
+
+        @Override
+        public SharedResources.Builder maxConnectionPerNode(int connections) {
+            if (connections <= 0) {
+                throw new IllegalArgumentException(
+                        "maxConnectionPerNode must be greater than zero: " + connections);
+            }
+            this.maxConnectionPerNode = connections;
+            return this;
+        }
+
+        @Override
+        public SharedResources.Builder openTelemetry(@NonNull OpenTelemetry openTelemetry) {
+            this.openTelemetry = openTelemetry;
+            return this;
+        }
+
+        @Override
+        public SharedResources build() {
+            var transportConfig =
+                    new ClientConfig(
+                            "shared",
+                            OxiaClientBuilderImpl.DefaultRequestTimeout,
+                            OxiaClientBuilderImpl.DefaultMaxRequestsPerBatch,
+                            OxiaClientBuilderImpl.DefaultMaxBatchSize,
+                            OxiaClientBuilderImpl.DefaultMaxPendingBytes,
+                            OxiaClientBuilderImpl.DefaultSessionTimeout,
+                            "oxia-shared-resources",
+                            openTelemetry,
+                            OxiaClientBuilderImpl.DefaultNamespace,
+                            authentication,
+                            enableTls,
+                            connectionBackoffMinDelay,
+                            connectionBackoffMaxDelay,
+                            connectionKeepAliveTime,
+                            connectionKeepAliveTimeout,
+                            maxConnectionPerNode);
+            return new SharedResourcesImpl(numWorkerThreads, transportConfig);
+        }
+    }
+}

--- a/client/src/main/java/io/oxia/client/grpc/ConnectionManager.java
+++ b/client/src/main/java/io/oxia/client/grpc/ConnectionManager.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 
-class ConnectionManager implements AutoCloseable {
+public class ConnectionManager implements AutoCloseable {
     private static final Logger log = Logger.get(ConnectionManager.class);
 
     @VisibleForTesting final Map<Key, Connection> connections = new ConcurrentHashMap<>();
@@ -32,7 +32,7 @@ class ConnectionManager implements AutoCloseable {
     private final ClientConfig clientConfig;
     private final ScheduledExecutorService executor;
 
-    ConnectionManager(ClientConfig clientConfig, ScheduledExecutorService executor) {
+    public ConnectionManager(ClientConfig clientConfig, ScheduledExecutorService executor) {
         this.clientConfig = clientConfig;
         this.maxConnectionPerNode = clientConfig.maxConnectionPerNode();
         this.executor = executor;
@@ -60,6 +60,11 @@ class ConnectionManager implements AutoCloseable {
                             .log("Creating managed GRPC connection");
                     return connection;
                 });
+    }
+
+    /** The number of currently-open connections. Exposed to demonstrate connection sharing. */
+    public int getConnectionCount() {
+        return connections.size();
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -64,6 +64,7 @@ final class GrpcRpcProvider implements RpcProvider {
 
     private final ClientConfig clientConfig;
     private final ConnectionManager connectionManager;
+    private final boolean ownsConnectionManager;
     private final ScheduledExecutorService asyncExecutor;
     private final LongFunction<String> shardLeaderProvider;
     private final Map<Long, ManagedWriteStream> writeStreams;
@@ -72,9 +73,32 @@ final class GrpcRpcProvider implements RpcProvider {
             @NonNull ClientConfig clientConfig,
             @NonNull ScheduledExecutorService asyncExecutor,
             @NonNull LongFunction<String> shardLeaderProvider) {
+        this(
+                clientConfig,
+                asyncExecutor,
+                new ConnectionManager(clientConfig, asyncExecutor),
+                shardLeaderProvider,
+                true);
+    }
+
+    GrpcRpcProvider(
+            @NonNull ClientConfig clientConfig,
+            @NonNull ScheduledExecutorService asyncExecutor,
+            @NonNull ConnectionManager connectionManager,
+            @NonNull LongFunction<String> shardLeaderProvider) {
+        this(clientConfig, asyncExecutor, connectionManager, shardLeaderProvider, false);
+    }
+
+    private GrpcRpcProvider(
+            @NonNull ClientConfig clientConfig,
+            @NonNull ScheduledExecutorService asyncExecutor,
+            @NonNull ConnectionManager connectionManager,
+            @NonNull LongFunction<String> shardLeaderProvider,
+            boolean ownsConnectionManager) {
         this.clientConfig = clientConfig;
         this.asyncExecutor = asyncExecutor;
-        this.connectionManager = new ConnectionManager(clientConfig, asyncExecutor);
+        this.connectionManager = connectionManager;
+        this.ownsConnectionManager = ownsConnectionManager;
         this.shardLeaderProvider = shardLeaderProvider;
         this.writeStreams = Maps.newConcurrentMap();
     }
@@ -385,7 +409,9 @@ final class GrpcRpcProvider implements RpcProvider {
             writeStreams.values().forEach(ManagedWriteStream::close);
             writeStreams.clear();
         } finally {
-            connectionManager.close();
+            if (ownsConnectionManager) {
+                connectionManager.close();
+            }
         }
     }
 

--- a/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
@@ -33,6 +33,20 @@ public interface RpcProvider extends AutoCloseable {
         return new GrpcRpcProvider(clientConfig, asyncExecutor, shardLeaderProvider);
     }
 
+    /**
+     * Create an {@link RpcProvider} that routes over an externally-owned {@link ConnectionManager}.
+     *
+     * <p>The provider will <b>not</b> close the connection manager when it is closed; the owner (for
+     * example a shared-resources pool) is responsible for that.
+     */
+    static RpcProvider create(
+            @NonNull ClientConfig clientConfig,
+            @NonNull ScheduledExecutorService asyncExecutor,
+            @NonNull ConnectionManager connectionManager,
+            @NonNull LongFunction<String> shardLeaderProvider) {
+        return new GrpcRpcProvider(clientConfig, asyncExecutor, connectionManager, shardLeaderProvider);
+    }
+
     void getShardAssignments(
             @NonNull ShardAssignmentsRequest request, @NonNull StreamObserver<ShardAssignments> observer);
 

--- a/client/src/main/java/io/oxia/client/shard/ShardManager.java
+++ b/client/src/main/java/io/oxia/client/shard/ShardManager.java
@@ -249,4 +249,8 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
     public void addCallback(@NonNull Consumer<ShardAssignmentChanges> callback) {
         callbacks.add(callback);
     }
+
+    public void removeCallback(@NonNull Consumer<ShardAssignmentChanges> callback) {
+        callbacks.remove(callback);
+    }
 }

--- a/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
@@ -94,7 +94,8 @@ class AsyncOxiaClientImplTest {
                 writeBatchManager,
                 sessionManager,
                 requestTimeout,
-                maxPendingBytes);
+                maxPendingBytes,
+                true);
     }
 
     @BeforeEach

--- a/client/src/test/java/io/oxia/client/CompositeConsumerTest.java
+++ b/client/src/test/java/io/oxia/client/CompositeConsumerTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 class CompositeConsumerTest {
@@ -41,5 +42,26 @@ class CompositeConsumerTest {
         }
         assertThat(received1).isEqualTo(expected);
         assertThat(received2).isEqualTo(expected);
+    }
+
+    @Test
+    void removedCallbackStopsReceivingEvents() {
+        var composite = new CompositeConsumer<Integer>();
+        List<Integer> received1 = new ArrayList<>();
+        List<Integer> received2 = new ArrayList<>();
+        Consumer<Integer> callback1 = received1::add;
+        composite.add(callback1);
+        composite.add(received2::add);
+
+        composite.accept(1);
+        composite.remove(callback1);
+        composite.accept(2);
+
+        // Removing an absent callback is a no-op.
+        composite.remove(callback1);
+        composite.accept(3);
+
+        assertThat(received1).containsExactly(1);
+        assertThat(received2).containsExactly(1, 2, 3);
     }
 }

--- a/client/src/test/java/io/oxia/client/SharedResourcesImplTest.java
+++ b/client/src/test/java/io/oxia/client/SharedResourcesImplTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.oxia.client.api.SharedResources;
+import org.junit.jupiter.api.Test;
+
+class SharedResourcesImplTest {
+
+    @Test
+    void builderValidatesArguments() {
+        var builder = SharedResourcesImpl.builder();
+        assertThatThrownBy(() -> builder.numWorkerThreads(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.maxConnectionPerNode(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void startsWithNoOpenConnections() {
+        try (var shared = (SharedResourcesImpl) SharedResourcesImpl.builder().build()) {
+            assertThat(shared.getConnectionCount()).isZero();
+            assertThat(shared.namespaceCount()).isZero();
+        }
+    }
+
+    @Test
+    void deduplicatesShardManagersByAddressAndNamespace() {
+        try (var shared =
+                (SharedResourcesImpl) SharedResourcesImpl.builder().numWorkerThreads(1).build()) {
+            // Unroutable addresses: the shard-assignment stream never connects, but namespace
+            // registration is synchronous, so dedup/keying can be asserted without a real server.
+            shared.getOrCreateShardManager(config("localhost:1", "ns-a"));
+            assertThat(shared.namespaceCount()).isEqualTo(1);
+
+            // Same (address, namespace) -> reused, no new entry.
+            shared.getOrCreateShardManager(config("localhost:1", "ns-a"));
+            assertThat(shared.namespaceCount()).isEqualTo(1);
+
+            // Different namespace -> new entry.
+            shared.getOrCreateShardManager(config("localhost:1", "ns-b"));
+            assertThat(shared.namespaceCount()).isEqualTo(2);
+
+            // Different address -> new entry.
+            shared.getOrCreateShardManager(config("localhost:2", "ns-a"));
+            assertThat(shared.namespaceCount()).isEqualTo(3);
+        }
+    }
+
+    @Test
+    void closeShutsDownExecutorAndIsIdempotent() {
+        var shared = (SharedResourcesImpl) SharedResourcesImpl.builder().numWorkerThreads(1).build();
+        assertThat(shared.executor().isShutdown()).isFalse();
+
+        shared.close();
+        assertThat(shared.executor().isShutdown()).isTrue();
+
+        // Closing again is a no-op.
+        shared.close();
+        assertThat(shared.executor().isShutdown()).isTrue();
+    }
+
+    @Test
+    void getOrCreateShardManagerFailsAfterClose() {
+        var shared = (SharedResourcesImpl) SharedResourcesImpl.builder().build();
+        shared.close();
+
+        var future = shared.getOrCreateShardManager(config("localhost:1", "ns"));
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThat(shared.namespaceCount()).isZero();
+    }
+
+    @Test
+    void rejectsClientTransportSettingsWhenSharedResourcesAttached() {
+        try (SharedResources shared = SharedResourcesImpl.builder().build()) {
+            assertThatThrownBy(
+                            () ->
+                                    new OxiaClientBuilderImpl("localhost:6648")
+                                            .enableTls(true)
+                                            .sharedResources(shared)
+                                            .asyncClient())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("enableTls");
+
+            assertThatThrownBy(
+                            () ->
+                                    new OxiaClientBuilderImpl("localhost:6648")
+                                            .maxConnectionPerNode(4)
+                                            .sharedResources(shared)
+                                            .asyncClient())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("maxConnectionPerNode");
+        }
+    }
+
+    private static ClientConfig config(String serviceAddress, String namespace) {
+        var builder = new OxiaClientBuilderImpl(serviceAddress);
+        builder.namespace(namespace);
+        return builder.getClientConfig();
+    }
+}

--- a/client/src/test/java/io/oxia/client/grpc/RpcProviderSharedConnectionTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/RpcProviderSharedConnectionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.oxia.client.OxiaClientBuilderImpl;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.Test;
+
+class RpcProviderSharedConnectionTest {
+
+    /**
+     * A provider that borrows an externally-owned {@link ConnectionManager} (as the shared-resources
+     * pool does) must not close it when the provider itself is closed — only its owner may.
+     */
+    @Test
+    void doesNotCloseExternallyOwnedConnectionManager() throws Exception {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            var config = new OxiaClientBuilderImpl("localhost:6648").getClientConfig();
+            ConnectionManager sharedConnections = mock(ConnectionManager.class);
+
+            RpcProvider provider =
+                    RpcProvider.create(config, executor, sharedConnections, shardId -> "localhost:6648");
+            provider.close();
+
+            verify(sharedConnections, never()).close();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/client/src/test/java/io/oxia/client/it/SharedResourcesIT.java
+++ b/client/src/test/java/io/oxia/client/it/SharedResourcesIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.oxia.client.SharedResourcesImpl;
+import io.oxia.client.api.AsyncOxiaClient;
+import io.oxia.client.api.OxiaClientBuilder;
+import io.oxia.client.api.SharedResources;
+import io.oxia.client.api.options.PutOption;
+import io.oxia.testcontainers.OxiaContainer;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class SharedResourcesIT {
+
+    @Container
+    private static final OxiaContainer oxia =
+            new OxiaContainer(OxiaImages.OXIA)
+                    .withShards(3)
+                    .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(SharedResourcesIT.class)));
+
+    @Test
+    void clientsShareTransportButKeepIndependentSessions() throws Exception {
+        // Baseline of dedicated "oxia-client-async" threads created by any standalone clients running
+        // in this JVM, so the assertion below is robust to other test classes.
+        long asyncThreadsBefore = threadCount("oxia-client-async");
+
+        try (SharedResources shared = SharedResources.builder().numWorkerThreads(2).build()) {
+            AsyncOxiaClient c1 =
+                    OxiaClientBuilder.create(oxia.getServiceAddress())
+                            .sharedResources(shared)
+                            .clientIdentifier("client-1")
+                            .asyncClient()
+                            .join();
+            AsyncOxiaClient c2 =
+                    OxiaClientBuilder.create(oxia.getServiceAddress())
+                            .sharedResources(shared)
+                            .clientIdentifier("client-2")
+                            .asyncClient()
+                            .join();
+
+            // Both clients are functional and see each other's (non-ephemeral) writes.
+            c1.put("k1", "v1".getBytes(UTF_8)).join();
+            c2.put("k2", "v2".getBytes(UTF_8)).join();
+            assertThat(c2.get("k1").join().value()).isEqualTo("v1".getBytes(UTF_8));
+            assertThat(c1.get("k2").join().value()).isEqualTo("v2".getBytes(UTF_8));
+
+            // The executor is shared: the pooled clients spawned no dedicated async thread pool, and
+            // the shared pool's threads are present.
+            assertThat(threadCount("oxia-client-async")).isEqualTo(asyncThreadsBefore);
+            assertThat(threadCount("oxia-client-shared")).isGreaterThan(0);
+
+            // Connections are shared and actually open.
+            assertThat(((SharedResourcesImpl) shared).getConnectionCount()).isGreaterThan(0);
+
+            // Sessions are independent per client: each ephemeral record is tied to its own session.
+            c1.put("e1", "e1".getBytes(UTF_8), Set.of(PutOption.AsEphemeralRecord)).join();
+            c2.put("e2", "e2".getBytes(UTF_8), Set.of(PutOption.AsEphemeralRecord)).join();
+            assertThat(c2.get("e1").join()).isNotNull();
+            assertThat(c1.get("e2").join()).isNotNull();
+
+            // Closing one client only removes its own ephemeral keys; the shared resources and the
+            // other client keep working.
+            c1.close();
+            await().untilAsserted(() -> assertThat(c2.get("e1").join()).isNull());
+            assertThat(c2.get("e2").join()).isNotNull();
+
+            c2.put("k3", "v3".getBytes(UTF_8)).join();
+            assertThat(c2.get("k3").join().value()).isEqualTo("v3".getBytes(UTF_8));
+            assertThat(((SharedResourcesImpl) shared).getConnectionCount()).isGreaterThan(0);
+            assertThat(threadCount("oxia-client-shared")).isGreaterThan(0);
+
+            c2.close();
+
+            // A new client can still be created from the still-open pool.
+            AsyncOxiaClient c3 =
+                    OxiaClientBuilder.create(oxia.getServiceAddress())
+                            .sharedResources(shared)
+                            .clientIdentifier("client-3")
+                            .asyncClient()
+                            .join();
+            assertThat(c3.get("k1").join().value()).isEqualTo("v1".getBytes(UTF_8));
+            c3.close();
+        }
+    }
+
+    private static long threadCount(String namePrefix) {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(t -> t.getName().startsWith(namePrefix))
+                .count();
+    }
+}


### PR DESCRIPTION
## What

Add a public `SharedResources` pool so that many client instances (or many sessions) in one JVM can **share** the heavy per-client resources instead of each paying a full footprint:

- the background `ScheduledExecutorService`
- the gRPC connection pool (`ConnectionManager`)
- the shard-assignment stream (`ShardManager`), one per `(serviceAddress, namespace)`

This targets benchmarks and apps that simulate/hold tens of thousands of sessions, which today pay one full client footprint per session.

## Usage

```java
try (SharedResources shared = SharedResources.builder().numWorkerThreads(4).build()) {
    AsyncOxiaClient c1 = OxiaClientBuilder.create("localhost:6648")
            .sharedResources(shared)
            .clientIdentifier("app-1")
            .asyncClient()
            .join();
    // c1..cN share the executor, connections and shard-assignment stream;
    // each keeps its own sessions/ephemeral records, notifications and batching.
} // releases the shared executor, connections and shard managers
```

## Design

- **Shared pool-wide:** the executor and the `ConnectionManager` (namespaces are applied per-RPC, so connections are namespace-agnostic).
- **Shared per `(serviceAddress, namespace)`:** the `ShardManager` shard-assignment stream (plus an `RpcProvider` for it).
- **Per-client:** `SessionManager`/sessions, `NotificationManager`, the `BatchManager`s, per-client metric instruments, and the client's own `RpcProvider` + write streams.

The **write path stays per-client** (each client keeps its own `RpcProvider` and write streams over the shared connection pool). `ManagedWriteStream` correlates responses to requests by FIFO position, and a shared stream would force a single `requestTimeout` across clients — so keeping it per-client preserves per-client timeouts and write-failure isolation while still sharing the expensive transport (TCP/TLS/netty event loops).

Closing an individual pooled client tears down only its per-client state and detaches its callbacks from the shared `ShardManager`; the shared resources are released only when the pool itself is closed.

## Backward compatibility

The standalone `OxiaClientBuilder.create(addr).syncClient()/asyncClient()` path is unchanged — each such client still owns and closes its own executor, connections and shard-assignment stream. `sharedResources(...)` is strictly opt-in.

## Transport-settings guard

Transport-level settings (TLS, authentication, keep-alive, connection pool size) are governed by the pool. Setting any of them on a client that also uses `sharedResources(...)` fails fast with an `IllegalArgumentException` (covering both explicit setters and `loadConfig`), rather than being silently ignored.

## Testing

- **Unit:** pool dedup/keying and lifecycle (`SharedResourcesImplTest`), the shared connection pool not being closed on single-client close (`RpcProviderSharedConnectionTest`), and `CompositeConsumer.remove`.
- **Integration (`SharedResourcesIT`, testcontainers):** multiple pooled clients are functional, ephemeral sessions are independent per client (closing one client removes only its own ephemeral keys), and the executor/connections are shared (no per-client thread pool is spawned).
