### PR TITLE
chore: log write stream closing at debug level

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -350,7 +350,8 @@ public final class ManagedWriteStream implements AutoCloseable {
                 log.warn().exceptionMessage(ex).log("Failed to close write stream");
             }
         }
-        log.info().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
+        log.debug(
+                event -> event.attr("pendingWrites", inflightWrites.size()).log("Closing write stream"));
         final var inflightsToFail = new ArrayList<>(inflightWrites);
         inflightWrites.clear();
         return inflightsToFail;

--- a/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
+++ b/client/src/main/java/io/oxia/client/grpc/ManagedWriteStream.java
@@ -350,8 +350,7 @@ public final class ManagedWriteStream implements AutoCloseable {
                 log.warn().exceptionMessage(ex).log("Failed to close write stream");
             }
         }
-        log.debug(
-                event -> event.attr("pendingWrites", inflightWrites.size()).log("Closing write stream"));
+        log.debug().attr("pendingWrites", inflightWrites.size()).log("Closing write stream");
         final var inflightsToFail = new ArrayList<>(inflightWrites);
         inflightWrites.clear();
         return inflightsToFail;


### PR DESCRIPTION
### Motivation

`Closing write stream` is logged on every stream close and re-creation, once per shard, so at info level it adds noise during normal operation on clients with many shards. The matching "Opened write stream" message was already moved to debug in #363.

### Modification

Move the message to debug level, keeping the fluent `log.debug().attr(...)` style.