### PR TITLE
perf: share batcher threads across pooled client instances

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/SharedResources.java
+++ b/client-api/src/main/java/io/oxia/client/api/SharedResources.java
@@ -83,6 +83,17 @@ public interface SharedResources extends AutoCloseable {
         Builder numWorkerThreads(int numWorkerThreads);
 
         /**
+         * Set the number of shared batch-assembly threads (reads and writes each get this many).
+         *
+         * <p>These threads are shared by every client built on this pool, so the total number of
+         * batching threads stays fixed no matter how many clients are created. Default is {@code 1}.
+         *
+         * @param batchingThreads the number of shared batching threads
+         * @return the builder instance
+         */
+        Builder batchingThreads(int batchingThreads);
+
+        /**
          * Configure whether to enable TLS for the shared connections.
          *
          * <p>Default is {@code false}.

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -32,6 +32,7 @@ import io.oxia.client.api.options.ListOption;
 import io.oxia.client.api.options.PutOption;
 import io.oxia.client.api.options.RangeScanOption;
 import io.oxia.client.batch.BatchManager;
+import io.oxia.client.batch.BatcherPool;
 import io.oxia.client.batch.Operation.ReadOperation.GetOperation;
 import io.oxia.client.batch.Operation.WriteOperation.DeleteOperation;
 import io.oxia.client.batch.Operation.WriteOperation.DeleteRangeOperation;
@@ -89,12 +90,16 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         var notificationManager =
                 new NotificationManager(asyncExecutor, rpcProvider, shardManager, instrumentProvider);
         shardManager.addCallback(notificationManager);
+        var readBatcherPool = new BatcherPool("oxia-read-batcher", config.batchingThreads());
         var readBatchManager =
-                BatchManager.newReadBatchManager(config, rpcProvider, instrumentProvider);
+                BatchManager.newReadBatchManager(
+                        config, rpcProvider, instrumentProvider, readBatcherPool, true);
         var sessionManager = new SessionManager(asyncExecutor, config, rpcProvider, instrumentProvider);
         shardManager.addCallback(sessionManager);
+        var writeBatcherPool = new BatcherPool("oxia-write-batcher", config.batchingThreads());
         var writeBatchManager =
-                BatchManager.newWriteBatchManager(config, rpcProvider, sessionManager, instrumentProvider);
+                BatchManager.newWriteBatchManager(
+                        config, rpcProvider, sessionManager, instrumentProvider, writeBatcherPool, true);
 
         var client =
                 new AsyncOxiaClientImpl(
@@ -136,13 +141,23 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                                             asyncExecutor, rpcProvider, shardManager, instrumentProvider);
                             shardManager.addCallback(notificationManager);
                             var readBatchManager =
-                                    BatchManager.newReadBatchManager(config, rpcProvider, instrumentProvider);
+                                    BatchManager.newReadBatchManager(
+                                            config,
+                                            rpcProvider,
+                                            instrumentProvider,
+                                            sharedResources.readBatcherPool(),
+                                            false);
                             var sessionManager =
                                     new SessionManager(asyncExecutor, config, rpcProvider, instrumentProvider);
                             shardManager.addCallback(sessionManager);
                             var writeBatchManager =
                                     BatchManager.newWriteBatchManager(
-                                            config, rpcProvider, sessionManager, instrumentProvider);
+                                            config,
+                                            rpcProvider,
+                                            sessionManager,
+                                            instrumentProvider,
+                                            sharedResources.writeBatcherPool(),
+                                            false);
                             return new AsyncOxiaClientImpl(
                                     config.clientIdentifier(),
                                     asyncExecutor,

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -146,6 +146,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                     "batchingThreads must be greater than zero: " + batchingThreads);
         }
         this.batchingThreads = batchingThreads;
+        explicitTransportSettings.add("batchingThreads");
         return this;
     }
 
@@ -317,7 +318,10 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     /** Record, by builder-property name, that a shared-resources-owned transport setting was set. */
     private void recordExplicitTransportSetting(String propertyName) {
         switch (propertyName) {
-            case "enableTls", "connectionKeepAliveTime", "connectionKeepAliveTimeout" ->
+            case "enableTls",
+                    "connectionKeepAliveTime",
+                    "connectionKeepAliveTimeout",
+                    "batchingThreads" ->
                     explicitTransportSettings.add(propertyName);
             case "maxConnectionsPerNode" -> explicitTransportSettings.add("maxConnectionPerNode");
             case "authPluginClassName", "authParams" -> explicitTransportSettings.add("authentication");
@@ -332,7 +336,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
         if (sharedResources != null) {
             if (!explicitTransportSettings.isEmpty()) {
                 throw new IllegalArgumentException(
-                        "Transport-level settings "
+                        "The settings "
                                 + explicitTransportSettings
                                 + " are governed by the shared-resources pool and must not also be set on a "
                                 + "client that uses sharedResources(...); configure them on "

--- a/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
+++ b/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.oxia.client.api.Authentication;
 import io.oxia.client.api.SharedResources;
+import io.oxia.client.batch.BatcherPool;
 import io.oxia.client.grpc.ConnectionManager;
 import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.metrics.InstrumentProvider;
@@ -58,6 +59,8 @@ public class SharedResourcesImpl implements SharedResources {
 
     private final ScheduledExecutorService executor;
     private final ConnectionManager connectionManager;
+    private final BatcherPool readBatcherPool;
+    private final BatcherPool writeBatcherPool;
     private final OpenTelemetry openTelemetry;
     private final Map<NamespaceKey, SharedNamespace> namespaces = new ConcurrentHashMap<>();
     private volatile boolean closed;
@@ -71,6 +74,10 @@ public class SharedResourcesImpl implements SharedResources {
                 Executors.newScheduledThreadPool(
                         numWorkerThreads, new DefaultThreadFactory("oxia-client-shared"));
         this.connectionManager = new ConnectionManager(transportConfig, executor);
+        this.readBatcherPool =
+                new BatcherPool("oxia-shared-read-batcher", transportConfig.batchingThreads());
+        this.writeBatcherPool =
+                new BatcherPool("oxia-shared-write-batcher", transportConfig.batchingThreads());
         this.openTelemetry = transportConfig.openTelemetry();
     }
 
@@ -80,6 +87,14 @@ public class SharedResourcesImpl implements SharedResources {
 
     ConnectionManager connectionManager() {
         return connectionManager;
+    }
+
+    BatcherPool readBatcherPool() {
+        return readBatcherPool;
+    }
+
+    BatcherPool writeBatcherPool() {
+        return writeBatcherPool;
     }
 
     /** The number of currently-open shared connections. Exposed to demonstrate connection sharing. */
@@ -145,6 +160,8 @@ public class SharedResourcesImpl implements SharedResources {
         } catch (Exception e) {
             log.warn().exception(e).log("Failed to close shared connection manager");
         }
+        readBatcherPool.close();
+        writeBatcherPool.close();
         executor.shutdownNow();
     }
 
@@ -156,6 +173,7 @@ public class SharedResourcesImpl implements SharedResources {
     /** Builder for {@link SharedResourcesImpl}. */
     public static final class Builder implements SharedResources.Builder {
         private int numWorkerThreads = Runtime.getRuntime().availableProcessors();
+        private int batchingThreads = OxiaClientBuilderImpl.DefaultBatchingThreads;
         private boolean enableTls = OxiaClientBuilderImpl.DefaultEnableTls;
         private Authentication authentication;
         private Duration connectionKeepAliveTime = Duration.ofSeconds(10);
@@ -172,6 +190,16 @@ public class SharedResourcesImpl implements SharedResources {
                         "numWorkerThreads must be greater than zero: " + numWorkerThreads);
             }
             this.numWorkerThreads = numWorkerThreads;
+            return this;
+        }
+
+        @Override
+        public SharedResources.Builder batchingThreads(int batchingThreads) {
+            if (batchingThreads <= 0) {
+                throw new IllegalArgumentException(
+                        "batchingThreads must be greater than zero: " + batchingThreads);
+            }
+            this.batchingThreads = batchingThreads;
             return this;
         }
 
@@ -232,7 +260,7 @@ public class SharedResourcesImpl implements SharedResources {
                             OxiaClientBuilderImpl.DefaultMaxRequestsPerBatch,
                             OxiaClientBuilderImpl.DefaultMaxBatchSize,
                             OxiaClientBuilderImpl.DefaultMaxPendingBytes,
-                            OxiaClientBuilderImpl.DefaultBatchingThreads,
+                            batchingThreads,
                             OxiaClientBuilderImpl.DefaultSessionTimeout,
                             "oxia-shared-resources",
                             openTelemetry,

--- a/client/src/main/java/io/oxia/client/batch/BatchManager.java
+++ b/client/src/main/java/io/oxia/client/batch/BatchManager.java
@@ -22,26 +22,32 @@ import io.oxia.client.session.SessionManager;
 import lombok.NonNull;
 
 /**
- * Routes operations to a fixed set of {@link Batcher} threads. A shard is always served by the same
- * batcher, so that the per-shard ordering of operations is preserved.
+ * Per-client entry point into the batching layer. It binds a client's {@link BatchFactory} (its
+ * {@code RpcProvider}, session and config) to a {@link BatcherPool} and routes the client's
+ * operations onto it.
+ *
+ * <p>The pool may be private to this client (standalone client — the manager owns and closes it) or
+ * shared across many clients (a {@link io.oxia.client.api.SharedResources} pool — closing this
+ * manager only flushes and fails this client's pending operations, leaving the pool running).
  */
 public class BatchManager implements AutoCloseable {
 
-    private final Batcher[] batchers;
+    private final @NonNull BatchFactory factory;
+    private final @NonNull BatcherPool pool;
+    private final boolean ownsPool;
     private volatile boolean closed;
 
-    BatchManager(@NonNull ClientConfig config, String name, @NonNull BatchFactory batchFactory) {
-        this.batchers = new Batcher[config.batchingThreads()];
-        for (int i = 0; i < batchers.length; i++) {
-            batchers[i] = new Batcher(config, name + "-" + i, batchFactory);
-        }
+    BatchManager(@NonNull BatchFactory factory, @NonNull BatcherPool pool, boolean ownsPool) {
+        this.factory = factory;
+        this.pool = pool;
+        this.ownsPool = ownsPool;
     }
 
     public void add(@NonNull Operation<?> operation) {
         if (closed) {
             throw new IllegalStateException("Batch manager is closed");
         }
-        batchers[(int) Math.floorMod(operation.shardId(), batchers.length)].add(operation);
+        pool.route(factory, operation);
     }
 
     @Override
@@ -50,27 +56,34 @@ public class BatchManager implements AutoCloseable {
             return;
         }
         closed = true;
-        for (Batcher batcher : batchers) {
-            batcher.close();
+        if (ownsPool) {
+            pool.close();
+        } else {
+            // Shared pool: only tear down this client's pending operations, not the pool.
+            pool.closeFactory(factory).join();
         }
     }
 
     public static @NonNull BatchManager newReadBatchManager(
             @NonNull ClientConfig config,
             @NonNull RpcProvider rpcProvider,
-            @NonNull InstrumentProvider instrumentProvider) {
+            @NonNull InstrumentProvider instrumentProvider,
+            @NonNull BatcherPool pool,
+            boolean ownsPool) {
         return new BatchManager(
-                config, "oxia-read-batcher", new ReadBatchFactory(rpcProvider, config, instrumentProvider));
+                new ReadBatchFactory(rpcProvider, config, instrumentProvider), pool, ownsPool);
     }
 
     public static @NonNull BatchManager newWriteBatchManager(
             @NonNull ClientConfig config,
             @NonNull RpcProvider rpcProvider,
             @NonNull SessionManager sessionManager,
-            @NonNull InstrumentProvider instrumentProvider) {
+            @NonNull InstrumentProvider instrumentProvider,
+            @NonNull BatcherPool pool,
+            boolean ownsPool) {
         return new BatchManager(
-                config,
-                "oxia-write-batcher",
-                new WriteBatchFactory(rpcProvider, sessionManager, config, instrumentProvider));
+                new WriteBatchFactory(rpcProvider, sessionManager, config, instrumentProvider),
+                pool,
+                ownsPool);
     }
 }

--- a/client/src/main/java/io/oxia/client/batch/Batcher.java
+++ b/client/src/main/java/io/oxia/client/batch/Batcher.java
@@ -18,56 +18,77 @@ package io.oxia.client.batch;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import io.grpc.netty.shaded.io.netty.util.concurrent.DefaultThreadFactory;
-import io.oxia.client.ClientConfig;
 import io.oxia.client.util.BatchedArrayBlockingQueue;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import lombok.NonNull;
 
 /**
- * One batching thread, serving the operations of all the shards assigned to it. Producers enqueue
- * into the thread's multi-producer single-consumer queue; the thread drains it and groups the
- * operations into per-shard batches. A batch is sent when full, and any partial batch is flushed as
- * soon as the queue is found empty, since there is nothing left to coalesce with.
+ * One batching thread, serving every shard — and, when it belongs to a shared pool, every client
+ * instance — routed to it. Producers enqueue commands into the thread's multi-producer
+ * single-consumer queue; the thread drains it and groups operations into per-(client, shard)
+ * batches. A batch is sent when full, and any open batch is flushed as soon as the queue is found
+ * empty, since there is nothing left to coalesce with.
+ *
+ * <p>Each operation carries the {@link BatchFactory} of the client that submitted it (the factory
+ * binds to that client's {@code RpcProvider}, session and config), so a single batcher can serve
+ * many clients without being tied to any one of them.
  */
-public class Batcher implements AutoCloseable {
+final class Batcher implements AutoCloseable {
 
     private static final int DEFAULT_QUEUE_CAPACITY = 10_000;
 
-    @NonNull private final ClientConfig config;
-    @NonNull private final BatchFactory batchFactory;
-    @NonNull private final BatchedArrayBlockingQueue<Operation<?>> operations;
+    /** Identifies an open batch: the submitting client's factory and the target shard. */
+    private record BatchKey(BatchFactory factory, long shardId) {}
 
-    // Open batches, grouped by shard. Only accessed by the batcher thread.
-    private final Map<Long, Batch> batchesByShardId = new HashMap<>();
+    sealed interface Command permits Enqueue, CloseFactory {}
+
+    record Enqueue(BatchFactory factory, Operation<?> operation) implements Command {}
+
+    record CloseFactory(BatchFactory factory, CompletableFuture<Void> done) implements Command {}
+
+    @NonNull private final BatchedArrayBlockingQueue<Command> commands;
+
+    // Open batches, grouped by (client factory, shard). Only accessed by the batcher thread.
+    private final Map<BatchKey, Batch> openBatches = new HashMap<>();
 
     private final Thread thread;
     private volatile boolean closed;
 
-    Batcher(@NonNull ClientConfig config, String name, @NonNull BatchFactory batchFactory) {
-        this(config, name, batchFactory, new BatchedArrayBlockingQueue<>(DEFAULT_QUEUE_CAPACITY));
-    }
-
-    Batcher(
-            @NonNull ClientConfig config,
-            String name,
-            @NonNull BatchFactory batchFactory,
-            @NonNull BatchedArrayBlockingQueue<Operation<?>> operations) {
-        this.config = config;
-        this.batchFactory = batchFactory;
-        this.operations = operations;
-
+    Batcher(String name) {
+        this.commands = new BatchedArrayBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
         this.thread = new DefaultThreadFactory(name).newThread(this::batcherLoop);
         this.thread.start();
     }
 
-    public <R> void add(@NonNull Operation<R> operation) {
+    <R> void add(@NonNull BatchFactory factory, @NonNull Operation<R> operation) {
         if (closed) {
             operation.fail(new IllegalStateException("Batcher has been closed"));
             return;
         }
+        put(new Enqueue(factory, operation));
+    }
+
+    /**
+     * Flush and fail the open batches belonging to {@code factory} — a client that is closing — so
+     * its pending operations complete promptly instead of lingering until an unrelated flush. Runs on
+     * the batcher thread (via the command queue) so it observes all of that client's earlier
+     * operations. Returns a future that completes once the request has been processed.
+     */
+    CompletableFuture<Void> closeFactory(@NonNull BatchFactory factory) {
+        var done = new CompletableFuture<Void>();
+        if (closed) {
+            done.complete(null);
+            return done;
+        }
+        put(new CloseFactory(factory, done));
+        return done;
+    }
+
+    private void put(Command command) {
         try {
-            operations.put(operation);
+            commands.put(command);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -75,80 +96,108 @@ public class Batcher implements AutoCloseable {
     }
 
     private void batcherLoop() {
-        Operation<?>[] localOperations = new Operation<?>[DEFAULT_QUEUE_CAPACITY];
-        int localOperationsIndex = 0;
-        int localOperationsCount = 0;
+        Command[] local = new Command[DEFAULT_QUEUE_CAPACITY];
+        int index = 0;
+        int count = 0;
 
         while (true) {
             try {
-                if (localOperationsIndex >= localOperationsCount) {
-                    if (batchesByShardId.isEmpty()) {
-                        // No pending batches — block until at least one operation arrives.
-                        localOperationsCount = operations.takeAll(localOperations);
+                if (index >= count) {
+                    if (openBatches.isEmpty()) {
+                        // No pending batches — block until at least one command arrives.
+                        count = commands.takeAll(local);
                     } else {
-                        // There are open batches. Non-blocking drain to pick up any operations
+                        // There are open batches. Non-blocking drain to pick up any commands
                         // that arrived while we were processing.
-                        localOperationsCount = operations.pollAll(localOperations, 0, NANOSECONDS);
-                        if (localOperationsCount == 0) {
+                        count = commands.pollAll(local, 0, NANOSECONDS);
+                        if (count == 0) {
                             // Queue is empty — no concurrent producers are filling it right
                             // now. Flush the open batches immediately rather than lingering,
                             // since there is nothing to batch with.
                             sendAll();
 
-                            // Block until the next operation arrives.
-                            localOperationsCount = operations.takeAll(localOperations);
+                            // Block until the next command arrives.
+                            count = commands.takeAll(local);
                         }
                     }
-                    localOperationsIndex = 0;
+                    index = 0;
                 }
             } catch (InterruptedException e) {
                 // Exiting thread
-                failPendingOperations();
+                failPending();
                 return;
             }
 
-            Operation<?> operation = localOperations[localOperationsIndex];
-            localOperations[localOperationsIndex++] = null;
-            try {
-                Batch batch = batchesByShardId.get(operation.shardId());
-                if (batch == null) {
-                    batch = batchFactory.getBatch(operation.shardId());
-                    batchesByShardId.put(operation.shardId(), batch);
-                }
-                if (!batch.canAdd(operation) && batch.size() > 0) {
-                    batch.send();
-                    batch = batchFactory.getBatch(operation.shardId());
-                    batchesByShardId.put(operation.shardId(), batch);
-                }
-                batch.add(operation);
-                if (batch.size() >= config.maxRequestsPerBatch()) {
-                    batch.send();
-                    batchesByShardId.remove(operation.shardId());
-                }
-            } catch (Exception e) {
-                operation.fail(e);
-                // Don't leave behind an open batch that the failed operation just created:
-                // it would be flushed empty
-                Batch open = batchesByShardId.get(operation.shardId());
-                if (open != null && open.size() == 0) {
-                    batchesByShardId.remove(operation.shardId());
-                }
+            Command command = local[index];
+            local[index++] = null;
+            if (command instanceof Enqueue enqueue) {
+                process(enqueue.factory(), enqueue.operation());
+            } else if (command instanceof CloseFactory closeFactory) {
+                closeFactoryBatches(closeFactory.factory());
+                closeFactory.done().complete(null);
             }
         }
     }
 
-    private void sendAll() {
-        batchesByShardId.values().forEach(Batch::send);
-        batchesByShardId.clear();
+    private void process(BatchFactory factory, Operation<?> operation) {
+        var key = new BatchKey(factory, operation.shardId());
+        try {
+            Batch batch = openBatches.get(key);
+            if (batch == null) {
+                batch = factory.getBatch(operation.shardId());
+                openBatches.put(key, batch);
+            }
+            if (!batch.canAdd(operation) && batch.size() > 0) {
+                batch.send();
+                batch = factory.getBatch(operation.shardId());
+                openBatches.put(key, batch);
+            }
+            batch.add(operation);
+            if (batch.size() >= factory.getConfig().maxRequestsPerBatch()) {
+                batch.send();
+                openBatches.remove(key);
+            }
+        } catch (Exception e) {
+            operation.fail(e);
+            // Don't leave behind an open batch that the failed operation just created:
+            // it would be flushed empty
+            Batch open = openBatches.get(key);
+            if (open != null && open.size() == 0) {
+                openBatches.remove(key);
+            }
+        }
     }
 
-    private void failPendingOperations() {
+    private void closeFactoryBatches(BatchFactory factory) {
+        var closedException = new IllegalStateException("Batch manager is closed");
+        openBatches
+                .entrySet()
+                .removeIf(
+                        entry -> {
+                            if (entry.getKey().factory() == factory) {
+                                entry.getValue().fail(closedException);
+                                return true;
+                            }
+                            return false;
+                        });
+    }
+
+    private void sendAll() {
+        openBatches.values().forEach(Batch::send);
+        openBatches.clear();
+    }
+
+    private void failPending() {
         var closedException = new IllegalStateException("Batcher has been closed");
-        batchesByShardId.values().forEach(batch -> batch.fail(closedException));
-        batchesByShardId.clear();
-        Operation<?> operation;
-        while ((operation = operations.poll()) != null) {
-            operation.fail(closedException);
+        openBatches.values().forEach(batch -> batch.fail(closedException));
+        openBatches.clear();
+        Command command;
+        while ((command = commands.poll()) != null) {
+            if (command instanceof Enqueue enqueue) {
+                enqueue.operation().fail(closedException);
+            } else if (command instanceof CloseFactory closeFactory) {
+                closeFactory.done().complete(null);
+            }
         }
     }
 

--- a/client/src/main/java/io/oxia/client/batch/BatcherPool.java
+++ b/client/src/main/java/io/oxia/client/batch/BatcherPool.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.batch;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.NonNull;
+
+/**
+ * A fixed set of {@link Batcher} threads that operations are routed across by shard. A shard is
+ * always served by the same batcher, so per-shard ordering is preserved.
+ *
+ * <p>The pool is factory-agnostic: each operation is routed together with the {@link BatchFactory}
+ * of the client that submitted it, so one pool can be shared by many client instances (via {@link
+ * io.oxia.client.api.SharedResources}) instead of every client owning its own batcher threads.
+ */
+public final class BatcherPool implements AutoCloseable {
+
+    private final Batcher[] batchers;
+
+    public BatcherPool(@NonNull String name, int batchingThreads) {
+        this.batchers = new Batcher[batchingThreads];
+        for (int i = 0; i < batchingThreads; i++) {
+            batchers[i] = new Batcher(name + "-" + i);
+        }
+    }
+
+    void route(@NonNull BatchFactory factory, @NonNull Operation<?> operation) {
+        batchers[(int) Math.floorMod(operation.shardId(), batchers.length)].add(factory, operation);
+    }
+
+    /**
+     * Flush and fail the open batches of {@code factory} across all batchers (a client is closing).
+     * The returned future completes once every batcher has processed the request.
+     */
+    CompletableFuture<Void> closeFactory(@NonNull BatchFactory factory) {
+        var futures = new CompletableFuture[batchers.length];
+        for (int i = 0; i < batchers.length; i++) {
+            futures[i] = batchers[i].closeFactory(factory);
+        }
+        return CompletableFuture.allOf(futures);
+    }
+
+    @Override
+    public void close() {
+        for (Batcher batcher : batchers) {
+            batcher.close();
+        }
+    }
+}

--- a/client/src/test/java/io/oxia/client/SharedResourcesImplTest.java
+++ b/client/src/test/java/io/oxia/client/SharedResourcesImplTest.java
@@ -28,6 +28,8 @@ class SharedResourcesImplTest {
         var builder = SharedResourcesImpl.builder();
         assertThatThrownBy(() -> builder.numWorkerThreads(0))
                 .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.batchingThreads(0))
+                .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> builder.maxConnectionPerNode(0))
                 .isInstanceOf(IllegalArgumentException.class);
     }
@@ -106,6 +108,16 @@ class SharedResourcesImplTest {
                                             .asyncClient())
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("maxConnectionPerNode");
+
+            // Batching threads are governed by the pool too.
+            assertThatThrownBy(
+                            () ->
+                                    new OxiaClientBuilderImpl("localhost:6648")
+                                            .batchingThreads(4)
+                                            .sharedResources(shared)
+                                            .asyncClient())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("batchingThreads");
         }
     }
 

--- a/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022-2026 The Oxia Authors
+ * Copyright © 2026 The Oxia Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
  */
 package io.oxia.client.batch;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,10 +36,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class BatchManagerTest {
+class BatcherPoolTest {
 
-    @Mock BatchFactory batchFactory;
-    @Mock Batch batch;
+    // Two factories stand in for two different client instances sharing one pool.
+    @Mock BatchFactory factoryA;
+    @Mock BatchFactory factoryB;
+    @Mock Batch batchA;
+    @Mock Batch batchB;
 
     ClientConfig config =
             new ClientConfig(
@@ -50,7 +51,7 @@ class BatchManagerTest {
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,
-                    2,
+                    1,
                     Duration.ofMillis(1000),
                     "client_id",
                     null,
@@ -64,17 +65,15 @@ class BatchManagerTest {
                     1);
 
     BatcherPool pool;
-    BatchManager manager;
 
     @BeforeEach
     void setup() {
-        pool = new BatcherPool("test-batcher", config.batchingThreads());
-        manager = new BatchManager(batchFactory, pool, true);
+        pool = new BatcherPool("test-shared-batcher", 2);
     }
 
     @AfterEach
-    void teardown() throws Exception {
-        manager.close();
+    void teardown() {
+        pool.close();
     }
 
     private static Operation<?> newOp(long shardId) {
@@ -86,29 +85,47 @@ class BatchManagerTest {
     }
 
     @Test
-    void routesOperationsByShard() {
-        when(batchFactory.getConfig()).thenReturn(config);
-        when(batchFactory.getBatch(anyLong())).thenReturn(batch);
-        when(batch.canAdd(any())).thenReturn(true);
-        when(batch.size()).thenReturn(1);
+    void oneThreadPoolServesMultipleClients() {
+        when(factoryA.getConfig()).thenReturn(config);
+        when(factoryB.getConfig()).thenReturn(config);
+        when(factoryA.getBatch(1L)).thenReturn(batchA);
+        when(factoryB.getBatch(1L)).thenReturn(batchB);
+        when(batchA.canAdd(any())).thenReturn(true);
+        when(batchA.size()).thenReturn(1);
+        when(batchB.canAdd(any())).thenReturn(true);
+        when(batchB.size()).thenReturn(1);
 
-        // More shards than batching threads: every operation is still processed
-        for (long shardId = 0; shardId < 4; shardId++) {
-            manager.add(newOp(shardId));
-        }
+        // Both operations target shard 1, so they land on the same batcher thread, but each is
+        // batched through its own client's factory.
+        pool.route(factoryA, newOp(1L));
+        pool.route(factoryB, newOp(1L));
 
         await()
                 .untilAsserted(
                         () -> {
-                            for (long shardId = 0; shardId < 4; shardId++) {
-                                verify(batchFactory).getBatch(shardId);
-                            }
+                            verify(factoryA).getBatch(1L);
+                            verify(batchA).send();
+                            verify(factoryB).getBatch(1L);
+                            verify(batchB).send();
                         });
     }
 
     @Test
-    void addAfterCloseThrows() throws Exception {
-        manager.close();
-        assertThatThrownBy(() -> manager.add(newOp(1L))).isInstanceOf(IllegalStateException.class);
+    void closingOneClientKeepsThePoolRunningForOthers() {
+        when(factoryB.getConfig()).thenReturn(config);
+        when(factoryB.getBatch(1L)).thenReturn(batchB);
+        when(batchB.canAdd(any())).thenReturn(true);
+        when(batchB.size()).thenReturn(1);
+
+        // A closing client only detaches itself; the shared pool stays up.
+        pool.closeFactory(factoryA).join();
+
+        pool.route(factoryB, newOp(1L));
+        await()
+                .untilAsserted(
+                        () -> {
+                            verify(factoryB).getBatch(1L);
+                            verify(batchB).send();
+                        });
     }
 }

--- a/client/src/test/java/io/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherTest.java
@@ -29,7 +29,6 @@ import io.oxia.client.OxiaClientBuilderImpl;
 import io.oxia.client.api.GetResult;
 import io.oxia.client.batch.Operation.ReadOperation.GetOperation;
 import io.oxia.client.options.GetOptions;
-import io.oxia.client.util.BatchedArrayBlockingQueue;
 import io.oxia.proto.KeyComparisonType;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -65,18 +64,20 @@ class BatcherTest {
                     Duration.ofSeconds(5),
                     1);
 
-    BatchedArrayBlockingQueue<Operation<?>> queue;
     Batcher batcher;
 
     @BeforeEach
     void setup() {
-        queue = new BatchedArrayBlockingQueue<>(100);
-        batcher = new Batcher(config, "test-batcher", batchFactory, queue);
+        batcher = new Batcher("test-batcher");
     }
 
     @AfterEach
     void teardown() {
         batcher.close();
+    }
+
+    private void add(Operation<?> operation) {
+        batcher.add(batchFactory, operation);
     }
 
     private static Operation<?> newOp(long shardId) {
@@ -90,11 +91,12 @@ class BatcherTest {
     @Test
     void singleOperationIsFlushedImmediately() {
         var op = newOp(1L);
+        when(batchFactory.getConfig()).thenReturn(config);
         when(batchFactory.getBatch(1L)).thenReturn(batch);
         when(batch.canAdd(any())).thenReturn(true);
         when(batch.size()).thenReturn(1);
 
-        batcher.add(op);
+        add(op);
 
         // Single operation with empty queue: the batch is flushed immediately
         await()
@@ -107,11 +109,12 @@ class BatcherTest {
 
     @Test
     void sendBatchWhenFull() {
+        when(batchFactory.getConfig()).thenReturn(config);
         when(batchFactory.getBatch(1L)).thenReturn(batch);
         when(batch.canAdd(any())).thenReturn(true);
         when(batch.size()).thenReturn(config.maxRequestsPerBatch());
 
-        batcher.add(newOp(1L));
+        add(newOp(1L));
 
         await().untilAsserted(() -> verify(batch).send());
     }
@@ -119,11 +122,12 @@ class BatcherTest {
     @Test
     void sealBatchWhenOperationDoesNotFit() {
         var op = newOp(1L);
+        when(batchFactory.getConfig()).thenReturn(config);
         when(batchFactory.getBatch(1L)).thenReturn(batch);
         when(batch.canAdd(any())).thenReturn(false);
         when(batch.size()).thenReturn(1);
 
-        batcher.add(op);
+        add(op);
 
         // The operation does not fit in the open batch: the batch is sent and the operation
         // starts a new one
@@ -138,6 +142,7 @@ class BatcherTest {
     @Test
     void groupOperationsByShard() {
         var batch2 = mock(Batch.class);
+        when(batchFactory.getConfig()).thenReturn(config);
         when(batchFactory.getBatch(1L)).thenReturn(batch);
         when(batchFactory.getBatch(2L)).thenReturn(batch2);
         when(batch.canAdd(any())).thenReturn(true);
@@ -147,8 +152,8 @@ class BatcherTest {
 
         var op1 = newOp(1L);
         var op2 = newOp(2L);
-        batcher.add(op1);
-        batcher.add(op2);
+        add(op1);
+        add(op2);
 
         // Operations of different shards are grouped into different batches, all of them
         // flushed once the queue is empty
@@ -166,16 +171,17 @@ class BatcherTest {
     void failedOperationDoesNotBreakTheBatcher() {
         var op1 = newOp(1L);
         var op2 = newOp(1L);
+        when(batchFactory.getConfig()).thenReturn(config);
         when(batchFactory.getBatch(1L)).thenReturn(batch);
         when(batch.canAdd(any())).thenReturn(true);
         doThrow(new RuntimeException("add failed")).when(batch).add(op1);
         // Empty after the failed add, then one operation
         when(batch.size()).thenReturn(0, 1);
 
-        batcher.add(op1);
+        add(op1);
         await().untilAsserted(() -> assertThat(op1.callback()).isCompletedExceptionally());
 
-        batcher.add(op2);
+        add(op2);
         await()
                 .untilAsserted(
                         () -> {
@@ -189,7 +195,7 @@ class BatcherTest {
         batcher.close();
 
         var op = newOp(1L);
-        batcher.add(op);
+        add(op);
         assertThat(op.callback()).isCompletedExceptionally();
     }
 }

--- a/client/src/test/java/io/oxia/client/it/SharedResourcesIT.java
+++ b/client/src/test/java/io/oxia/client/it/SharedResourcesIT.java
@@ -46,6 +46,8 @@ class SharedResourcesIT {
         // Baseline of dedicated "oxia-client-async" threads created by any standalone clients running
         // in this JVM, so the assertion below is robust to other test classes.
         long asyncThreadsBefore = threadCount("oxia-client-async");
+        long readBatcherThreadsBefore = threadCount("oxia-read-batcher");
+        long writeBatcherThreadsBefore = threadCount("oxia-write-batcher");
 
         try (SharedResources shared = SharedResources.builder().numWorkerThreads(2).build()) {
             AsyncOxiaClient c1 =
@@ -71,6 +73,13 @@ class SharedResourcesIT {
             // the shared pool's threads are present.
             assertThat(threadCount("oxia-client-async")).isEqualTo(asyncThreadsBefore);
             assertThat(threadCount("oxia-client-shared")).isGreaterThan(0);
+
+            // The batcher threads are shared too: the pooled clients spawned no dedicated read/write
+            // batcher threads, and the shared pool's batcher threads are present.
+            assertThat(threadCount("oxia-read-batcher")).isEqualTo(readBatcherThreadsBefore);
+            assertThat(threadCount("oxia-write-batcher")).isEqualTo(writeBatcherThreadsBefore);
+            assertThat(threadCount("oxia-shared-read-batcher")).isGreaterThan(0);
+            assertThat(threadCount("oxia-shared-write-batcher")).isGreaterThan(0);
 
             // Connections are shared and actually open.
             assertThat(((SharedResourcesImpl) shared).getConnectionCount()).isGreaterThan(0);


### PR DESCRIPTION
## What

Follow-up to #355. Even with `SharedResources`, every client still spun up its own read and write batcher threads (`batchingThreads` each, so 2 by default), so a process holding many pooled clients paid `2 × batchingThreads` **threads per client**. This shares the batcher threads the same way `SharedResources` already shares the executor, connection pool and shard-assignment stream.

## How

- **`Batcher` is now factory-agnostic.** It groups open batches by **(client-factory, shard)** instead of just shard, and reads `maxRequestsPerBatch` from each operation's own `BatchFactory`. So one batcher thread serves many client instances while preserving per-client batch tuning and per-`(client, shard)` ordering (`maxBatchSize` stays per-client, enforced by the `Batch`).
- **`BatcherPool`** (new) owns the `Batcher[]` and routes operations by shard; **`BatchManager`** becomes a thin per-client adapter `(factory, pool, ownsPool)`.
- **`SharedResources` owns shared read + write pools**, so pooled clients share `2 × batchingThreads` batcher threads **in total**, regardless of how many clients are created. Sized via `SharedResources.builder().batchingThreads(n)` (default 1).
- **Close semantics:** a closing pooled client enqueues a per-factory flush-and-fail command that runs on the batcher thread (FIFO, after that client's own operations), so its pending operations complete promptly without disturbing other clients or the shared threads — matching the prior "fail pending on close" contract.

## Backward compatibility

- **Standalone clients are unchanged**: they own private pools and close them (same thread count as before).
- Setting `batchingThreads(...)` on a client that also uses `sharedResources(...)` is now rejected with `IllegalArgumentException`, consistent with the transport-settings guard from #355 (the pool governs it).
- No breaking API changes.

## Testing

- **Unit:** `BatcherPoolTest` (one pool serves multiple client factories; the pool keeps running when one client closes); updated `BatcherTest`/`BatchManagerTest` for the factory-agnostic API; guard test extended for `batchingThreads`.
- **Integration (`SharedResourcesIT`):** asserts that pooled clients spawn **no** per-client `oxia-read-batcher`/`oxia-write-batcher` threads while the shared `oxia-shared-read-batcher`/`oxia-shared-write-batcher` threads are present.
