### PR TITLE
feat: rate-adaptive write batching with a bounded per-shard in-flight window

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -115,6 +115,20 @@ public interface OxiaClientBuilder {
     OxiaClientBuilder maxPendingBytes(long maxPendingBytes);
 
     /**
+     * Specify the maximum number of write batches that can be in flight to the server for each shard.
+     *
+     * <p>While a shard's window is exhausted, operations keep accumulating into the shard's open
+     * batch (up to the batch limits) instead of being flushed as new small requests, so the batch
+     * size automatically adapts to the rate at which the server is processing write requests.
+     *
+     * <p>Default is <code>4</code>.
+     *
+     * @param maxWriteBatchesInFlight the maximum number of in-flight write batches per shard
+     * @return the builder instance
+     */
+    OxiaClientBuilder maxWriteBatchesInFlight(int maxWriteBatchesInFlight);
+
+    /**
      * Specify the number of threads dedicated to assembling operation batches, shared by all the
      * shards.
      *

--- a/client/src/main/java/io/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/oxia/client/ClientConfig.java
@@ -27,6 +27,7 @@ public record ClientConfig(
         int maxRequestsPerBatch,
         int maxBatchSize,
         long maxPendingBytes,
+        int maxWriteBatchesInFlight,
         int batchingThreads,
         @NonNull Duration sessionTimeout,
         @NonNull String clientIdentifier,

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -52,6 +52,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     public static final int DefaultMaxRequestsPerBatch = 1000;
     public static final int DefaultMaxBatchSize = 128 * 1024;
     public static final long DefaultMaxPendingBytes = 256L * 1024 * 1024;
+    public static final int DefaultMaxWriteBatchesInFlight = 4;
     public static final int DefaultBatchingThreads = 1;
     public static final Duration DefaultRequestTimeout = Duration.ofSeconds(30);
     public static final Duration DefaultSessionTimeout = Duration.ofSeconds(15);
@@ -69,6 +70,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
 
     protected int maxRequestsPerBatch = DefaultMaxRequestsPerBatch;
     protected long maxPendingBytes = DefaultMaxPendingBytes;
+    protected int maxWriteBatchesInFlight = DefaultMaxWriteBatchesInFlight;
     protected int batchingThreads = DefaultBatchingThreads;
     @NonNull protected Duration sessionTimeout = DefaultSessionTimeout;
 
@@ -136,6 +138,16 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                     "maxPendingBytes must not be negative: " + maxPendingBytes);
         }
         this.maxPendingBytes = maxPendingBytes;
+        return this;
+    }
+
+    @Override
+    public @NonNull OxiaClientBuilder maxWriteBatchesInFlight(int maxWriteBatchesInFlight) {
+        if (maxWriteBatchesInFlight <= 0) {
+            throw new IllegalArgumentException(
+                    "maxWriteBatchesInFlight must be greater than zero: " + maxWriteBatchesInFlight);
+        }
+        this.maxWriteBatchesInFlight = maxWriteBatchesInFlight;
         return this;
     }
 
@@ -355,6 +367,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                 maxRequestsPerBatch,
                 DefaultMaxBatchSize,
                 maxPendingBytes,
+                maxWriteBatchesInFlight,
                 batchingThreads,
                 sessionTimeout,
                 clientIdentifierSupplier.get(),

--- a/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
+++ b/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
@@ -260,6 +260,7 @@ public class SharedResourcesImpl implements SharedResources {
                             OxiaClientBuilderImpl.DefaultMaxRequestsPerBatch,
                             OxiaClientBuilderImpl.DefaultMaxBatchSize,
                             OxiaClientBuilderImpl.DefaultMaxPendingBytes,
+                            OxiaClientBuilderImpl.DefaultMaxWriteBatchesInFlight,
                             batchingThreads,
                             OxiaClientBuilderImpl.DefaultSessionTimeout,
                             "oxia-shared-resources",

--- a/client/src/main/java/io/oxia/client/batch/BatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/BatchFactory.java
@@ -31,4 +31,12 @@ abstract class BatchFactory {
     private final @NonNull ClientConfig config;
 
     public abstract Batch getBatch(long shardId);
+
+    /** The in-flight dispatch window for the given shard, or null when dispatch is unwindowed. */
+    WriteWindow getWriteWindow(long shardId) {
+        return null;
+    }
+
+    /** Fail every batch still held back by this factory's dispatch windows — the client closes. */
+    void failWindows(Throwable error) {}
 }

--- a/client/src/main/java/io/oxia/client/batch/BatchManager.java
+++ b/client/src/main/java/io/oxia/client/batch/BatchManager.java
@@ -62,6 +62,9 @@ public class BatchManager implements AutoCloseable {
             // Shared pool: only tear down this client's pending operations, not the pool.
             pool.closeFactory(factory).join();
         }
+        // Batches held back by the dispatch windows were never handed to the batchers: fail their
+        // operations here so they complete promptly.
+        factory.failWindows(new IllegalStateException("Batch manager is closed"));
     }
 
     public static @NonNull BatchManager newReadBatchManager(

--- a/client/src/main/java/io/oxia/client/batch/Batcher.java
+++ b/client/src/main/java/io/oxia/client/batch/Batcher.java
@@ -144,17 +144,23 @@ final class Batcher implements AutoCloseable {
         try {
             Batch batch = openBatches.get(key);
             if (batch == null) {
-                batch = factory.getBatch(operation.shardId());
+                // Take back a batch parked in the shard's dispatch window, if any: it must keep
+                // accumulating, and stay ahead of newer operations, until a slot frees up.
+                WriteWindow window = factory.getWriteWindow(operation.shardId());
+                batch = window != null ? window.reclaim() : null;
+                if (batch == null) {
+                    batch = factory.getBatch(operation.shardId());
+                }
                 openBatches.put(key, batch);
             }
             if (!batch.canAdd(operation) && batch.size() > 0) {
-                batch.send();
+                send(factory, operation.shardId(), batch);
                 batch = factory.getBatch(operation.shardId());
                 openBatches.put(key, batch);
             }
             batch.add(operation);
             if (batch.size() >= factory.getConfig().maxRequestsPerBatch()) {
-                batch.send();
+                send(factory, operation.shardId(), batch);
                 openBatches.remove(key);
             }
         } catch (Exception e) {
@@ -182,8 +188,29 @@ final class Batcher implements AutoCloseable {
                         });
     }
 
+    // Dispatch a batch that takes no more operations, through the shard's window when it has one.
+    private static void send(BatchFactory factory, long shardId, Batch batch) {
+        WriteWindow window = factory.getWriteWindow(shardId);
+        if (window == null) {
+            batch.send();
+        } else {
+            window.send(batch);
+        }
+    }
+
     private void sendAll() {
-        openBatches.values().forEach(Batch::send);
+        openBatches.forEach(
+                (key, batch) -> {
+                    // If the shard's window is exhausted, the batch is parked instead: it is
+                    // flushed when an in-flight request completes, or reclaimed to accumulate
+                    // more operations.
+                    WriteWindow window = key.factory().getWriteWindow(key.shardId());
+                    if (window == null) {
+                        batch.send();
+                    } else {
+                        window.sendOrPark(batch);
+                    }
+                });
         openBatches.clear();
     }
 

--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -39,6 +39,7 @@ final class WriteBatch extends BatchBase implements Batch {
     final List<Operation.WriteOperation.DeleteRangeOperation> deleteRanges = new ArrayList<>();
 
     private final SessionManager sessionManager;
+    private final WriteWindow window;
     private final int maxBatchSize;
     private int byteSize;
     private long bytes;
@@ -53,6 +54,7 @@ final class WriteBatch extends BatchBase implements Batch {
         super(rpcProvider, shardId);
         this.factory = factory;
         this.sessionManager = sessionManager;
+        this.window = factory.getWriteWindow(shardId);
         this.byteSize = 0;
         this.maxBatchSize = maxBatchSize;
     }
@@ -102,6 +104,9 @@ final class WriteBatch extends BatchBase implements Batch {
                     .send(this::toProto)
                     .whenComplete(
                             (response, ex) -> {
+                                // Free the window slot first, so the next batch is dispatched
+                                // before the operation callbacks below run.
+                                window.release();
                                 if (ex != null) {
                                     handleError(ex);
                                 } else {
@@ -109,6 +114,7 @@ final class WriteBatch extends BatchBase implements Batch {
                                 }
                             });
         } catch (Throwable t) {
+            window.release();
             handleError(t);
         }
     }

--- a/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
@@ -21,12 +21,17 @@ import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.client.metrics.LatencyHistogram;
 import io.oxia.client.session.SessionManager;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import lombok.NonNull;
 
 class WriteBatchFactory extends BatchFactory {
     final @NonNull SessionManager sessionManager;
 
     final LatencyHistogram writeRequestLatencyHistogram;
+
+    // In-flight dispatch window per shard, created lazily on first use.
+    private final ConcurrentMap<Long, WriteWindow> writeWindows = new ConcurrentHashMap<>();
 
     public WriteBatchFactory(
             @NonNull RpcProvider rpcProvider,
@@ -46,5 +51,16 @@ class WriteBatchFactory extends BatchFactory {
     @Override
     public Batch getBatch(long shardId) {
         return new WriteBatch(this, rpcProvider, sessionManager, shardId, getConfig().maxBatchSize());
+    }
+
+    @Override
+    WriteWindow getWriteWindow(long shardId) {
+        return writeWindows.computeIfAbsent(
+                shardId, s -> new WriteWindow(getConfig().maxWriteBatchesInFlight()));
+    }
+
+    @Override
+    void failWindows(Throwable error) {
+        writeWindows.values().forEach(window -> window.fail(error));
     }
 }

--- a/client/src/main/java/io/oxia/client/batch/WriteWindow.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteWindow.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.batch;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Bounded in-flight window for the write batches of one (client, shard) pair.
+ *
+ * <p>The window limits how many write batches may be outstanding on the shard's write stream at any
+ * time, so that batching adapts to the rate at which the server is servicing requests: while the
+ * window is exhausted, the shard's open batch keeps accumulating operations (up to the batch
+ * limits) instead of being flushed as a new tiny request. A fast server keeps the window open and
+ * batches stay small, minimizing latency; a saturated server exhausts the window and batches grow,
+ * maximizing throughput.
+ *
+ * <p>No method ever blocks: the batcher thread is shared with other shards and clients, so a slow
+ * shard must not stall it. Batches that cannot be dispatched are held back — full batches in a FIFO
+ * queue, the open batch in a single parked slot — and dispatched by {@link #release} as in-flight
+ * batches complete. The batcher parks the open batch only when it goes idle, and takes it back
+ * through {@link #reclaim} before opening a new batch for the shard, so the parked batch always
+ * carries the youngest operations and dispatch order matches submission order.
+ */
+final class WriteWindow {
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final int maxBatchesInFlight;
+    private int batchesInFlight;
+
+    // Full batches waiting for a slot, oldest first.
+    private final ArrayDeque<Batch> readyBatches = new ArrayDeque<>();
+
+    // Open batch parked at idle, awaiting either a slot or more operations.
+    private Batch parkedBatch;
+
+    WriteWindow(int maxBatchesInFlight) {
+        this.maxBatchesInFlight = maxBatchesInFlight;
+    }
+
+    /** Dispatch a batch that accepts no more operations, queueing it if the window is exhausted. */
+    void send(Batch batch) {
+        lock.lock();
+        try {
+            if (batchesInFlight >= maxBatchesInFlight) {
+                readyBatches.addLast(batch);
+                return;
+            }
+            batchesInFlight++;
+        } finally {
+            lock.unlock();
+        }
+        batch.send();
+    }
+
+    /**
+     * Dispatch the open batch if the window has a free slot, otherwise park it. A parked batch is
+     * either flushed by {@link #release} when an in-flight batch completes, or taken back by the
+     * batcher through {@link #reclaim} to accumulate more operations.
+     */
+    void sendOrPark(Batch batch) {
+        lock.lock();
+        try {
+            if (batchesInFlight >= maxBatchesInFlight) {
+                parkedBatch = batch;
+                return;
+            }
+            batchesInFlight++;
+        } finally {
+            lock.unlock();
+        }
+        batch.send();
+    }
+
+    /** Take back the parked batch, if it has not been flushed yet. */
+    Batch reclaim() {
+        lock.lock();
+        try {
+            Batch batch = parkedBatch;
+            parkedBatch = null;
+            return batch;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Return the slot of a completed batch, dispatching the oldest queued batch, or, when none is
+     * queued, flushing the parked batch.
+     */
+    void release() {
+        lock.lock();
+        try {
+            batchesInFlight--;
+            Batch next = readyBatches.pollFirst();
+            if (next == null) {
+                next = parkedBatch;
+                parkedBatch = null;
+            }
+            if (next != null) {
+                batchesInFlight++;
+                // Send while holding the lock: a slot freed concurrently must not let the batcher
+                // dispatch a newer batch ahead of this one on the write stream.
+                next.send();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Fail every batch that is still held back — the owning client is closing. */
+    void fail(Throwable error) {
+        List<Batch> toFail;
+        lock.lock();
+        try {
+            toFail = new ArrayList<>(readyBatches);
+            readyBatches.clear();
+            if (parkedBatch != null) {
+                toFail.add(parkedBatch);
+                parkedBatch = null;
+            }
+        } finally {
+            lock.unlock();
+        }
+        toFail.forEach(batch -> batch.fail(error));
+    }
+}

--- a/client/src/test/java/io/oxia/client/batch/BatchManagerTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchManagerTest.java
@@ -50,6 +50,7 @@ class BatchManagerTest {
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,
+                    4,
                     2,
                     Duration.ofMillis(1000),
                     "client_id",
@@ -110,5 +111,11 @@ class BatchManagerTest {
     void addAfterCloseThrows() throws Exception {
         manager.close();
         assertThatThrownBy(() -> manager.add(newOp(1L))).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void closeFailsWindowHeldBatches() throws Exception {
+        manager.close();
+        verify(batchFactory).failWindows(any(IllegalStateException.class));
     }
 }

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -28,6 +28,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.CallCredentials;
@@ -102,6 +104,7 @@ class BatchTest {
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,
+                    4,
                     1,
                     Duration.ofMillis(1000),
                     "client_id",
@@ -432,6 +435,101 @@ class BatchTest {
         public void shardId() {
             assertThat(batch.getShardId()).isEqualTo(shardId);
         }
+
+        // Config with a single-slot in-flight window, to exercise the dispatch window.
+        private WriteBatchFactory factoryWithWindow() {
+            var windowConfig =
+                    new ClientConfig(
+                            "address",
+                            Duration.ofMillis(100),
+                            10,
+                            1024 * 1024,
+                            256L * 1024 * 1024,
+                            1,
+                            1,
+                            Duration.ofMillis(1000),
+                            "client_id",
+                            null,
+                            OxiaClientBuilderImpl.DefaultNamespace,
+                            authentication,
+                            authentication != null,
+                            Duration.ofMillis(100),
+                            Duration.ofSeconds(30),
+                            Duration.ofSeconds(10),
+                            Duration.ofSeconds(5),
+                            1);
+            return new WriteBatchFactory(
+                    mock(RpcProvider.class),
+                    mock(SessionManager.class),
+                    windowConfig,
+                    InstrumentProvider.NOOP);
+        }
+
+        @Test
+        public void releasesWindowSlotOnResponse() {
+            var factory = factoryWithWindow();
+            var window = factory.getWriteWindow(shardId);
+            batch = new WriteBatch(factory, clientByShardId, sessionManager, shardId, 1024 * 1024);
+            batch.add(put);
+
+            var responseFuture = new CompletableFuture<WriteResponse>();
+            when(writeStream.send(any())).thenReturn(responseFuture);
+
+            // The dispatched batch holds the only window slot: the next batch parks.
+            window.send(batch);
+            var parked = mock(Batch.class);
+            window.sendOrPark(parked);
+            verify(parked, never()).send();
+
+            var resp = new WriteResponse();
+            resp.addPut().setStatus(OK).setVersion();
+            responseFuture.complete(resp);
+
+            // Completing the in-flight batch released the slot and flushed the parked batch.
+            verify(parked).send();
+            assertThat(putCallable).isCompleted();
+        }
+
+        @Test
+        public void releasesWindowSlotOnFailure() {
+            var factory = factoryWithWindow();
+            var window = factory.getWriteWindow(shardId);
+            batch = new WriteBatch(factory, clientByShardId, sessionManager, shardId, 1024 * 1024);
+            batch.add(put);
+
+            var responseFuture = new CompletableFuture<WriteResponse>();
+            when(writeStream.send(any())).thenReturn(responseFuture);
+
+            window.send(batch);
+            var parked = mock(Batch.class);
+            window.sendOrPark(parked);
+            verify(parked, never()).send();
+
+            responseFuture.completeExceptionally(Status.UNAVAILABLE.asRuntimeException());
+
+            verify(parked).send();
+            assertThat(putCallable).isCompletedExceptionally();
+        }
+
+        @Test
+        public void releasesWindowSlotOnSynchronousFailure() {
+            var rpcProvider = mock(RpcProvider.class);
+            when(rpcProvider.getWriteStream(shardId))
+                    .thenThrow(OxiaStatusException.shardNotFound(shardId));
+
+            var factory = factoryWithWindow();
+            var window = factory.getWriteWindow(shardId);
+            batch = new WriteBatch(factory, rpcProvider, sessionManager, shardId, 1024 * 1024);
+            batch.add(put);
+
+            window.send(batch);
+            assertThat(putCallable).isCompletedExceptionally();
+
+            // The slot was released despite the dispatch failing synchronously.
+            var next = mock(Batch.class);
+            window.sendOrPark(next);
+            verify(next).send();
+        }
     }
 
     @Nested
@@ -551,6 +649,7 @@ class BatchTest {
                         1,
                         1024 * 1024,
                         256L * 1024 * 1024,
+                        4,
                         1,
                         ZERO,
                         "client_id",

--- a/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
@@ -51,6 +51,7 @@ class BatcherPoolTest {
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,
+                    4,
                     1,
                     Duration.ofMillis(1000),
                     "client_id",

--- a/client/src/test/java/io/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherTest.java
@@ -20,6 +20,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,6 +52,7 @@ class BatcherTest {
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,
+                    4,
                     1,
                     Duration.ofMillis(1000),
                     "client_id",
@@ -197,5 +199,97 @@ class BatcherTest {
         var op = newOp(1L);
         add(op);
         assertThat(op.callback()).isCompletedExceptionally();
+    }
+
+    @Test
+    void accumulatesIntoOpenBatchWhileWindowExhausted() {
+        var window = new WriteWindow(1);
+        var batch2 = mock(Batch.class);
+        when(batchFactory.getConfig()).thenReturn(config);
+        when(batchFactory.getWriteWindow(1L)).thenReturn(window);
+        when(batchFactory.getBatch(1L)).thenReturn(batch, batch2);
+        when(batch.canAdd(any())).thenReturn(true);
+        when(batch.size()).thenReturn(1);
+        when(batch2.canAdd(any())).thenReturn(true);
+        when(batch2.size()).thenReturn(1, 2);
+
+        var op = newOp(1L);
+        // The first batch is flushed immediately and takes the only window slot.
+        add(op);
+        await().untilAsserted(() -> verify(batch).send());
+
+        // Window exhausted: operations accumulate into the open batch instead of being flushed.
+        add(op);
+        add(op);
+        await().untilAsserted(() -> verify(batch2, times(2)).add(op));
+        verify(batch2, never()).send();
+
+        // Completing the in-flight batch frees the slot and flushes the accumulated batch.
+        window.release();
+        await().untilAsserted(() -> verify(batch2).send());
+    }
+
+    @Test
+    void fullBatchIsQueuedWhileWindowExhausted() {
+        var window = new WriteWindow(1);
+        var batch2 = mock(Batch.class);
+        var batch3 = mock(Batch.class);
+        when(batchFactory.getConfig()).thenReturn(config);
+        when(batchFactory.getWriteWindow(1L)).thenReturn(window);
+        when(batchFactory.getBatch(1L)).thenReturn(batch, batch2, batch3);
+        when(batch.canAdd(any())).thenReturn(true);
+        when(batch.size()).thenReturn(1);
+        when(batch2.canAdd(any())).thenReturn(true);
+        when(batch2.size()).thenReturn(config.maxRequestsPerBatch());
+        when(batch3.canAdd(any())).thenReturn(true);
+        when(batch3.size()).thenReturn(1);
+
+        var op = newOp(1L);
+        add(op);
+        await().untilAsserted(() -> verify(batch).send());
+
+        // A batch that fills up while the window is exhausted is queued, not dispatched...
+        add(op);
+        await().untilAsserted(() -> verify(batch2).add(op));
+        verify(batch2, never()).send();
+
+        // ...and the batcher thread moves on to later operations without blocking.
+        add(op);
+        await().untilAsserted(() -> verify(batch3).add(op));
+        verify(batch3, never()).send();
+
+        // Freed slots dispatch the queued full batch first, then the parked open batch.
+        window.release();
+        await().untilAsserted(() -> verify(batch2).send());
+        verify(batch3, never()).send();
+        window.release();
+        await().untilAsserted(() -> verify(batch3).send());
+    }
+
+    @Test
+    void exhaustedWindowDoesNotBlockOtherShards() {
+        var window1 = new WriteWindow(1);
+        var window2 = new WriteWindow(1);
+        var shard2Batch = mock(Batch.class);
+        when(batchFactory.getConfig()).thenReturn(config);
+        when(batchFactory.getWriteWindow(1L)).thenReturn(window1);
+        when(batchFactory.getWriteWindow(2L)).thenReturn(window2);
+        when(batchFactory.getBatch(1L)).thenReturn(batch);
+        when(batchFactory.getBatch(2L)).thenReturn(shard2Batch);
+        when(batch.canAdd(any())).thenReturn(true);
+        when(batch.size()).thenReturn(1, 2);
+        when(shard2Batch.canAdd(any())).thenReturn(true);
+        when(shard2Batch.size()).thenReturn(1);
+
+        // Exhaust shard 1's window: the first batch holds the only slot, the second one parks.
+        add(newOp(1L));
+        await().untilAsserted(() -> verify(batch).send());
+        add(newOp(1L));
+        await().untilAsserted(() -> verify(batch, times(2)).add(any()));
+
+        // Shard 2 flows on the same batcher thread: its own window has a free slot.
+        add(newOp(2L));
+        await().untilAsserted(() -> verify(shard2Batch).send());
+        verify(batch, times(1)).send();
     }
 }

--- a/client/src/test/java/io/oxia/client/batch/WriteWindowTest.java
+++ b/client/src/test/java/io/oxia/client/batch/WriteWindowTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+class WriteWindowTest {
+
+    @Test
+    void dispatchesWhileWindowHasSlots() {
+        var window = new WriteWindow(2);
+        var batch1 = mock(Batch.class);
+        var batch2 = mock(Batch.class);
+
+        window.send(batch1);
+        window.send(batch2);
+
+        verify(batch1).send();
+        verify(batch2).send();
+    }
+
+    @Test
+    void queuesFullBatchesWhileExhaustedAndDispatchesInOrder() {
+        var window = new WriteWindow(1);
+        var batch1 = mock(Batch.class);
+        var batch2 = mock(Batch.class);
+        var batch3 = mock(Batch.class);
+
+        window.send(batch1);
+        window.send(batch2);
+        window.send(batch3);
+        verify(batch1).send();
+        verify(batch2, never()).send();
+        verify(batch3, never()).send();
+
+        window.release();
+        verify(batch2).send();
+        verify(batch3, never()).send();
+
+        window.release();
+        verify(batch3).send();
+    }
+
+    @Test
+    void sendOrParkDispatchesWhenSlotAvailable() {
+        var window = new WriteWindow(1);
+        var batch = mock(Batch.class);
+
+        window.sendOrPark(batch);
+
+        verify(batch).send();
+    }
+
+    @Test
+    void releaseFlushesParkedBatch() {
+        var window = new WriteWindow(1);
+        var batch1 = mock(Batch.class);
+        var batch2 = mock(Batch.class);
+
+        window.send(batch1);
+        window.sendOrPark(batch2);
+        verify(batch2, never()).send();
+
+        window.release();
+        verify(batch2).send();
+
+        // The parked batch consumed the released slot: the window is still exhausted.
+        var batch3 = mock(Batch.class);
+        window.sendOrPark(batch3);
+        verify(batch3, never()).send();
+    }
+
+    @Test
+    void parkedBatchFlushedAfterQueuedBatches() {
+        var window = new WriteWindow(1);
+        var inflight = mock(Batch.class);
+        var full = mock(Batch.class);
+        var open = mock(Batch.class);
+
+        window.send(inflight);
+        window.send(full); // queued: full batch
+        window.sendOrPark(open); // parked: open batch, younger operations
+
+        window.release();
+        verify(full).send();
+        verify(open, never()).send();
+
+        window.release();
+        verify(open).send();
+    }
+
+    @Test
+    void reclaimTakesBackParkedBatch() {
+        var window = new WriteWindow(1);
+        var batch1 = mock(Batch.class);
+        var batch2 = mock(Batch.class);
+
+        window.send(batch1);
+        window.sendOrPark(batch2);
+
+        assertThat(window.reclaim()).isSameAs(batch2);
+        assertThat(window.reclaim()).isNull();
+
+        // A reclaimed batch is not flushed when a slot is released...
+        window.release();
+        verify(batch2, never()).send();
+
+        // ...and the freed slot is available for the next dispatch.
+        window.sendOrPark(batch2);
+        verify(batch2).send();
+    }
+
+    @Test
+    void failsHeldBackBatches() {
+        var window = new WriteWindow(1);
+        var inflight = mock(Batch.class);
+        var full = mock(Batch.class);
+        var open = mock(Batch.class);
+
+        window.send(inflight);
+        window.send(full);
+        window.sendOrPark(open);
+
+        var error = new IllegalStateException("Batch manager is closed");
+        window.fail(error);
+        verify(full).fail(error);
+        verify(open).fail(error);
+        verify(full, never()).send();
+        verify(open, never()).send();
+
+        // Slots released afterwards have nothing left to dispatch.
+        window.release();
+        verify(full, never()).send();
+        verify(open, never()).send();
+    }
+}

--- a/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
@@ -64,6 +64,7 @@ class SessionManagerTest {
                         1,
                         1024,
                         256L * 1024 * 1024,
+                        4,
                         1,
                         Duration.ofSeconds(10),
                         "client",

--- a/client/src/test/java/io/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionTest.java
@@ -72,6 +72,7 @@ class SessionTest {
                         1,
                         1024 * 1024,
                         256L * 1024 * 1024,
+                        4,
                         1,
                         sessionTimeout,
                         clientId,


### PR DESCRIPTION
### Problem

Write batching never adapts to the server's service rate, because there is no backpressure between the write stream and the batcher:

- `ManagedWriteStream.send()` never pushes back: it appends to the unbounded `inflightWrites` deque and writes straight to the gRPC stream.
- The batcher flushes every open batch (`sendAll()`) as soon as the command queue is momentarily empty. Since dispatch is non-blocking and cheap, a full cycle is sub-millisecond and batch size equilibrates at arrivals-per-cycle — it adapts to the batcher thread's speed, never to the server's.

On a real 3-node cluster (RF=3), server-side `oxia_server_kv_batch_count` shows writes arriving in batches of ~4.5 puts regardless of load, despite `maxRequestsPerBatch=1000`. The write path is then bound by per-shard serialized replication rounds (~2.1k rounds/s, ~0.5 ms each) carrying almost no work: the cluster caps at ~56–63k writes/s while server CPU is at ~70% of 2 cores and disks are ~25% utilized. With high in-flight counts, client p50 write latency reaches seconds — pure queueing in the unbounded deque.

### Fix

Bounded in-flight window per (client, shard): at most `maxWriteBatchesInFlight` (new builder option, default 4) write batches may be outstanding on a shard's write stream. When the window is exhausted, the shard's open batch keeps accumulating operations instead of being flushed, so batch size automatically tracks the server's service rate: a fast server keeps the window open and batches stay small (low latency); a saturated server exhausts the window and batches grow toward `maxRequestsPerBatch` (max throughput).

The window never blocks the batcher thread, which is shared across shards and clients (`BatcherPool`):

- A batch that fills up while the window is exhausted is queued FIFO inside the window; the batcher moves on.
- The open batch parks in a single slot at idle; the batcher reclaims it (before opening any newer batch, preserving dispatch order) to keep accumulating.
- Completion of an in-flight request dispatches the next held-back batch, oldest first, under the window lock so a concurrently freed slot cannot reorder dispatches on the stream.
- On client close, batches still held back by windows are failed promptly, matching the existing close semantics for open batches.

Held-back batches are bounded upstream by the existing `maxPendingBytes` limit.

### Validation

Loopback A/B (`oxia standalone`, insert-only, 64-byte values, 8 workers × 10k outstanding), measuring the same server-side `oxia_server_kv_batch_count` metric:

| | v0.9.2 | this PR |
|---|---|---|
| ops per storage commit | 11.9 (716k commits) | **1,003** (7.8k commits, ~84× fewer rounds) |
| write throughput | 181.0k w/s | **224.1k w/s** |
| write p99 / p99.9 / max | 248.5 / 404 / 415 ms | **87.7 / 147 / 150 ms** |

The full YCSB throughput suite also improved in every phase on loopback (mixed and read-heavy phases 2–3×, as reads stop queueing behind floods of tiny write requests), with no regression anywhere. On the real cluster the ~84× reduction in replication rounds per operation is what removes the rounds/s ceiling before CPU/disk saturate.

Unit tests cover the window semantics (FIFO dispatch order, parking/reclaiming, slot release on response/failure/synchronous failure, per-shard independence on a shared batcher thread, close cleanup).
