### PR TITLE
chore: upgrade lightproto to 0.8.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 grpc = "1.75.0"
 netty = "4.1.131.Final"
-lightproto = "0.6.6"
+lightproto = "0.8.0"
 opentelemetry = "1.63.0"
 opentelemetry-semconv = "1.37.0"
 junit = "5.11.3"


### PR DESCRIPTION
Upgrade the lightproto Gradle plugin from 0.6.6 to 0.8.0.

The regenerated code is source-compatible: everything compiles unchanged and all unit tests pass.