### PR TITLE
chore: log write stream opening at debug level

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -292,7 +292,8 @@ public final class ManagedWriteStream implements AutoCloseable {
 
     private void initWithRecovery(OxiaStatusException leaderHint) {
         subStreamObserver = new ManagedSubWriteStream(this, rpcProvider, shardId, leaderHint);
-        log.info().attr("pendingWrites", inflightWrites.size()).log("Opened write stream");
+        log.debug(
+                event -> event.attr("pendingWrites", inflightWrites.size()).log("Opened write stream"));
         log.debug(
                 event ->
                         event


### PR DESCRIPTION
### Motivation

`Opened write stream` is logged on every stream (re)establishment, once per shard, so at info level it adds noise during normal operation on clients with many shards. The related recovery details ("Replaying inflight writes on opened stream") are already at debug.

### Modification

Move the message to debug level, using the lambda form so the `pendingWrites` attribute is not built when debug logging is disabled (same pattern as the surrounding debug logs).