### PR TITLE
chore: log session created/closed at debug level

### DIFF
--- a/client/src/main/java/io/oxia/client/session/Session.java
+++ b/client/src/main/java/io/oxia/client/session/Session.java
@@ -83,7 +83,7 @@ public class Session {
                         .attr("clientIdentity", config.clientIdentifier())
                         .build();
 
-        log.info("Session created");
+        log.debug("Session created");
 
         this.sessionsOpened =
                 instrumentProvider.newCounter(
@@ -174,7 +174,7 @@ public class Session {
                         log.warn().exceptionMessage(error).log("Session closed failed.");
                         return;
                     }
-                    log.info("Session closed");
+                    log.debug("Session closed");
                 });
     }
 }


### PR DESCRIPTION
Session creation and close are routine per-session lifecycle events; at `info` level they become noise in processes that hold many sessions (e.g. clients built on a shared-resources pool). Drop both to `debug`.

`Session expired` and `Session closed failed` remain at `warn`.