### PR TITLE
chore: release 0.9.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.oxia-db
-version=0.9.0
+version=0.9.1
 
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true


### PR DESCRIPTION
Release 0.9.1.

Changes since 0.9.0:
- feat: share transport resources across client instances (#355) — new `SharedResources` pool for sharing the background executor, gRPC connection pool and shard-assignment stream across many client instances in one JVM.
- ci: wait for VALIDATED instead of PUBLISHED on Maven Central release (#354).