### PR TITLE
feat: rate-adaptive read batching with a bounded per-shard in-flight window

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -129,6 +129,20 @@ public interface OxiaClientBuilder {
     OxiaClientBuilder maxWriteBatchesInFlight(int maxWriteBatchesInFlight);
 
     /**
+     * Specify the maximum number of read batches that can be in flight to the server for each shard.
+     *
+     * <p>While a shard's window is exhausted, operations keep accumulating into the shard's open
+     * batch (up to the batch limits) instead of being flushed as new small requests, so the batch
+     * size automatically adapts to the rate at which the server is processing read requests.
+     *
+     * <p>Default is <code>4</code>.
+     *
+     * @param maxReadBatchesInFlight the maximum number of in-flight read batches per shard
+     * @return the builder instance
+     */
+    OxiaClientBuilder maxReadBatchesInFlight(int maxReadBatchesInFlight);
+
+    /**
      * Specify the number of threads dedicated to assembling operation batches, shared by all the
      * shards.
      *

--- a/client/src/main/java/io/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/oxia/client/ClientConfig.java
@@ -28,6 +28,7 @@ public record ClientConfig(
         int maxBatchSize,
         long maxPendingBytes,
         int maxWriteBatchesInFlight,
+        int maxReadBatchesInFlight,
         int batchingThreads,
         @NonNull Duration sessionTimeout,
         @NonNull String clientIdentifier,

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -53,6 +53,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     public static final int DefaultMaxBatchSize = 128 * 1024;
     public static final long DefaultMaxPendingBytes = 256L * 1024 * 1024;
     public static final int DefaultMaxWriteBatchesInFlight = 4;
+    public static final int DefaultMaxReadBatchesInFlight = 4;
     public static final int DefaultBatchingThreads = 1;
     public static final Duration DefaultRequestTimeout = Duration.ofSeconds(30);
     public static final Duration DefaultSessionTimeout = Duration.ofSeconds(15);
@@ -71,6 +72,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     protected int maxRequestsPerBatch = DefaultMaxRequestsPerBatch;
     protected long maxPendingBytes = DefaultMaxPendingBytes;
     protected int maxWriteBatchesInFlight = DefaultMaxWriteBatchesInFlight;
+    protected int maxReadBatchesInFlight = DefaultMaxReadBatchesInFlight;
     protected int batchingThreads = DefaultBatchingThreads;
     @NonNull protected Duration sessionTimeout = DefaultSessionTimeout;
 
@@ -148,6 +150,16 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                     "maxWriteBatchesInFlight must be greater than zero: " + maxWriteBatchesInFlight);
         }
         this.maxWriteBatchesInFlight = maxWriteBatchesInFlight;
+        return this;
+    }
+
+    @Override
+    public @NonNull OxiaClientBuilder maxReadBatchesInFlight(int maxReadBatchesInFlight) {
+        if (maxReadBatchesInFlight <= 0) {
+            throw new IllegalArgumentException(
+                    "maxReadBatchesInFlight must be greater than zero: " + maxReadBatchesInFlight);
+        }
+        this.maxReadBatchesInFlight = maxReadBatchesInFlight;
         return this;
     }
 
@@ -368,6 +380,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                 DefaultMaxBatchSize,
                 maxPendingBytes,
                 maxWriteBatchesInFlight,
+                maxReadBatchesInFlight,
                 batchingThreads,
                 sessionTimeout,
                 clientIdentifierSupplier.get(),

--- a/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
+++ b/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
@@ -261,6 +261,7 @@ public class SharedResourcesImpl implements SharedResources {
                             OxiaClientBuilderImpl.DefaultMaxBatchSize,
                             OxiaClientBuilderImpl.DefaultMaxPendingBytes,
                             OxiaClientBuilderImpl.DefaultMaxWriteBatchesInFlight,
+                            OxiaClientBuilderImpl.DefaultMaxReadBatchesInFlight,
                             batchingThreads,
                             OxiaClientBuilderImpl.DefaultSessionTimeout,
                             "oxia-shared-resources",

--- a/client/src/main/java/io/oxia/client/batch/BatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/BatchFactory.java
@@ -33,7 +33,7 @@ abstract class BatchFactory {
     public abstract Batch getBatch(long shardId);
 
     /** The in-flight dispatch window for the given shard, or null when dispatch is unwindowed. */
-    WriteWindow getWriteWindow(long shardId) {
+    DispatchWindow getDispatchWindow(long shardId) {
         return null;
     }
 

--- a/client/src/main/java/io/oxia/client/batch/Batcher.java
+++ b/client/src/main/java/io/oxia/client/batch/Batcher.java
@@ -146,7 +146,7 @@ final class Batcher implements AutoCloseable {
             if (batch == null) {
                 // Take back a batch parked in the shard's dispatch window, if any: it must keep
                 // accumulating, and stay ahead of newer operations, until a slot frees up.
-                WriteWindow window = factory.getWriteWindow(operation.shardId());
+                DispatchWindow window = factory.getDispatchWindow(operation.shardId());
                 batch = window != null ? window.reclaim() : null;
                 if (batch == null) {
                     batch = factory.getBatch(operation.shardId());
@@ -190,7 +190,7 @@ final class Batcher implements AutoCloseable {
 
     // Dispatch a batch that takes no more operations, through the shard's window when it has one.
     private static void send(BatchFactory factory, long shardId, Batch batch) {
-        WriteWindow window = factory.getWriteWindow(shardId);
+        DispatchWindow window = factory.getDispatchWindow(shardId);
         if (window == null) {
             batch.send();
         } else {
@@ -204,7 +204,7 @@ final class Batcher implements AutoCloseable {
                     // If the shard's window is exhausted, the batch is parked instead: it is
                     // flushed when an in-flight request completes, or reclaimed to accumulate
                     // more operations.
-                    WriteWindow window = key.factory().getWriteWindow(key.shardId());
+                    DispatchWindow window = key.factory().getDispatchWindow(key.shardId());
                     if (window == null) {
                         batch.send();
                     } else {

--- a/client/src/main/java/io/oxia/client/batch/DispatchWindow.java
+++ b/client/src/main/java/io/oxia/client/batch/DispatchWindow.java
@@ -21,14 +21,14 @@ import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Bounded in-flight window for the write batches of one (client, shard) pair.
+ * Bounded in-flight window for the batches of one (client, shard) pair.
  *
- * <p>The window limits how many write batches may be outstanding on the shard's write stream at any
- * time, so that batching adapts to the rate at which the server is servicing requests: while the
- * window is exhausted, the shard's open batch keeps accumulating operations (up to the batch
- * limits) instead of being flushed as a new tiny request. A fast server keeps the window open and
- * batches stay small, minimizing latency; a saturated server exhausts the window and batches grow,
- * maximizing throughput.
+ * <p>The window limits how many batches may be outstanding to the server at any time, so that
+ * batching adapts to the rate at which the server is servicing requests: while the window is
+ * exhausted, the shard's open batch keeps accumulating operations (up to the batch limits) instead
+ * of being flushed as a new tiny request. A fast server keeps the window open and batches stay
+ * small, minimizing latency; a saturated server exhausts the window and batches grow, maximizing
+ * throughput.
  *
  * <p>No method ever blocks: the batcher thread is shared with other shards and clients, so a slow
  * shard must not stall it. Batches that cannot be dispatched are held back — full batches in a FIFO
@@ -37,7 +37,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * through {@link #reclaim} before opening a new batch for the shard, so the parked batch always
  * carries the youngest operations and dispatch order matches submission order.
  */
-final class WriteWindow {
+final class DispatchWindow {
 
     private final ReentrantLock lock = new ReentrantLock();
     private final int maxBatchesInFlight;
@@ -49,7 +49,7 @@ final class WriteWindow {
     // Open batch parked at idle, awaiting either a slot or more operations.
     private Batch parkedBatch;
 
-    WriteWindow(int maxBatchesInFlight) {
+    DispatchWindow(int maxBatchesInFlight) {
         this.maxBatchesInFlight = maxBatchesInFlight;
     }
 
@@ -115,7 +115,7 @@ final class WriteWindow {
             if (next != null) {
                 batchesInFlight++;
                 // Send while holding the lock: a slot freed concurrently must not let the batcher
-                // dispatch a newer batch ahead of this one on the write stream.
+                // dispatch a newer batch ahead of this one.
                 next.send();
             }
         } finally {

--- a/client/src/main/java/io/oxia/client/batch/ReadBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatch.java
@@ -32,12 +32,14 @@ final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadRes
 
     @VisibleForTesting final List<Operation.ReadOperation.GetOperation> gets = new ArrayList<>();
 
+    private final DispatchWindow window;
     private int responseIndex = 0;
     long startSendTimeNanos;
 
     ReadBatch(ReadBatchFactory factory, RpcProvider rpcProvider, long shardId) {
         super(rpcProvider, shardId);
         this.factory = factory;
+        this.window = factory.getDispatchWindow(shardId);
     }
 
     @Override
@@ -83,12 +85,16 @@ final class ReadBatch extends BatchBase implements Batch, StreamObserver<ReadRes
 
     @Override
     public void onError(Throwable batchError) {
+        // Free the window slot first, so the next batch is dispatched before the operation
+        // callbacks below run.
+        window.release();
         fail(batchError);
         factory.getReadRequestLatencyHistogram().recordFailure(System.nanoTime() - startSendTimeNanos);
     }
 
     @Override
     public void onCompleted() {
+        window.release();
         // complete pending request if the server close stream without any response
         gets.forEach(
                 g -> {

--- a/client/src/main/java/io/oxia/client/batch/ReadBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/ReadBatchFactory.java
@@ -20,12 +20,17 @@ import io.oxia.client.ClientConfig;
 import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.client.metrics.LatencyHistogram;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import lombok.Getter;
 import lombok.NonNull;
 
 class ReadBatchFactory extends BatchFactory {
 
     @Getter private final LatencyHistogram readRequestLatencyHistogram;
+
+    // In-flight dispatch window per shard, created lazily on first use.
+    private final ConcurrentMap<Long, DispatchWindow> windows = new ConcurrentHashMap<>();
 
     public ReadBatchFactory(
             @NonNull RpcProvider rpcProvider,
@@ -43,5 +48,16 @@ class ReadBatchFactory extends BatchFactory {
     @Override
     public Batch getBatch(long shardId) {
         return new ReadBatch(this, rpcProvider, shardId);
+    }
+
+    @Override
+    DispatchWindow getDispatchWindow(long shardId) {
+        return windows.computeIfAbsent(
+                shardId, s -> new DispatchWindow(getConfig().maxReadBatchesInFlight()));
+    }
+
+    @Override
+    void failWindows(Throwable error) {
+        windows.values().forEach(window -> window.fail(error));
     }
 }

--- a/client/src/main/java/io/oxia/client/batch/WriteBatch.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatch.java
@@ -39,7 +39,7 @@ final class WriteBatch extends BatchBase implements Batch {
     final List<Operation.WriteOperation.DeleteRangeOperation> deleteRanges = new ArrayList<>();
 
     private final SessionManager sessionManager;
-    private final WriteWindow window;
+    private final DispatchWindow window;
     private final int maxBatchSize;
     private int byteSize;
     private long bytes;
@@ -54,7 +54,7 @@ final class WriteBatch extends BatchBase implements Batch {
         super(rpcProvider, shardId);
         this.factory = factory;
         this.sessionManager = sessionManager;
-        this.window = factory.getWriteWindow(shardId);
+        this.window = factory.getDispatchWindow(shardId);
         this.byteSize = 0;
         this.maxBatchSize = maxBatchSize;
     }

--- a/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
+++ b/client/src/main/java/io/oxia/client/batch/WriteBatchFactory.java
@@ -31,7 +31,7 @@ class WriteBatchFactory extends BatchFactory {
     final LatencyHistogram writeRequestLatencyHistogram;
 
     // In-flight dispatch window per shard, created lazily on first use.
-    private final ConcurrentMap<Long, WriteWindow> writeWindows = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, DispatchWindow> windows = new ConcurrentHashMap<>();
 
     public WriteBatchFactory(
             @NonNull RpcProvider rpcProvider,
@@ -54,13 +54,13 @@ class WriteBatchFactory extends BatchFactory {
     }
 
     @Override
-    WriteWindow getWriteWindow(long shardId) {
-        return writeWindows.computeIfAbsent(
-                shardId, s -> new WriteWindow(getConfig().maxWriteBatchesInFlight()));
+    DispatchWindow getDispatchWindow(long shardId) {
+        return windows.computeIfAbsent(
+                shardId, s -> new DispatchWindow(getConfig().maxWriteBatchesInFlight()));
     }
 
     @Override
     void failWindows(Throwable error) {
-        writeWindows.values().forEach(window -> window.fail(error));
+        windows.values().forEach(window -> window.fail(error));
     }
 }

--- a/client/src/test/java/io/oxia/client/batch/BatchManagerTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchManagerTest.java
@@ -51,6 +51,7 @@ class BatchManagerTest {
                     1024 * 1024,
                     256L * 1024 * 1024,
                     4,
+                    4,
                     2,
                     Duration.ofMillis(1000),
                     "client_id",

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -76,6 +76,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -104,6 +105,7 @@ class BatchTest {
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,
+                    4,
                     4,
                     1,
                     Duration.ofMillis(1000),
@@ -446,6 +448,7 @@ class BatchTest {
                             1024 * 1024,
                             256L * 1024 * 1024,
                             1,
+                            4,
                             1,
                             Duration.ofMillis(1000),
                             "client_id",
@@ -468,7 +471,7 @@ class BatchTest {
         @Test
         public void releasesWindowSlotOnResponse() {
             var factory = factoryWithWindow();
-            var window = factory.getWriteWindow(shardId);
+            var window = factory.getDispatchWindow(shardId);
             batch = new WriteBatch(factory, clientByShardId, sessionManager, shardId, 1024 * 1024);
             batch.add(put);
 
@@ -493,7 +496,7 @@ class BatchTest {
         @Test
         public void releasesWindowSlotOnFailure() {
             var factory = factoryWithWindow();
-            var window = factory.getWriteWindow(shardId);
+            var window = factory.getDispatchWindow(shardId);
             batch = new WriteBatch(factory, clientByShardId, sessionManager, shardId, 1024 * 1024);
             batch.add(put);
 
@@ -518,7 +521,7 @@ class BatchTest {
                     .thenThrow(OxiaStatusException.shardNotFound(shardId));
 
             var factory = factoryWithWindow();
-            var window = factory.getWriteWindow(shardId);
+            var window = factory.getDispatchWindow(shardId);
             batch = new WriteBatch(factory, rpcProvider, sessionManager, shardId, 1024 * 1024);
             batch.add(put);
 
@@ -637,6 +640,101 @@ class BatchTest {
         public void shardId() {
             assertThat(batch.getShardId()).isEqualTo(shardId);
         }
+
+        // Config with a single-slot in-flight window, to exercise the dispatch window.
+        private ReadBatchFactory factoryWithWindow() {
+            var windowConfig =
+                    new ClientConfig(
+                            "address",
+                            Duration.ofMillis(100),
+                            10,
+                            1024 * 1024,
+                            256L * 1024 * 1024,
+                            4,
+                            1,
+                            1,
+                            Duration.ofMillis(1000),
+                            "client_id",
+                            null,
+                            OxiaClientBuilderImpl.DefaultNamespace,
+                            authentication,
+                            authentication != null,
+                            Duration.ofMillis(100),
+                            Duration.ofSeconds(30),
+                            Duration.ofSeconds(10),
+                            Duration.ofSeconds(5),
+                            1);
+            return new ReadBatchFactory(mock(RpcProvider.class), windowConfig, InstrumentProvider.NOOP);
+        }
+
+        @Test
+        public void releasesWindowSlotOnResponse() {
+            var factory = factoryWithWindow();
+            var window = factory.getDispatchWindow(shardId);
+            batch = new ReadBatch(factory, clientByShardId, shardId);
+            batch.add(get);
+
+            // Capture the server-side stream so the batch stays in flight until we respond.
+            var serverObserver = new AtomicReference<StreamObserver<ReadResponse>>();
+            readResponses.add(serverObserver::set);
+
+            // The dispatched batch holds the only window slot: the next batch parks.
+            window.send(batch);
+            var parked = mock(Batch.class);
+            window.sendOrPark(parked);
+            verify(parked, never()).send();
+
+            var resp = new ReadResponse();
+            resp.addGet().setStatus(KEY_NOT_FOUND);
+            serverObserver.get().onNext(resp);
+            serverObserver.get().onCompleted();
+
+            // Completing the in-flight batch released the slot and flushed the parked batch.
+            verify(parked).send();
+            assertThat(getCallable).isCompletedWithValueMatching(Objects::isNull);
+        }
+
+        @Test
+        public void releasesWindowSlotOnFailure() {
+            var factory = factoryWithWindow();
+            var window = factory.getDispatchWindow(shardId);
+            batch = new ReadBatch(factory, clientByShardId, shardId);
+            batch.add(get);
+
+            var serverObserver = new AtomicReference<StreamObserver<ReadResponse>>();
+            readResponses.add(serverObserver::set);
+
+            window.send(batch);
+            var parked = mock(Batch.class);
+            window.sendOrPark(parked);
+            verify(parked, never()).send();
+
+            serverObserver.get().onError(Status.UNAVAILABLE.asRuntimeException());
+
+            verify(parked).send();
+            assertThat(getCallable).isCompletedExceptionally();
+        }
+
+        @Test
+        public void releasesWindowSlotOnSynchronousFailure() {
+            var rpcProvider = mock(RpcProvider.class);
+            doThrow(OxiaStatusException.shardNotFound(shardId))
+                    .when(rpcProvider)
+                    .read(any(ReadRequest.class), any(StreamObserver.class));
+
+            var factory = factoryWithWindow();
+            var window = factory.getDispatchWindow(shardId);
+            batch = new ReadBatch(factory, rpcProvider, shardId);
+            batch.add(get);
+
+            window.send(batch);
+            assertThat(getCallable).isCompletedExceptionally();
+
+            // The slot was released despite the dispatch failing synchronously.
+            var next = mock(Batch.class);
+            window.sendOrPark(next);
+            verify(next).send();
+        }
     }
 
     @Nested
@@ -649,6 +747,7 @@ class BatchTest {
                         1,
                         1024 * 1024,
                         256L * 1024 * 1024,
+                        4,
                         4,
                         1,
                         ZERO,

--- a/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
@@ -52,6 +52,7 @@ class BatcherPoolTest {
                     1024 * 1024,
                     256L * 1024 * 1024,
                     4,
+                    4,
                     1,
                     Duration.ofMillis(1000),
                     "client_id",

--- a/client/src/test/java/io/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherTest.java
@@ -53,6 +53,7 @@ class BatcherTest {
                     1024 * 1024,
                     256L * 1024 * 1024,
                     4,
+                    4,
                     1,
                     Duration.ofMillis(1000),
                     "client_id",
@@ -203,10 +204,10 @@ class BatcherTest {
 
     @Test
     void accumulatesIntoOpenBatchWhileWindowExhausted() {
-        var window = new WriteWindow(1);
+        var window = new DispatchWindow(1);
         var batch2 = mock(Batch.class);
         when(batchFactory.getConfig()).thenReturn(config);
-        when(batchFactory.getWriteWindow(1L)).thenReturn(window);
+        when(batchFactory.getDispatchWindow(1L)).thenReturn(window);
         when(batchFactory.getBatch(1L)).thenReturn(batch, batch2);
         when(batch.canAdd(any())).thenReturn(true);
         when(batch.size()).thenReturn(1);
@@ -231,11 +232,11 @@ class BatcherTest {
 
     @Test
     void fullBatchIsQueuedWhileWindowExhausted() {
-        var window = new WriteWindow(1);
+        var window = new DispatchWindow(1);
         var batch2 = mock(Batch.class);
         var batch3 = mock(Batch.class);
         when(batchFactory.getConfig()).thenReturn(config);
-        when(batchFactory.getWriteWindow(1L)).thenReturn(window);
+        when(batchFactory.getDispatchWindow(1L)).thenReturn(window);
         when(batchFactory.getBatch(1L)).thenReturn(batch, batch2, batch3);
         when(batch.canAdd(any())).thenReturn(true);
         when(batch.size()).thenReturn(1);
@@ -268,12 +269,12 @@ class BatcherTest {
 
     @Test
     void exhaustedWindowDoesNotBlockOtherShards() {
-        var window1 = new WriteWindow(1);
-        var window2 = new WriteWindow(1);
+        var window1 = new DispatchWindow(1);
+        var window2 = new DispatchWindow(1);
         var shard2Batch = mock(Batch.class);
         when(batchFactory.getConfig()).thenReturn(config);
-        when(batchFactory.getWriteWindow(1L)).thenReturn(window1);
-        when(batchFactory.getWriteWindow(2L)).thenReturn(window2);
+        when(batchFactory.getDispatchWindow(1L)).thenReturn(window1);
+        when(batchFactory.getDispatchWindow(2L)).thenReturn(window2);
         when(batchFactory.getBatch(1L)).thenReturn(batch);
         when(batchFactory.getBatch(2L)).thenReturn(shard2Batch);
         when(batch.canAdd(any())).thenReturn(true);

--- a/client/src/test/java/io/oxia/client/batch/DispatchWindowTest.java
+++ b/client/src/test/java/io/oxia/client/batch/DispatchWindowTest.java
@@ -22,11 +22,11 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-class WriteWindowTest {
+class DispatchWindowTest {
 
     @Test
     void dispatchesWhileWindowHasSlots() {
-        var window = new WriteWindow(2);
+        var window = new DispatchWindow(2);
         var batch1 = mock(Batch.class);
         var batch2 = mock(Batch.class);
 
@@ -39,7 +39,7 @@ class WriteWindowTest {
 
     @Test
     void queuesFullBatchesWhileExhaustedAndDispatchesInOrder() {
-        var window = new WriteWindow(1);
+        var window = new DispatchWindow(1);
         var batch1 = mock(Batch.class);
         var batch2 = mock(Batch.class);
         var batch3 = mock(Batch.class);
@@ -61,7 +61,7 @@ class WriteWindowTest {
 
     @Test
     void sendOrParkDispatchesWhenSlotAvailable() {
-        var window = new WriteWindow(1);
+        var window = new DispatchWindow(1);
         var batch = mock(Batch.class);
 
         window.sendOrPark(batch);
@@ -71,7 +71,7 @@ class WriteWindowTest {
 
     @Test
     void releaseFlushesParkedBatch() {
-        var window = new WriteWindow(1);
+        var window = new DispatchWindow(1);
         var batch1 = mock(Batch.class);
         var batch2 = mock(Batch.class);
 
@@ -90,7 +90,7 @@ class WriteWindowTest {
 
     @Test
     void parkedBatchFlushedAfterQueuedBatches() {
-        var window = new WriteWindow(1);
+        var window = new DispatchWindow(1);
         var inflight = mock(Batch.class);
         var full = mock(Batch.class);
         var open = mock(Batch.class);
@@ -109,7 +109,7 @@ class WriteWindowTest {
 
     @Test
     void reclaimTakesBackParkedBatch() {
-        var window = new WriteWindow(1);
+        var window = new DispatchWindow(1);
         var batch1 = mock(Batch.class);
         var batch2 = mock(Batch.class);
 
@@ -130,7 +130,7 @@ class WriteWindowTest {
 
     @Test
     void failsHeldBackBatches() {
-        var window = new WriteWindow(1);
+        var window = new DispatchWindow(1);
         var inflight = mock(Batch.class);
         var full = mock(Batch.class);
         var open = mock(Batch.class);

--- a/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
@@ -65,6 +65,7 @@ class SessionManagerTest {
                         1024,
                         256L * 1024 * 1024,
                         4,
+                        4,
                         1,
                         Duration.ofSeconds(10),
                         "client",

--- a/client/src/test/java/io/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionTest.java
@@ -73,6 +73,7 @@ class SessionTest {
                         1024 * 1024,
                         256L * 1024 * 1024,
                         4,
+                        4,
                         1,
                         sessionTimeout,
                         clientId,


### PR DESCRIPTION
### Motivation

Read batching never adapts to the server's service rate: the batcher dispatches a `ReadBatch` as one RPC the moment its queue drains, and the read dispatch path has no in-flight limit — so under load the client floods the server with tiny `ReadRequest`s (~4–5 gets each) instead of growing batches. Every few gets pay a full gRPC round: on saturated clusters, server read-path CPU is dominated by gRPC stream/header handling (~35%) and the per-connection `loopyWriter` (~25%) while the actual data work (pebble get) stays ~11%, and per-worker read throughput caps at the per-shard RPC round rate regardless of cluster size. Writes had the identical pathology before #360 — post-#360, writes on a 6-node cluster do 333–362k/s while reads (no replication, no fsync) manage only 189k/s.

### Modification

Mirror #360 on the read path: at most `maxReadBatchesInFlight` (default 4) read batches may be outstanding per (client, shard).

- `WriteWindow` is generalized to `DispatchWindow` (nothing in it was write-specific; it's the same credit mechanism, and `BatchFactory`/`BatchManager` already called it "the dispatch window"). `BatchFactory.getWriteWindow` becomes `getDispatchWindow`. Both are package-private; no API impact.
- `ReadBatchFactory` now keeps a lazily-created per-shard `DispatchWindow` sized by the new `maxReadBatchesInFlight` config, and fails held-back batches on close via the existing `failWindows` path.
- `ReadBatch` frees its window slot in the RPC terminal callbacks (`onError`/`onCompleted`). `GrpcRpcProvider.read` routes every synchronous failure into the guarded observer and `GuardedStreamObserver` CASes on terminal delivery, so the release is exactly-once per dispatched batch, including across Failsafe retries.
- The batcher needs no logic changes — it already routes any factory's window generically; while a shard's window is exhausted, the open read batch keeps accumulating toward `maxRequestsPerBatch`, full batches queue FIFO in the window, and per-shard credits mean no cross-shard head-of-line blocking and no blocking of the batcher thread.
- Public API: `OxiaClientBuilder.maxReadBatchesInFlight(int)`, naming consistent with `maxWriteBatchesInFlight`. Held-back operations remain bounded by the existing `maxPendingBytes` limiter.

### Verifications

Unit tests mirror the #360 set: window release on response/failure/synchronous-failure for `ReadBatch` (via a single-slot window and a captured in-process server stream), plus the existing generic batcher tests for exhaustion-accumulation, FIFO dispatch on completion, per-shard independence, and close-fails-held-batches.

Loopback A/B (oxia standalone + oxia-benchmark, this branch vs 0.9.3, alternating runs with cool-downs, fresh server per run):

**Fixed-rate 10k ops/s read-only (regression gate)** — unchanged; the window does not delay dispatch when the server keeps up, and batches stay small on both sides:

| run | p50 | p95 | p99 | p99.9 | gets/RPC |
|---|---|---|---|---|---|
| 0.9.3 run 1 | 0.2 ms | 0.5 | 1.2 | 12.6 | 1.4 |
| 0.9.3 run 2 | 0.3 ms | 0.5 | 1.0 | 7.6 | 1.7 |
| this PR run 1 | 0.2 ms | 0.8 | 9.9¹ | 57.7¹ | 1.6 |
| this PR run 2 | 0.2 ms | 0.5 | 1.1 | 6.7 | 1.5 |

¹ first run of the suite; the tail comes from the first measured interval (JIT settling) — its steady-state intervals are p95 0.4 / p99 ≤1.5 ms.

**Max-rate read-only (10k outstanding), directional on loopback** — the adaptive mechanism works end-to-end: server-observed batch size pins at the `maxRequestsPerBatch` ceiling and read RPC count drops 34×, with better tail latencies (0.9.3: 1.50M RPCs at 33 gets/RPC, p99 36.5 ms; this PR: 43.6k RPCs at 1000 gets/RPC, p99 26.5 ms). Peak loopback throughput is not the decisive test here — against a many-core server over loopback, per-RPC overhead is near zero, which is the opposite of the saturated-cluster geometry this targets (gRPC per-RPC overhead dominating 2-CPU servers). The cluster expectation stays as in the write-side change: server-observed read batch size well beyond ~5 under load, per-worker reads far above ~19k/s, and 6-node aggregate reads exceeding the 333–362k/s write figure.
